### PR TITLE
Use CONFIG_HAS_GDLIB as common define to use gigadevice hal.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright (c) 2021, ATL Electronics
 # SPDX-License-Identifier: Apache-2.0
 
-if(CONFIG_SOC_FAMILY_GD32)
+if(CONFIG_HAS_GDLIB)
 
 	zephyr_library()
 


### PR DESCRIPTION
GD32 and GD32V is different series, so SOC_FAMILY must be different.
(GD32V can't have CONFIG_SOC_FAMILY_GD32 by naming  convention in soc/riscv/riscv-privilege, must be CONFIG_SOC_FAMILY_RISCV_PRIVILEGE.)

I think CONFIG_HAS_GDLIB is good to share define between GD32 and GD32V.
The define is respecting @feilongfl branch https://github.com/feilongfl/zephyr/tree/dev-GD32E103_EVAL.
(It is seem to be inherit from stm32. There may be a better name. )
