### PR TITLE
Add i2c clock frequency boundary for each transfer mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,3 +111,7 @@ conflict resolution. See below list with the proposed solution:
 #define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
 +#endif
 ```
+- i2c-gd32 driver needs to know the clock frequency boundary. Fix it with
+  two step work. First move I2CCLK_MAX and I2CCLK_MIN marco from i2c source
+  file to header file. Then split the I2CCLK_MIN for each supported transfer
+  mode.

--- a/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
@@ -315,6 +315,12 @@ typedef enum
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)                  /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
@@ -40,8 +40,6 @@ OF SUCH DAMAGE.
 #define I2C_ERROR_HANDLE(s)           do{}while(1)
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32f3x0/standard_peripheral/include/gd32f3x0_i2c.h
+++ b/gd32f3x0/standard_peripheral/include/gd32f3x0_i2c.h
@@ -279,6 +279,12 @@ typedef enum
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)                  /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32f3x0/standard_peripheral/source/gd32f3x0_i2c.c
+++ b/gd32f3x0/standard_peripheral/source/gd32f3x0_i2c.c
@@ -37,8 +37,6 @@ OF SUCH DAMAGE.
 #include "gd32f3x0_i2c.h"
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32f403/standard_peripheral/include/gd32f403_i2c.h
+++ b/gd32f403/standard_peripheral/include/gd32f403_i2c.h
@@ -284,6 +284,12 @@ typedef enum
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x00000054U)                  /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32f403/standard_peripheral/source/gd32f403_i2c.c
+++ b/gd32f403/standard_peripheral/source/gd32f403_i2c.c
@@ -40,8 +40,6 @@ OF SUCH DAMAGE.
 #define I2C_ERROR_HANDLE(s)           do{}while(1)
     
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x00000054U)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK         ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
@@ -336,6 +336,12 @@ typedef enum
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x00000032U)                  /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
@@ -38,8 +38,6 @@ OF SUCH DAMAGE.
 #include "gd32f4xx_i2c.h"
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x00000032U)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32vf103/standard_peripheral/include/gd32vf103_i2c.h
+++ b/gd32vf103/standard_peripheral/include/gd32vf103_i2c.h
@@ -274,6 +274,12 @@ typedef enum {
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x00000036U)                  /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32vf103/standard_peripheral/source/gd32vf103_i2c.c
+++ b/gd32vf103/standard_peripheral/source/gd32vf103_i2c.c
@@ -36,8 +36,6 @@ OF SUCH DAMAGE.
 #include "gd32vf103_i2c.h"
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x00000036U)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */


### PR DESCRIPTION
i2c-gd32 driver needs to know the clock frequency boundary to implement the configure api.
