### PR TITLE
dt-bindings: fix GD32_REMAP_MSK error.

### DIFF
--- a/include/dt-bindings/pinctrl/gd32-afio.h
+++ b/include/dt-bindings/pinctrl/gd32-afio.h
@@ -38,7 +38,7 @@
 /** Mode field position. */
 #define GD32_MODE_POS 8U
 /** Remap field mask. */
-#define GD32_REMAP_MSK 0x1FFU
+#define GD32_REMAP_MSK 0x3FFU
 /** Remap field position. */
 #define GD32_REMAP_POS 10U
 


### PR DESCRIPTION
GD32_REMAP is 10bit, origin `0x1ff` is only 9bit.change to `0x3ff`

this cause remap pin config fail.

``` c
/**
 * @brief Remap configuration bit field.
 * 
 * Fields:
 *
 * - 0..3: port
 * - 4..7: pin
 * - 8..9: mode
 * - 10..19: remap <----------------------------------- 10bit
 * 
 * @param port Port ('A'..'P')
 * @param pin Pin (0..15)
 * @param mode Mode (ANALOG, GPIO_IN, ALTERNATE).
 * @param remap Remap value, see #GD32_REMAP.
 */
#define GD32_PINMUX_AFIO(port, pin, mode, remap)			\
	(((((port) - 'A') & GD32_PORT_MSK) << GD32_PORT_POS) |		\
	 (((pin) & GD32_PIN_MSK) << GD32_PIN_POS) |			\
	 (((GD32_MODE_ ## mode) & GD32_MODE_MSK) << GD32_MODE_POS) |	\
	 (((GD32_ ## remap) & GD32_REMAP_MSK) << GD32_REMAP_POS))

```