### PR TITLE
gd32f4xx: Update to firmware v3.0.0

### DIFF
--- a/gd32f4xx/cmsis/gd/gd32f4xx/include/gd32f4xx.h
+++ b/gd32f4xx/cmsis/gd/gd32f4xx/include/gd32f4xx.h
@@ -295,7 +295,9 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 #define REG32(addr)                  (*(volatile uint32_t *)(uint32_t)(addr))
 #define REG16(addr)                  (*(volatile uint16_t *)(uint32_t)(addr))
 #define REG8(addr)                   (*(volatile uint8_t *)(uint32_t)(addr))
+#ifndef BIT
 #define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
+#endif /* BIT */
 #define BITS(start, end)             ((0xFFFFFFFFUL << (start)) & (0xFFFFFFFFUL >> (31U - (uint32_t)(end)))) 
 #define GET_BITS(regval, start, end) (((regval) & BITS((start),(end))) >> (start))
 

--- a/gd32f4xx/cmsis/gd/gd32f4xx/include/gd32f4xx.h
+++ b/gd32f4xx/cmsis/gd/gd32f4xx/include/gd32f4xx.h
@@ -42,13 +42,16 @@ OF SUCH DAMAGE.
 #endif 
 
 /* define GD32F4xx */
-#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407)
+#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407) && !defined (GD32F470)  && !defined (GD32F425) && !defined (GD32F427)
   /* #define GD32F450 */
   /* #define GD32F405 */
   /* #define GD32F407 */
+  /* #define GD32F470 */
+  /* #define GD32F425 */
+  /* #define GD32F427 */
 #endif /* define GD32F4xx */
    
-#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407)
+#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407) && !defined (GD32F470)  && !defined (GD32F425) && !defined (GD32F427)
  #error "Please select the target GD32F4xx device in gd32f4xx.h file"
 #endif /* undefine GD32F4xx tip */
 
@@ -163,7 +166,7 @@ typedef enum IRQn
     TIMER7_Channel_IRQn          = 46,     /*!< TIMER7 channel capture compare interrupt                 */
     DMA0_Channel7_IRQn           = 47,     /*!< DMA0 channel7 interrupt                                  */
     
-#if defined (GD32F450)
+#if defined (GD32F450) || defined (GD32F470)
     EXMC_IRQn                    = 48,     /*!< EXMC interrupt                                           */
     SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
     TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
@@ -205,9 +208,9 @@ typedef enum IRQn
     TLI_IRQn                     = 88,     /*!< TLI interrupt                                            */
     TLI_ER_IRQn                  = 89,     /*!< TLI error interrupt                                      */
     IPA_IRQn                     = 90,     /*!< IPA interrupt                                            */
-#endif /* GD32F450 */
+#endif /* GD32F450 and GD32F470 */
 
-#if defined (GD32F405)
+#if defined (GD32F405) || defined (GD32F425)
     SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
     TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
     SPI2_IRQn                    = 51,     /*!< SPI2 interrupt                                           */
@@ -238,9 +241,9 @@ typedef enum IRQn
     DCI_IRQn                     = 78,     /*!< DCI interrupt                                            */
     TRNG_IRQn                    = 80,     /*!< TRNG interrupt                                           */
     FPU_IRQn                     = 81,     /*!< FPU interrupt                                            */
-#endif /* GD32F405 */
+#endif /* GD32F405 and GD32F425 */
 
-#if defined (GD32F407)
+#if defined (GD32F407) || defined (GD32F427)
     EXMC_IRQn                    = 48,     /*!< EXMC interrupt                                           */
     SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
     TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
@@ -274,7 +277,7 @@ typedef enum IRQn
     DCI_IRQn                     = 78,     /*!< DCI interrupt                                            */
     TRNG_IRQn                    = 80,     /*!< TRNG interrupt                                           */
     FPU_IRQn                     = 81,     /*!< FPU interrupt                                            */
-#endif /* GD32F407 */
+#endif /* GD32F407 and GD32F427 */
 
 } IRQn_Type;
 
@@ -292,9 +295,7 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 #define REG32(addr)                  (*(volatile uint32_t *)(uint32_t)(addr))
 #define REG16(addr)                  (*(volatile uint16_t *)(uint32_t)(addr))
 #define REG8(addr)                   (*(volatile uint8_t *)(uint32_t)(addr))
-#ifndef BIT
 #define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
-#endif
 #define BITS(start, end)             ((0xFFFFFFFFUL << (start)) & (0xFFFFFFFFUL >> (31U - (uint32_t)(end)))) 
 #define GET_BITS(regval, start, end) (((regval) & BITS((start),(end))) >> (start))
 

--- a/gd32f4xx/cmsis/gd/gd32f4xx/source/system_gd32f4xx.c
+++ b/gd32f4xx/cmsis/gd/gd32f4xx/source/system_gd32f4xx.c
@@ -44,14 +44,17 @@
 //#define __SYSTEM_CLOCK_IRC16M                   (uint32_t)(__IRC16M)
 //#define __SYSTEM_CLOCK_HXTAL                    (uint32_t)(__HXTAL)
 //#define __SYSTEM_CLOCK_120M_PLL_IRC16M          (uint32_t)(120000000)
-//#define __SYSTEM_CLOCK_120M_PLL_8M_HXTAL          (uint32_t)(120000000)
+//#define __SYSTEM_CLOCK_120M_PLL_8M_HXTAL        (uint32_t)(120000000)
 //#define __SYSTEM_CLOCK_120M_PLL_25M_HXTAL       (uint32_t)(120000000)
 //#define __SYSTEM_CLOCK_168M_PLL_IRC16M          (uint32_t)(168000000)
 //#define __SYSTEM_CLOCK_168M_PLL_8M_HXTAL        (uint32_t)(168000000)
 //#define __SYSTEM_CLOCK_168M_PLL_25M_HXTAL       (uint32_t)(168000000)
-// #define __SYSTEM_CLOCK_200M_PLL_IRC16M          (uint32_t)(200000000)
+//#define __SYSTEM_CLOCK_200M_PLL_IRC16M          (uint32_t)(200000000)
 //#define __SYSTEM_CLOCK_200M_PLL_8M_HXTAL        (uint32_t)(200000000)
-#define __SYSTEM_CLOCK_200M_PLL_25M_HXTAL         (uint32_t)(200000000)
+#define __SYSTEM_CLOCK_200M_PLL_25M_HXTAL       (uint32_t)(200000000)
+//#define __SYSTEM_CLOCK_240M_PLL_IRC16M          (uint32_t)(240000000)
+//#define __SYSTEM_CLOCK_240M_PLL_8M_HXTAL        (uint32_t)(240000000)
+//#define __SYSTEM_CLOCK_240M_PLL_25M_HXTAL       (uint32_t)(240000000)
 
 #define SEL_IRC16M      0x00U
 #define SEL_HXTAL       0x01U
@@ -96,6 +99,15 @@ static void system_clock_200m_8m_hxtal(void);
 #elif defined (__SYSTEM_CLOCK_200M_PLL_25M_HXTAL)
 uint32_t SystemCoreClock = __SYSTEM_CLOCK_200M_PLL_25M_HXTAL;
 static void system_clock_200m_25m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_IRC16M;
+static void system_clock_240m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_8M_HXTAL;
+static void system_clock_240m_8m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_25M_HXTAL;
+static void system_clock_240m_25m_hxtal(void);
 
 #endif /* __SYSTEM_CLOCK_IRC16M */
 
@@ -119,7 +131,15 @@ void SystemInit (void)
     RCU_CTL |= RCU_CTL_IRC16MEN;
 
     RCU_MODIFY
+    
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    
+    /* Reset HXTALEN, CKMEN and PLLEN bits */
+    RCU_CTL &= ~(RCU_CTL_PLLEN | RCU_CTL_CKMEN | RCU_CTL_HXTALEN);
 
+    /* Reset HSEBYP bit */
+    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
+    
     /* Reset CFG0 register */
     RCU_CFG0 = 0x00000000U;
 
@@ -127,14 +147,8 @@ void SystemInit (void)
     while(0 != (RCU_CFG0 & RCU_SCSS_IRC16M)){
     }
 
-    /* Reset HXTALEN, CKMEN and PLLEN bits */
-    RCU_CTL &= ~(RCU_CTL_PLLEN | RCU_CTL_CKMEN | RCU_CTL_HXTALEN);
-
     /* Reset PLLCFGR register */
     RCU_PLL = 0x24003010U;
-
-    /* Reset HSEBYP bit */
-    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
 
     /* Disable all interrupts */
     RCU_INT = 0x00000000U;
@@ -173,6 +187,12 @@ static void system_clock_config(void)
     system_clock_200m_8m_hxtal();
 #elif defined (__SYSTEM_CLOCK_200M_PLL_25M_HXTAL)
     system_clock_200m_25m_hxtal();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+    system_clock_240m_irc16m();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+    system_clock_240m_8m_hxtal();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+    system_clock_240m_25m_hxtal();
 #endif /* __SYSTEM_CLOCK_IRC16M */   
 }
 
@@ -870,6 +890,209 @@ static void system_clock_200m_25m_hxtal(void)
     }
 }
 
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects IRC16M as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* IRC16M is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 16, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (16U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_IRC16M) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects HXTAL(8M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_8m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 8, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (8U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects HXTAL(25M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_25m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 25, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (25U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
 #endif /* __SYSTEM_CLOCK_IRC16M */
 /*!
     \brief      update the SystemCoreClock with current core clock retrieved from cpu registers

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_adc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_adc.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -189,7 +190,7 @@ OF SUCH DAMAGE.
 #define CTL0_DISNUM(regval)             (BITS(13,15) & ((uint32_t)(regval) << 13))   /*!< write value to ADC_CTL0_DISNUM bit field */
 
 /* ADC special function definitions */
-#define ADC_SCAN_MODE                   ADC_CTL0_SM                  /*!< scan mode */
+#define ADC_SCAN_MODE                   ADC_CTL0_SM                   /*!< scan mode */
 #define ADC_INSERTED_CHANNEL_AUTO       ADC_CTL0_ICA                  /*!< inserted channel group convert automatically */
 #define ADC_CONTINUOUS_MODE             ADC_CTL1_CTN                  /*!< continuous mode */
 
@@ -198,14 +199,14 @@ OF SUCH DAMAGE.
 #define ADC_TEMP_VREF_CHANNEL_SWITCH    ADC_SYNCCTL_TSVREN                  /*!< Vref and Vtemp channel */
 
 /* ADC synchronization mode */
-#define SYNCCTL_SYNCM(regval)              (BITS(0,4) & ((uint32_t)(regval)))   /*!< write value to ADC_CTL0_SYNCM bit field */
-#define ADC_SYNC_MODE_INDEPENDENT                           SYNCCTL_SYNCM(0)    /*!< ADC synchronization mode disabled.All the ADCs work independently */
-#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL         SYNCCTL_SYNCM(1)    /*!< ADC0 and ADC1 work in combined regular parallel & inserted parallel mode. ADC2 works independently */
-#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION         SYNCCTL_SYNCM(2)    /*!< ADC0 and ADC1 work in combined regular parallel & trigger rotation mode. ADC2 works independently */
-#define ADC_DAUL_INSERTED_PARALLEL                          SYNCCTL_SYNCM(5)    /*!< ADC0 and ADC1 work in inserted parallel mode. ADC2 works independently */
-#define ADC_DAUL_REGULAL_PARALLEL                           SYNCCTL_SYNCM(6)    /*!< ADC0 and ADC1 work in regular parallel mode. ADC2 works independently */
-#define ADC_DAUL_REGULAL_FOLLOW_UP                          SYNCCTL_SYNCM(7)    /*!< ADC0 and ADC1 work in follow-up mode. ADC2 works independently */
-#define ADC_DAUL_INSERTED_TRRIGGER_ROTATION                 SYNCCTL_SYNCM(9)    /*!< ADC0 and ADC1 work in trigger rotation mode. ADC2 works independently */
+#define SYNCCTL_SYNCM(regval)              (BITS(0,4) & ((uint32_t)(regval)))    /*!< write value to ADC_CTL0_SYNCM bit field */
+#define ADC_SYNC_MODE_INDEPENDENT                           SYNCCTL_SYNCM(0)     /*!< ADC synchronization mode disabled.All the ADCs work independently */
+#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL         SYNCCTL_SYNCM(1)     /*!< ADC0 and ADC1 work in combined regular parallel & inserted parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION         SYNCCTL_SYNCM(2)     /*!< ADC0 and ADC1 work in combined regular parallel & trigger rotation mode. ADC2 works independently */
+#define ADC_DAUL_INSERTED_PARALLEL                          SYNCCTL_SYNCM(5)     /*!< ADC0 and ADC1 work in inserted parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_PARALLEL                           SYNCCTL_SYNCM(6)     /*!< ADC0 and ADC1 work in regular parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_FOLLOW_UP                          SYNCCTL_SYNCM(7)     /*!< ADC0 and ADC1 work in follow-up mode. ADC2 works independently */
+#define ADC_DAUL_INSERTED_TRRIGGER_ROTATION                 SYNCCTL_SYNCM(9)     /*!< ADC0 and ADC1 work in trigger rotation mode. ADC2 works independently */
 #define ADC_ALL_REGULAL_PARALLEL_INSERTED_PARALLEL          SYNCCTL_SYNCM(17)    /*!< all ADCs work in combined regular parallel & inserted parallel mode */
 #define ADC_ALL_REGULAL_PARALLEL_INSERTED_ROTATION          SYNCCTL_SYNCM(18)    /*!< all ADCs work in combined regular parallel & trigger rotation mode */
 #define ADC_ALL_INSERTED_PARALLEL                           SYNCCTL_SYNCM(21)    /*!< all ADCs work in inserted parallel mode */
@@ -215,7 +216,7 @@ OF SUCH DAMAGE.
 
 /* ADC data alignment */
 #define ADC_DATAALIGN_RIGHT             ((uint32_t)0x00000000U)                  /*!< LSB alignment */
-#define ADC_DATAALIGN_LEFT              ADC_CTL1_DAL                  /*!< MSB alignment */
+#define ADC_DATAALIGN_LEFT              ADC_CTL1_DAL                             /*!< MSB alignment */
 
 /* external trigger mode for regular and inserted  channel */
 #define EXTERNAL_TRIGGER_DISABLE        ((uint32_t)0x00000000U)           /*!< external trigger disable */
@@ -356,16 +357,16 @@ OF SUCH DAMAGE.
 #define ADC_CHANNEL_18                  ((uint8_t)0x12U)                  /*!< ADC channel 18 */
 
 /* ADC interrupt flag */
-#define ADC_INT_WDE                     ADC_CTL0_WDEIE                     /*!< analog watchdog event interrupt */
-#define ADC_INT_EOC                     ADC_CTL0_EOCIE                     /*!< end of group conversion interrupt */
-#define ADC_INT_EOIC                    ADC_CTL0_EOICIE                    /*!< end of inserted group conversion interrupt */
-#define ADC_INT_ROVF                    ADC_CTL0_ROVFIE                    /*!< regular data register overflow */
+#define ADC_INT_WDE                     ADC_CTL0_WDEIE                    /*!< analog watchdog event interrupt */
+#define ADC_INT_EOC                     ADC_CTL0_EOCIE                    /*!< end of group conversion interrupt */
+#define ADC_INT_EOIC                    ADC_CTL0_EOICIE                   /*!< end of inserted group conversion interrupt */
+#define ADC_INT_ROVF                    ADC_CTL0_ROVFIE                   /*!< regular data register overflow */
 
 /* ADC interrupt flag */
-#define ADC_INT_FLAG_WDE                ADC_STAT_WDE                     /*!< analog watchdog event interrupt */
-#define ADC_INT_FLAG_EOC                ADC_STAT_EOC                     /*!< end of group conversion interrupt */
-#define ADC_INT_FLAG_EOIC               ADC_STAT_EOIC                    /*!< end of inserted group conversion interrupt */
-#define ADC_INT_FLAG_ROVF               ADC_STAT_ROVF                    /*!< regular data register overflow */
+#define ADC_INT_FLAG_WDE                ADC_STAT_WDE                      /*!< analog watchdog event interrupt */
+#define ADC_INT_FLAG_EOC                ADC_STAT_EOC                      /*!< end of group conversion interrupt */
+#define ADC_INT_FLAG_EOIC               ADC_STAT_EOIC                     /*!< end of inserted group conversion interrupt */
+#define ADC_INT_FLAG_ROVF               ADC_STAT_ROVF                     /*!< regular data register overflow */
 
 /* configure the ADC clock for all the ADCs */
 #define SYNCCTL_ADCCK(regval)           (BITS(16,18) & ((uint32_t)(regval) << 16))

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
@@ -6,32 +6,33 @@
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2019-11-27, V2.0.1, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -42,99 +43,99 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* CAN definitions */
-#define CAN0                               CAN_BASE                      /*!< CAN0 base address */
-#define CAN1                               (CAN0 + 0x00000400U)          /*!< CAN1 base address */
+#define CAN0                               CAN_BASE                           /*!< CAN0 base address */
+#define CAN1                               (CAN0 + 0x00000400U)               /*!< CAN1 base address */
 
 /* registers definitions */
-#define CAN_CTL(canx)                      REG32((canx) + 0x00U)         /*!< CAN control register */
-#define CAN_STAT(canx)                     REG32((canx) + 0x04U)         /*!< CAN status register */
-#define CAN_TSTAT(canx)                    REG32((canx) + 0x08U)         /*!< CAN transmit status register*/
-#define CAN_RFIFO0(canx)                   REG32((canx) + 0x0CU)         /*!< CAN receive FIFO0 register */
-#define CAN_RFIFO1(canx)                   REG32((canx) + 0x10U)         /*!< CAN receive FIFO1 register */
-#define CAN_INTEN(canx)                    REG32((canx) + 0x14U)         /*!< CAN interrupt enable register */
-#define CAN_ERR(canx)                      REG32((canx) + 0x18U)         /*!< CAN error register */
-#define CAN_BT(canx)                       REG32((canx) + 0x1CU)         /*!< CAN bit timing register */
-#define CAN_TMI0(canx)                     REG32((canx) + 0x180U)        /*!< CAN transmit mailbox0 identifier register */
-#define CAN_TMP0(canx)                     REG32((canx) + 0x184U)        /*!< CAN transmit mailbox0 property register */
-#define CAN_TMDATA00(canx)                 REG32((canx) + 0x188U)        /*!< CAN transmit mailbox0 data0 register */
-#define CAN_TMDATA10(canx)                 REG32((canx) + 0x18CU)        /*!< CAN transmit mailbox0 data1 register */
-#define CAN_TMI1(canx)                     REG32((canx) + 0x190U)        /*!< CAN transmit mailbox1 identifier register */
-#define CAN_TMP1(canx)                     REG32((canx) + 0x194U)        /*!< CAN transmit mailbox1 property register */
-#define CAN_TMDATA01(canx)                 REG32((canx) + 0x198U)        /*!< CAN transmit mailbox1 data0 register */
-#define CAN_TMDATA11(canx)                 REG32((canx) + 0x19CU)        /*!< CAN transmit mailbox1 data1 register */
-#define CAN_TMI2(canx)                     REG32((canx) + 0x1A0U)        /*!< CAN transmit mailbox2 identifier register */
-#define CAN_TMP2(canx)                     REG32((canx) + 0x1A4U)        /*!< CAN transmit mailbox2 property register */
-#define CAN_TMDATA02(canx)                 REG32((canx) + 0x1A8U)        /*!< CAN transmit mailbox2 data0 register */
-#define CAN_TMDATA12(canx)                 REG32((canx) + 0x1ACU)        /*!< CAN transmit mailbox2 data1 register */
-#define CAN_RFIFOMI0(canx)                 REG32((canx) + 0x1B0U)        /*!< CAN receive FIFO0 mailbox identifier register */
-#define CAN_RFIFOMP0(canx)                 REG32((canx) + 0x1B4U)        /*!< CAN receive FIFO0 mailbox property register */
-#define CAN_RFIFOMDATA00(canx)             REG32((canx) + 0x1B8U)        /*!< CAN receive FIFO0 mailbox data0 register */
-#define CAN_RFIFOMDATA10(canx)             REG32((canx) + 0x1BCU)        /*!< CAN receive FIFO0 mailbox data1 register */
-#define CAN_RFIFOMI1(canx)                 REG32((canx) + 0x1C0U)        /*!< CAN receive FIFO1 mailbox identifier register */
-#define CAN_RFIFOMP1(canx)                 REG32((canx) + 0x1C4U)        /*!< CAN receive FIFO1 mailbox property register */
-#define CAN_RFIFOMDATA01(canx)             REG32((canx) + 0x1C8U)        /*!< CAN receive FIFO1 mailbox data0 register */
-#define CAN_RFIFOMDATA11(canx)             REG32((canx) + 0x1CCU)        /*!< CAN receive FIFO1 mailbox data1 register */
-#define CAN_FCTL(canx)                     REG32((canx) + 0x200U)        /*!< CAN filter control register */
-#define CAN_FMCFG(canx)                    REG32((canx) + 0x204U)        /*!< CAN filter mode register */
-#define CAN_FSCFG(canx)                    REG32((canx) + 0x20CU)        /*!< CAN filter scale register */
-#define CAN_FAFIFO(canx)                   REG32((canx) + 0x214U)        /*!< CAN filter associated FIFO register */
-#define CAN_FW(canx)                       REG32((canx) + 0x21CU)        /*!< CAN filter working register */
-#define CAN_F0DATA0(canx)                  REG32((canx) + 0x240U)        /*!< CAN filter 0 data 0 register */
-#define CAN_F1DATA0(canx)                  REG32((canx) + 0x248U)        /*!< CAN filter 1 data 0 register */
-#define CAN_F2DATA0(canx)                  REG32((canx) + 0x250U)        /*!< CAN filter 2 data 0 register */
-#define CAN_F3DATA0(canx)                  REG32((canx) + 0x258U)        /*!< CAN filter 3 data 0 register */
-#define CAN_F4DATA0(canx)                  REG32((canx) + 0x260U)        /*!< CAN filter 4 data 0 register */
-#define CAN_F5DATA0(canx)                  REG32((canx) + 0x268U)        /*!< CAN filter 5 data 0 register */
-#define CAN_F6DATA0(canx)                  REG32((canx) + 0x270U)        /*!< CAN filter 6 data 0 register */
-#define CAN_F7DATA0(canx)                  REG32((canx) + 0x278U)        /*!< CAN filter 7 data 0 register */
-#define CAN_F8DATA0(canx)                  REG32((canx) + 0x280U)        /*!< CAN filter 8 data 0 register */
-#define CAN_F9DATA0(canx)                  REG32((canx) + 0x288U)        /*!< CAN filter 9 data 0 register */
-#define CAN_F10DATA0(canx)                 REG32((canx) + 0x290U)        /*!< CAN filter 10 data 0 register */
-#define CAN_F11DATA0(canx)                 REG32((canx) + 0x298U)        /*!< CAN filter 11 data 0 register */
-#define CAN_F12DATA0(canx)                 REG32((canx) + 0x2A0U)        /*!< CAN filter 12 data 0 register */
-#define CAN_F13DATA0(canx)                 REG32((canx) + 0x2A8U)        /*!< CAN filter 13 data 0 register */
-#define CAN_F14DATA0(canx)                 REG32((canx) + 0x2B0U)        /*!< CAN filter 14 data 0 register */
-#define CAN_F15DATA0(canx)                 REG32((canx) + 0x2B8U)        /*!< CAN filter 15 data 0 register */
-#define CAN_F16DATA0(canx)                 REG32((canx) + 0x2C0U)        /*!< CAN filter 16 data 0 register */
-#define CAN_F17DATA0(canx)                 REG32((canx) + 0x2C8U)        /*!< CAN filter 17 data 0 register */
-#define CAN_F18DATA0(canx)                 REG32((canx) + 0x2D0U)        /*!< CAN filter 18 data 0 register */
-#define CAN_F19DATA0(canx)                 REG32((canx) + 0x2D8U)        /*!< CAN filter 19 data 0 register */
-#define CAN_F20DATA0(canx)                 REG32((canx) + 0x2E0U)        /*!< CAN filter 20 data 0 register */
-#define CAN_F21DATA0(canx)                 REG32((canx) + 0x2E8U)        /*!< CAN filter 21 data 0 register */
-#define CAN_F22DATA0(canx)                 REG32((canx) + 0x2F0U)        /*!< CAN filter 22 data 0 register */
-#define CAN_F23DATA0(canx)                 REG32((canx) + 0x3F8U)        /*!< CAN filter 23 data 0 register */
-#define CAN_F24DATA0(canx)                 REG32((canx) + 0x300U)        /*!< CAN filter 24 data 0 register */
-#define CAN_F25DATA0(canx)                 REG32((canx) + 0x308U)        /*!< CAN filter 25 data 0 register */
-#define CAN_F26DATA0(canx)                 REG32((canx) + 0x310U)        /*!< CAN filter 26 data 0 register */
-#define CAN_F27DATA0(canx)                 REG32((canx) + 0x318U)        /*!< CAN filter 27 data 0 register */
-#define CAN_F0DATA1(canx)                  REG32((canx) + 0x244U)        /*!< CAN filter 0 data 1 register */
-#define CAN_F1DATA1(canx)                  REG32((canx) + 0x24CU)        /*!< CAN filter 1 data 1 register */
-#define CAN_F2DATA1(canx)                  REG32((canx) + 0x254U)        /*!< CAN filter 2 data 1 register */
-#define CAN_F3DATA1(canx)                  REG32((canx) + 0x25CU)        /*!< CAN filter 3 data 1 register */
-#define CAN_F4DATA1(canx)                  REG32((canx) + 0x264U)        /*!< CAN filter 4 data 1 register */
-#define CAN_F5DATA1(canx)                  REG32((canx) + 0x26CU)        /*!< CAN filter 5 data 1 register */
-#define CAN_F6DATA1(canx)                  REG32((canx) + 0x274U)        /*!< CAN filter 6 data 1 register */
-#define CAN_F7DATA1(canx)                  REG32((canx) + 0x27CU)        /*!< CAN filter 7 data 1 register */
-#define CAN_F8DATA1(canx)                  REG32((canx) + 0x284U)        /*!< CAN filter 8 data 1 register */
-#define CAN_F9DATA1(canx)                  REG32((canx) + 0x28CU)        /*!< CAN filter 9 data 1 register */
-#define CAN_F10DATA1(canx)                 REG32((canx) + 0x294U)        /*!< CAN filter 10 data 1 register */
-#define CAN_F11DATA1(canx)                 REG32((canx) + 0x29CU)        /*!< CAN filter 11 data 1 register */
-#define CAN_F12DATA1(canx)                 REG32((canx) + 0x2A4U)        /*!< CAN filter 12 data 1 register */
-#define CAN_F13DATA1(canx)                 REG32((canx) + 0x2ACU)        /*!< CAN filter 13 data 1 register */
-#define CAN_F14DATA1(canx)                 REG32((canx) + 0x2B4U)        /*!< CAN filter 14 data 1 register */
-#define CAN_F15DATA1(canx)                 REG32((canx) + 0x2BCU)        /*!< CAN filter 15 data 1 register */
-#define CAN_F16DATA1(canx)                 REG32((canx) + 0x2C4U)        /*!< CAN filter 16 data 1 register */
-#define CAN_F17DATA1(canx)                 REG32((canx) + 0x24CU)        /*!< CAN filter 17 data 1 register */
-#define CAN_F18DATA1(canx)                 REG32((canx) + 0x2D4U)        /*!< CAN filter 18 data 1 register */
-#define CAN_F19DATA1(canx)                 REG32((canx) + 0x2DCU)        /*!< CAN filter 19 data 1 register */
-#define CAN_F20DATA1(canx)                 REG32((canx) + 0x2E4U)        /*!< CAN filter 20 data 1 register */
-#define CAN_F21DATA1(canx)                 REG32((canx) + 0x2ECU)        /*!< CAN filter 21 data 1 register */
-#define CAN_F22DATA1(canx)                 REG32((canx) + 0x2F4U)        /*!< CAN filter 22 data 1 register */
-#define CAN_F23DATA1(canx)                 REG32((canx) + 0x2FCU)        /*!< CAN filter 23 data 1 register */
-#define CAN_F24DATA1(canx)                 REG32((canx) + 0x304U)        /*!< CAN filter 24 data 1 register */
-#define CAN_F25DATA1(canx)                 REG32((canx) + 0x30CU)        /*!< CAN filter 25 data 1 register */
-#define CAN_F26DATA1(canx)                 REG32((canx) + 0x314U)        /*!< CAN filter 26 data 1 register */
-#define CAN_F27DATA1(canx)                 REG32((canx) + 0x31CU)        /*!< CAN filter 27 data 1 register */
+#define CAN_CTL(canx)                      REG32((canx) + 0x00000000U)        /*!< CAN control register */
+#define CAN_STAT(canx)                     REG32((canx) + 0x00000004U)        /*!< CAN status register */
+#define CAN_TSTAT(canx)                    REG32((canx) + 0x00000008U)        /*!< CAN transmit status register*/
+#define CAN_RFIFO0(canx)                   REG32((canx) + 0x0000000CU)        /*!< CAN receive FIFO0 register */
+#define CAN_RFIFO1(canx)                   REG32((canx) + 0x00000010U)        /*!< CAN receive FIFO1 register */
+#define CAN_INTEN(canx)                    REG32((canx) + 0x00000014U)        /*!< CAN interrupt enable register */
+#define CAN_ERR(canx)                      REG32((canx) + 0x00000018U)        /*!< CAN error register */
+#define CAN_BT(canx)                       REG32((canx) + 0x0000001CU)        /*!< CAN bit timing register */
+#define CAN_TMI0(canx)                     REG32((canx) + 0x00000180U)        /*!< CAN transmit mailbox0 identifier register */
+#define CAN_TMP0(canx)                     REG32((canx) + 0x00000184U)        /*!< CAN transmit mailbox0 property register */
+#define CAN_TMDATA00(canx)                 REG32((canx) + 0x00000188U)        /*!< CAN transmit mailbox0 data0 register */
+#define CAN_TMDATA10(canx)                 REG32((canx) + 0x0000018CU)        /*!< CAN transmit mailbox0 data1 register */
+#define CAN_TMI1(canx)                     REG32((canx) + 0x00000190U)        /*!< CAN transmit mailbox1 identifier register */
+#define CAN_TMP1(canx)                     REG32((canx) + 0x00000194U)        /*!< CAN transmit mailbox1 property register */
+#define CAN_TMDATA01(canx)                 REG32((canx) + 0x00000198U)        /*!< CAN transmit mailbox1 data0 register */
+#define CAN_TMDATA11(canx)                 REG32((canx) + 0x0000019CU)        /*!< CAN transmit mailbox1 data1 register */
+#define CAN_TMI2(canx)                     REG32((canx) + 0x000001A0U)        /*!< CAN transmit mailbox2 identifier register */
+#define CAN_TMP2(canx)                     REG32((canx) + 0x000001A4U)        /*!< CAN transmit mailbox2 property register */
+#define CAN_TMDATA02(canx)                 REG32((canx) + 0x000001A8U)        /*!< CAN transmit mailbox2 data0 register */
+#define CAN_TMDATA12(canx)                 REG32((canx) + 0x000001ACU)        /*!< CAN transmit mailbox2 data1 register */
+#define CAN_RFIFOMI0(canx)                 REG32((canx) + 0x000001B0U)        /*!< CAN receive FIFO0 mailbox identifier register */
+#define CAN_RFIFOMP0(canx)                 REG32((canx) + 0x000001B4U)        /*!< CAN receive FIFO0 mailbox property register */
+#define CAN_RFIFOMDATA00(canx)             REG32((canx) + 0x000001B8U)        /*!< CAN receive FIFO0 mailbox data0 register */
+#define CAN_RFIFOMDATA10(canx)             REG32((canx) + 0x000001BCU)        /*!< CAN receive FIFO0 mailbox data1 register */
+#define CAN_RFIFOMI1(canx)                 REG32((canx) + 0x000001C0U)        /*!< CAN receive FIFO1 mailbox identifier register */
+#define CAN_RFIFOMP1(canx)                 REG32((canx) + 0x000001C4U)        /*!< CAN receive FIFO1 mailbox property register */
+#define CAN_RFIFOMDATA01(canx)             REG32((canx) + 0x000001C8U)        /*!< CAN receive FIFO1 mailbox data0 register */
+#define CAN_RFIFOMDATA11(canx)             REG32((canx) + 0x000001CCU)        /*!< CAN receive FIFO1 mailbox data1 register */
+#define CAN_FCTL(canx)                     REG32((canx) + 0x00000200U)        /*!< CAN filter control register */
+#define CAN_FMCFG(canx)                    REG32((canx) + 0x00000204U)        /*!< CAN filter mode register */
+#define CAN_FSCFG(canx)                    REG32((canx) + 0x0000020CU)        /*!< CAN filter scale register */
+#define CAN_FAFIFO(canx)                   REG32((canx) + 0x00000214U)        /*!< CAN filter associated FIFO register */
+#define CAN_FW(canx)                       REG32((canx) + 0x0000021CU)        /*!< CAN filter working register */
+#define CAN_F0DATA0(canx)                  REG32((canx) + 0x00000240U)        /*!< CAN filter 0 data 0 register */
+#define CAN_F1DATA0(canx)                  REG32((canx) + 0x00000248U)        /*!< CAN filter 1 data 0 register */
+#define CAN_F2DATA0(canx)                  REG32((canx) + 0x00000250U)        /*!< CAN filter 2 data 0 register */
+#define CAN_F3DATA0(canx)                  REG32((canx) + 0x00000258U)        /*!< CAN filter 3 data 0 register */
+#define CAN_F4DATA0(canx)                  REG32((canx) + 0x00000260U)        /*!< CAN filter 4 data 0 register */
+#define CAN_F5DATA0(canx)                  REG32((canx) + 0x00000268U)        /*!< CAN filter 5 data 0 register */
+#define CAN_F6DATA0(canx)                  REG32((canx) + 0x00000270U)        /*!< CAN filter 6 data 0 register */
+#define CAN_F7DATA0(canx)                  REG32((canx) + 0x00000278U)        /*!< CAN filter 7 data 0 register */
+#define CAN_F8DATA0(canx)                  REG32((canx) + 0x00000280U)        /*!< CAN filter 8 data 0 register */
+#define CAN_F9DATA0(canx)                  REG32((canx) + 0x00000288U)        /*!< CAN filter 9 data 0 register */
+#define CAN_F10DATA0(canx)                 REG32((canx) + 0x00000290U)        /*!< CAN filter 10 data 0 register */
+#define CAN_F11DATA0(canx)                 REG32((canx) + 0x00000298U)        /*!< CAN filter 11 data 0 register */
+#define CAN_F12DATA0(canx)                 REG32((canx) + 0x000002A0U)        /*!< CAN filter 12 data 0 register */
+#define CAN_F13DATA0(canx)                 REG32((canx) + 0x000002A8U)        /*!< CAN filter 13 data 0 register */
+#define CAN_F14DATA0(canx)                 REG32((canx) + 0x000002B0U)        /*!< CAN filter 14 data 0 register */
+#define CAN_F15DATA0(canx)                 REG32((canx) + 0x000002B8U)        /*!< CAN filter 15 data 0 register */
+#define CAN_F16DATA0(canx)                 REG32((canx) + 0x000002C0U)        /*!< CAN filter 16 data 0 register */
+#define CAN_F17DATA0(canx)                 REG32((canx) + 0x000002C8U)        /*!< CAN filter 17 data 0 register */
+#define CAN_F18DATA0(canx)                 REG32((canx) + 0x000002D0U)        /*!< CAN filter 18 data 0 register */
+#define CAN_F19DATA0(canx)                 REG32((canx) + 0x000002D8U)        /*!< CAN filter 19 data 0 register */
+#define CAN_F20DATA0(canx)                 REG32((canx) + 0x000002E0U)        /*!< CAN filter 20 data 0 register */
+#define CAN_F21DATA0(canx)                 REG32((canx) + 0x000002E8U)        /*!< CAN filter 21 data 0 register */
+#define CAN_F22DATA0(canx)                 REG32((canx) + 0x000002F0U)        /*!< CAN filter 22 data 0 register */
+#define CAN_F23DATA0(canx)                 REG32((canx) + 0x000003F8U)        /*!< CAN filter 23 data 0 register */
+#define CAN_F24DATA0(canx)                 REG32((canx) + 0x00000300U)        /*!< CAN filter 24 data 0 register */
+#define CAN_F25DATA0(canx)                 REG32((canx) + 0x00000308U)        /*!< CAN filter 25 data 0 register */
+#define CAN_F26DATA0(canx)                 REG32((canx) + 0x00000310U)        /*!< CAN filter 26 data 0 register */
+#define CAN_F27DATA0(canx)                 REG32((canx) + 0x00000318U)        /*!< CAN filter 27 data 0 register */
+#define CAN_F0DATA1(canx)                  REG32((canx) + 0x00000244U)        /*!< CAN filter 0 data 1 register */
+#define CAN_F1DATA1(canx)                  REG32((canx) + 0x0000024CU)        /*!< CAN filter 1 data 1 register */
+#define CAN_F2DATA1(canx)                  REG32((canx) + 0x00000254U)        /*!< CAN filter 2 data 1 register */
+#define CAN_F3DATA1(canx)                  REG32((canx) + 0x0000025CU)        /*!< CAN filter 3 data 1 register */
+#define CAN_F4DATA1(canx)                  REG32((canx) + 0x00000264U)        /*!< CAN filter 4 data 1 register */
+#define CAN_F5DATA1(canx)                  REG32((canx) + 0x0000026CU)        /*!< CAN filter 5 data 1 register */
+#define CAN_F6DATA1(canx)                  REG32((canx) + 0x00000274U)        /*!< CAN filter 6 data 1 register */
+#define CAN_F7DATA1(canx)                  REG32((canx) + 0x0000027CU)        /*!< CAN filter 7 data 1 register */
+#define CAN_F8DATA1(canx)                  REG32((canx) + 0x00000284U)        /*!< CAN filter 8 data 1 register */
+#define CAN_F9DATA1(canx)                  REG32((canx) + 0x0000028CU)        /*!< CAN filter 9 data 1 register */
+#define CAN_F10DATA1(canx)                 REG32((canx) + 0x00000294U)        /*!< CAN filter 10 data 1 register */
+#define CAN_F11DATA1(canx)                 REG32((canx) + 0x0000029CU)        /*!< CAN filter 11 data 1 register */
+#define CAN_F12DATA1(canx)                 REG32((canx) + 0x000002A4U)        /*!< CAN filter 12 data 1 register */
+#define CAN_F13DATA1(canx)                 REG32((canx) + 0x000002ACU)        /*!< CAN filter 13 data 1 register */
+#define CAN_F14DATA1(canx)                 REG32((canx) + 0x000002B4U)        /*!< CAN filter 14 data 1 register */
+#define CAN_F15DATA1(canx)                 REG32((canx) + 0x000002BCU)        /*!< CAN filter 15 data 1 register */
+#define CAN_F16DATA1(canx)                 REG32((canx) + 0x000002C4U)        /*!< CAN filter 16 data 1 register */
+#define CAN_F17DATA1(canx)                 REG32((canx) + 0x0000024CU)        /*!< CAN filter 17 data 1 register */
+#define CAN_F18DATA1(canx)                 REG32((canx) + 0x000002D4U)        /*!< CAN filter 18 data 1 register */
+#define CAN_F19DATA1(canx)                 REG32((canx) + 0x000002DCU)        /*!< CAN filter 19 data 1 register */
+#define CAN_F20DATA1(canx)                 REG32((canx) + 0x000002E4U)        /*!< CAN filter 20 data 1 register */
+#define CAN_F21DATA1(canx)                 REG32((canx) + 0x000002ECU)        /*!< CAN filter 21 data 1 register */
+#define CAN_F22DATA1(canx)                 REG32((canx) + 0x000002F4U)        /*!< CAN filter 22 data 1 register */
+#define CAN_F23DATA1(canx)                 REG32((canx) + 0x000002FCU)        /*!< CAN filter 23 data 1 register */
+#define CAN_F24DATA1(canx)                 REG32((canx) + 0x00000304U)        /*!< CAN filter 24 data 1 register */
+#define CAN_F25DATA1(canx)                 REG32((canx) + 0x0000030CU)        /*!< CAN filter 25 data 1 register */
+#define CAN_F26DATA1(canx)                 REG32((canx) + 0x00000314U)        /*!< CAN filter 26 data 1 register */
+#define CAN_F27DATA1(canx)                 REG32((canx) + 0x0000031CU)        /*!< CAN filter 27 data 1 register */
 
 /* CAN transmit mailbox bank */
 #define CAN_TMI(canx, bank)                REG32((canx) + 0x180U + ((bank) * 0x10U))        /*!< CAN transmit mailbox identifier register */
@@ -146,7 +147,7 @@ OF SUCH DAMAGE.
 #define CAN_FDATA0(canx, bank)             REG32((canx) + 0x240U + ((bank) * 0x8U) + 0x0U)  /*!< CAN filter data 0 register */
 #define CAN_FDATA1(canx, bank)             REG32((canx) + 0x240U + ((bank) * 0x8U) + 0x4U)  /*!< CAN filter data 1 register */
 
-/* CAN receive fifo mailbox bank */
+/* CAN receive FIFO mailbox bank */
 #define CAN_RFIFOMI(canx, bank)            REG32((canx) + 0x1B0U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox identifier register */
 #define CAN_RFIFOMP(canx, bank)            REG32((canx) + 0x1B4U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox property register */
 #define CAN_RFIFOMDATA0(canx, bank)        REG32((canx) + 0x1B8U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox data0 register */
@@ -296,10 +297,10 @@ OF SUCH DAMAGE.
 #define CAN_FCTL_HBC1F                     BITS(8,13)                   /*!< header bank of CAN1 filter */
 
 /* CAN_FMCFG */
-#define CAN_FMCFG_FMOD(regval)             BIT(regval)                  /*!< filter mode, list or mask*/
+#define CAN_FMCFG_FMOD(regval)             BIT(regval)                  /*!< filter mode, list or mask */
 
 /* CAN_FSCFG */
-#define CAN_FSCFG_FS(regval)               BIT(regval)                  /*!< filter scale, 32 bits or 16 bits*/
+#define CAN_FSCFG_FS(regval)               BIT(regval)                  /*!< filter scale, 32 bits or 16 bits */
 
 /* CAN_FAFIFO */
 #define CAN_FAFIFOR_FAF(regval)            BIT(regval)                  /*!< filter associated with FIFO */
@@ -310,7 +311,7 @@ OF SUCH DAMAGE.
 /* CAN_FxDATAy */
 #define CAN_FDATA_FD(regval)               BIT(regval)                  /*!< filter data */
 
-/* consts definitions */
+/* constants definitions */
 /* define the CAN bit position and its register index offset */
 #define CAN_REGIDX_BIT(regidx, bitpos)              (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
 #define CAN_REG_VAL(canx, offset)                   (REG32((canx) + ((uint32_t)(offset) >> 6)))
@@ -329,56 +330,54 @@ OF SUCH DAMAGE.
 #define ERR_REG_OFFSET                     ((uint8_t)0x18U)             /*!< ERR register offset */
 
 /* CAN flags */
-typedef enum
-{
+typedef enum {
     /* flags in STAT register */
-    CAN_FLAG_RXL      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 11U),           /*!< RX level */ 
-    CAN_FLAG_LASTRX   = CAN_REGIDX_BIT(STAT_REG_OFFSET, 10U),           /*!< last sample value of RX pin */ 
-    CAN_FLAG_RS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 9U),            /*!< receiving state */ 
-    CAN_FLAG_TS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 8U),            /*!< transmitting state */ 
-    CAN_FLAG_SLPIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 4U),            /*!< status change flag of entering sleep working mode */ 
-    CAN_FLAG_WUIF     = CAN_REGIDX_BIT(STAT_REG_OFFSET, 3U),            /*!< status change flag of wakeup from sleep working mode */ 
-    CAN_FLAG_ERRIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 2U),            /*!< error flag */ 
-    CAN_FLAG_SLPWS    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 1U),            /*!< sleep working state */ 
-    CAN_FLAG_IWS      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 0U),            /*!< initial working state */ 
+    CAN_FLAG_RXL      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 11U),           /*!< RX level */
+    CAN_FLAG_LASTRX   = CAN_REGIDX_BIT(STAT_REG_OFFSET, 10U),           /*!< last sample value of RX pin */
+    CAN_FLAG_RS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 9U),            /*!< receiving state */
+    CAN_FLAG_TS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 8U),            /*!< transmitting state */
+    CAN_FLAG_SLPIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 4U),            /*!< status change flag of entering sleep working mode */
+    CAN_FLAG_WUIF     = CAN_REGIDX_BIT(STAT_REG_OFFSET, 3U),            /*!< status change flag of wakeup from sleep working mode */
+    CAN_FLAG_ERRIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 2U),            /*!< error flag */
+    CAN_FLAG_SLPWS    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 1U),            /*!< sleep working state */
+    CAN_FLAG_IWS      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 0U),            /*!< initial working state */
     /* flags in TSTAT register */
-    CAN_FLAG_TMLS2    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 31U),          /*!< transmit mailbox 2 last sending in Tx FIFO */ 
-    CAN_FLAG_TMLS1    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 30U),          /*!< transmit mailbox 1 last sending in Tx FIFO */ 
-    CAN_FLAG_TMLS0    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 29U),          /*!< transmit mailbox 0 last sending in Tx FIFO */ 
-    CAN_FLAG_TME2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 28U),          /*!< transmit mailbox 2 empty */ 
-    CAN_FLAG_TME1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 27U),          /*!< transmit mailbox 1 empty */ 
-    CAN_FLAG_TME0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 26U),          /*!< transmit mailbox 0 empty */ 
-    CAN_FLAG_MTE2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 19U),          /*!< mailbox 2 transmit error */ 
-    CAN_FLAG_MTE1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 11U),          /*!< mailbox 1 transmit error */ 
-    CAN_FLAG_MTE0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 3U),           /*!< mailbox 0 transmit error */ 
-    CAN_FLAG_MAL2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 18U),          /*!< mailbox 2 arbitration lost */ 
-    CAN_FLAG_MAL1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 10U),          /*!< mailbox 1 arbitration lost */ 
-    CAN_FLAG_MAL0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 2U),           /*!< mailbox 0 arbitration lost */ 
-    CAN_FLAG_MTFNERR2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 17U),          /*!< mailbox 2 transmit finished with no error */ 
-    CAN_FLAG_MTFNERR1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 9U),           /*!< mailbox 1 transmit finished with no error */ 
-    CAN_FLAG_MTFNERR0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 1U),           /*!< mailbox 0 transmit finished with no error */ 
-    CAN_FLAG_MTF2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 16U),          /*!< mailbox 2 transmit finished */ 
-    CAN_FLAG_MTF1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 8U),           /*!< mailbox 1 transmit finished */ 
-    CAN_FLAG_MTF0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 0U),           /*!< mailbox 0 transmit finished */ 
+    CAN_FLAG_TMLS2    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 31U),          /*!< transmit mailbox 2 last sending in TX FIFO */
+    CAN_FLAG_TMLS1    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 30U),          /*!< transmit mailbox 1 last sending in TX FIFO */
+    CAN_FLAG_TMLS0    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 29U),          /*!< transmit mailbox 0 last sending in TX FIFO */
+    CAN_FLAG_TME2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 28U),          /*!< transmit mailbox 2 empty */
+    CAN_FLAG_TME1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 27U),          /*!< transmit mailbox 1 empty */
+    CAN_FLAG_TME0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 26U),          /*!< transmit mailbox 0 empty */
+    CAN_FLAG_MTE2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 19U),          /*!< mailbox 2 transmit error */
+    CAN_FLAG_MTE1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 11U),          /*!< mailbox 1 transmit error */
+    CAN_FLAG_MTE0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 3U),           /*!< mailbox 0 transmit error */
+    CAN_FLAG_MAL2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 18U),          /*!< mailbox 2 arbitration lost */
+    CAN_FLAG_MAL1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 10U),          /*!< mailbox 1 arbitration lost */
+    CAN_FLAG_MAL0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 2U),           /*!< mailbox 0 arbitration lost */
+    CAN_FLAG_MTFNERR2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 17U),          /*!< mailbox 2 transmit finished with no error */
+    CAN_FLAG_MTFNERR1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 9U),           /*!< mailbox 1 transmit finished with no error */
+    CAN_FLAG_MTFNERR0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 1U),           /*!< mailbox 0 transmit finished with no error */
+    CAN_FLAG_MTF2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 16U),          /*!< mailbox 2 transmit finished */
+    CAN_FLAG_MTF1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 8U),           /*!< mailbox 1 transmit finished */
+    CAN_FLAG_MTF0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 0U),           /*!< mailbox 0 transmit finished */
     /* flags in RFIFO0 register */
-    CAN_FLAG_RFO0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 4U),          /*!< receive FIFO0 overfull */ 
-    CAN_FLAG_RFF0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 3U),          /*!< receive FIFO0 full */ 
+    CAN_FLAG_RFO0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 4U),          /*!< receive FIFO0 overfull */
+    CAN_FLAG_RFF0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 3U),          /*!< receive FIFO0 full */
     /* flags in RFIFO1 register */
-    CAN_FLAG_RFO1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 4U),          /*!< receive FIFO1 overfull */ 
-    CAN_FLAG_RFF1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 3U),          /*!< receive FIFO1 full */ 
+    CAN_FLAG_RFO1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 4U),          /*!< receive FIFO1 overfull */
+    CAN_FLAG_RFF1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 3U),          /*!< receive FIFO1 full */
     /* flags in ERR register */
-    CAN_FLAG_BOERR    = CAN_REGIDX_BIT(ERR_REG_OFFSET, 2U),             /*!< bus-off error */ 
-    CAN_FLAG_PERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 1U),             /*!< passive error */ 
-    CAN_FLAG_WERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 0U),             /*!< warning error */ 
-}can_flag_enum;
+    CAN_FLAG_BOERR    = CAN_REGIDX_BIT(ERR_REG_OFFSET, 2U),             /*!< bus-off error */
+    CAN_FLAG_PERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 1U),             /*!< passive error */
+    CAN_FLAG_WERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 0U),             /*!< warning error */
+} can_flag_enum;
 
 /* CAN interrupt flags */
-typedef enum
-{
+typedef enum {
     /* interrupt flags in STAT register */
-    CAN_INT_FLAG_SLPIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 4U, 17U),     /*!< status change interrupt flag of sleep working mode entering */ 
-    CAN_INT_FLAG_WUIF  = CAN_REGIDX_BITS(STAT_REG_OFFSET, 3U, 16),      /*!< status change interrupt flag of wakeup from sleep working mode */ 
-    CAN_INT_FLAG_ERRIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 2U, 15),      /*!< error interrupt flag */ 
+    CAN_INT_FLAG_SLPIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 4U, 17U),     /*!< status change interrupt flag of sleep working mode entering */
+    CAN_INT_FLAG_WUIF  = CAN_REGIDX_BITS(STAT_REG_OFFSET, 3U, 16),      /*!< status change interrupt flag of wakeup from sleep working mode */
+    CAN_INT_FLAG_ERRIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 2U, 15),      /*!< error interrupt flag */
     /* interrupt flags in TSTAT register */
     CAN_INT_FLAG_MTF2  = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 16U, 0U),    /*!< mailbox 2 transmit finished interrupt flag */
     CAN_INT_FLAG_MTF1  = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 8U, 0U),     /*!< mailbox 1 transmit finished interrupt flag */
@@ -390,44 +389,41 @@ typedef enum
     /* interrupt flags in RFIFO0 register */
     CAN_INT_FLAG_RFO1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 4U, 6U),    /*!< receive FIFO1 overfull interrupt flag */
     CAN_INT_FLAG_RFF1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 3U, 5U),    /*!< receive FIFO1 full interrupt flag */
-    CAN_INT_FLAG_RFL1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 2U, 4U),    /*!< receive FIFO0 not empty interrupt flag */
+    CAN_INT_FLAG_RFL1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 2U, 4U),    /*!< receive FIFO1 not empty interrupt flag */
     /* interrupt flags in ERR register */
-    CAN_INT_FLAG_ERRN  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 3U, 11U),      /*!< error number interrupt flag */ 
-    CAN_INT_FLAG_BOERR = CAN_REGIDX_BITS(ERR_REG_OFFSET, 2U, 10U),      /*!< bus-off error interrupt flag */ 
-    CAN_INT_FLAG_PERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 1U, 9U),       /*!< passive error interrupt flag */ 
-    CAN_INT_FLAG_WERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 0U, 8U),       /*!< warning error interrupt flag */ 
-}can_interrupt_flag_enum;
+    CAN_INT_FLAG_ERRN  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 3U, 11U),      /*!< error number interrupt flag */
+    CAN_INT_FLAG_BOERR = CAN_REGIDX_BITS(ERR_REG_OFFSET, 2U, 10U),      /*!< bus-off error interrupt flag */
+    CAN_INT_FLAG_PERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 1U, 9U),       /*!< passive error interrupt flag */
+    CAN_INT_FLAG_WERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 0U, 8U),       /*!< warning error interrupt flag */
+} can_interrupt_flag_enum;
 
-/* CAN initiliaze parameters struct */
-typedef struct
-{
-    uint8_t working_mode;                                               /*!< CAN working mode */ 
+/* CAN initiliaze parameters structure */
+typedef struct {
+    uint8_t working_mode;                                               /*!< CAN working mode */
     uint8_t resync_jump_width;                                          /*!< CAN resynchronization jump width */
     uint8_t time_segment_1;                                             /*!< time segment 1 */
     uint8_t time_segment_2;                                             /*!< time segment 2 */
     ControlStatus time_triggered;                                       /*!< time triggered communication mode */
     ControlStatus auto_bus_off_recovery;                                /*!< automatic bus-off recovery */
     ControlStatus auto_wake_up;                                         /*!< automatic wake-up mode */
-    ControlStatus no_auto_retrans;                                      /*!< automatic retransmission mode disable */
-    ControlStatus rec_fifo_overwrite;                                   /*!< receive FIFO overwrite mode */
+    ControlStatus auto_retrans;                                         /*!< automatic retransmission mode disable */
+    ControlStatus rec_fifo_overwrite;                                   /*!< receive FIFO overwrite mode disable */
     ControlStatus trans_fifo_order;                                     /*!< transmit FIFO order */
     uint16_t prescaler;                                                 /*!< baudrate prescaler */
-}can_parameter_struct;
+} can_parameter_struct;
 
-/* CAN transmit message struct */
-typedef struct
-{
+/* CAN transmit message structure */
+typedef struct {
     uint32_t tx_sfid;                                                   /*!< standard format frame identifier */
     uint32_t tx_efid;                                                   /*!< extended format frame identifier */
     uint8_t tx_ff;                                                      /*!< format of frame, standard or extended format */
     uint8_t tx_ft;                                                      /*!< type of frame, data or remote */
     uint8_t tx_dlen;                                                    /*!< data length */
     uint8_t tx_data[8];                                                 /*!< transmit data */
-}can_trasnmit_message_struct;
+} can_trasnmit_message_struct;
 
-/* CAN receive message struct */
-typedef struct
-{
+/* CAN receive message structure */
+typedef struct {
     uint32_t rx_sfid;                                                   /*!< standard format frame identifier */
     uint32_t rx_efid;                                                   /*!< extended format frame identifier */
     uint8_t rx_ff;                                                      /*!< format of frame, standard or extended format */
@@ -437,10 +433,9 @@ typedef struct
     uint8_t rx_fi;                                                      /*!< filtering index */
 } can_receive_message_struct;
 
-/* CAN filter parameters struct */
-typedef struct
-{
-    uint16_t filter_list_high;                                          /*!< filter list number high bits*/
+/* CAN filter parameters structure */
+typedef struct {
+    uint16_t filter_list_high;                                          /*!< filter list number high bits */
     uint16_t filter_list_low;                                           /*!< filter list number low bits */
     uint16_t filter_mask_high;                                          /*!< filter mask number high bits */
     uint16_t filter_mask_low;                                           /*!< filter mask number low bits */
@@ -449,11 +444,10 @@ typedef struct
     uint16_t filter_mode;                                               /*!< filter mode, list or mask */
     uint16_t filter_bits;                                               /*!< filter scale */
     ControlStatus filter_enable;                                        /*!< filter work or not */
-}can_filter_parameter_struct;
+} can_filter_parameter_struct;
 
 /* CAN errors */
-typedef enum
-{
+typedef enum {
     CAN_ERROR_NONE = 0,                                                 /*!< no error */
     CAN_ERROR_FILL,                                                     /*!< fill error */
     CAN_ERROR_FORMATE,                                                  /*!< format error */
@@ -462,38 +456,36 @@ typedef enum
     CAN_ERROR_BITDOMINANTER,                                            /*!< bit dominant error */
     CAN_ERROR_CRC,                                                      /*!< CRC error */
     CAN_ERROR_SOFTWARECFG,                                              /*!< software configure */
-}can_error_enum;
+} can_error_enum;
 
 /* transmit states */
-typedef enum
-{
-    CAN_TRANSMIT_FAILED = 0U,                                            /*!< CAN transmitted failure */
-    CAN_TRANSMIT_OK = 1U,                                                /*!< CAN transmitted success */
-    CAN_TRANSMIT_PENDING = 2U,                                           /*!< CAN transmitted pending */
-    CAN_TRANSMIT_NOMAILBOX = 4U,                                         /*!< no empty mailbox to be used for CAN */
-}can_transmit_state_enum;
+typedef enum {
+    CAN_TRANSMIT_FAILED = 0U,                                           /*!< CAN transmitted failure */
+    CAN_TRANSMIT_OK = 1U,                                               /*!< CAN transmitted success */
+    CAN_TRANSMIT_PENDING = 2U,                                          /*!< CAN transmitted pending */
+    CAN_TRANSMIT_NOMAILBOX = 4U,                                        /*!< no empty mailbox to be used for CAN */
+} can_transmit_state_enum;
 
-typedef enum
-{
+typedef enum {
     CAN_INIT_STRUCT = 0,                                                /* CAN initiliaze parameters struct */
     CAN_FILTER_STRUCT,                                                  /* CAN filter parameters struct */
     CAN_TX_MESSAGE_STRUCT,                                              /* CAN transmit message struct */
     CAN_RX_MESSAGE_STRUCT,                                              /* CAN receive message struct */
-}can_struct_type_enum;
+} can_struct_type_enum;
 
-/* CAN baudrate prescaler*/
+/* CAN baudrate prescaler */
 #define BT_BAUDPSC(regval)                 (BITS(0,9) & ((uint32_t)(regval) << 0))
 
-/* CAN bit segment 1*/
+/* CAN bit segment 1 */
 #define BT_BS1(regval)                     (BITS(16,19) & ((uint32_t)(regval) << 16))
 
-/* CAN bit segment 2*/
+/* CAN bit segment 2 */
 #define BT_BS2(regval)                     (BITS(20,22) & ((uint32_t)(regval) << 20))
 
-/* CAN resynchronization jump width*/
+/* CAN resynchronization jump width */
 #define BT_SJW(regval)                     (BITS(24,25) & ((uint32_t)(regval) << 24))
 
-/* CAN communication mode*/
+/* CAN communication mode */
 #define BT_MODE(regval)                    (BITS(30,31) & ((uint32_t)(regval) << 30))
 
 /* CAN FDATA high 16 bits */
@@ -502,13 +494,13 @@ typedef enum
 /* CAN FDATA low 16 bits */
 #define FDATA_MASK_LOW(regval)             (BITS(0,15) & ((uint32_t)(regval) << 0))
 
-/* CAN1 filter start bank_number*/
+/* CAN1 filter start bank_number */
 #define FCTL_HBC1F(regval)                 (BITS(8,13) & ((uint32_t)(regval) << 8))
 
-/* CAN transmit mailbox extended identifier*/
+/* CAN transmit mailbox extended identifier */
 #define TMI_EFID(regval)                   (BITS(3,31) & ((uint32_t)(regval) << 3))
 
-/* CAN transmit mailbox standard identifier*/
+/* CAN transmit mailbox standard identifier */
 #define TMI_SFID(regval)                   (BITS(21,31) & ((uint32_t)(regval) << 21))
 
 /* transmit data byte 0 */
@@ -520,25 +512,25 @@ typedef enum
 /* transmit data byte 2 */
 #define TMDATA0_DB2(regval)                (BITS(16,23) & ((uint32_t)(regval) << 16))
 
-/* transmit data byte 3 */                 
+/* transmit data byte 3 */
 #define TMDATA0_DB3(regval)                (BITS(24,31) & ((uint32_t)(regval) << 24))
 
-/* transmit data byte 4 */                 
+/* transmit data byte 4 */
 #define TMDATA1_DB4(regval)                (BITS(0,7) & ((uint32_t)(regval) << 0))
 
-/* transmit data byte 5 */                 
+/* transmit data byte 5 */
 #define TMDATA1_DB5(regval)                (BITS(8,15) & ((uint32_t)(regval) << 8))
 
-/* transmit data byte 6 */                 
+/* transmit data byte 6 */
 #define TMDATA1_DB6(regval)                (BITS(16,23) & ((uint32_t)(regval) << 16))
 
-/* transmit data byte 7 */                 
+/* transmit data byte 7 */
 #define TMDATA1_DB7(regval)                (BITS(24,31) & ((uint32_t)(regval) << 24))
 
-/* receive mailbox extended identifier*/
+/* receive mailbox extended identifier */
 #define GET_RFIFOMI_EFID(regval)           GET_BITS((uint32_t)(regval), 3U, 31U)
 
-/* receive mailbox standrad identifier*/
+/* receive mailbox standard identifier */
 #define GET_RFIFOMI_SFID(regval)           GET_BITS((uint32_t)(regval), 21U, 31U)
 
 /* receive data length */
@@ -571,33 +563,33 @@ typedef enum
 /* receive data byte 7 */
 #define GET_RFIFOMDATA1_DB7(regval)        GET_BITS((uint32_t)(regval), 24U, 31U)
 
-/* error number */        
+/* error number */
 #define GET_ERR_ERRN(regval)               GET_BITS((uint32_t)(regval), 4U, 6U)
 
-/* transmit error count */        
+/* transmit error count */
 #define GET_ERR_TECNT(regval)              GET_BITS((uint32_t)(regval), 16U, 23U)
 
-/* receive  error count */        
+/* receive  error count */
 #define GET_ERR_RECNT(regval)              GET_BITS((uint32_t)(regval), 24U, 31U)
 
 /* CAN errors */
 #define ERR_ERRN(regval)                   (BITS(4,6) & ((uint32_t)(regval) << 4))
-#define CAN_ERRN_0                         ERR_ERRN(0U)                  /* no error */
-#define CAN_ERRN_1                         ERR_ERRN(1U)                  /*!< fill error */
-#define CAN_ERRN_2                         ERR_ERRN(2U)                  /*!< format error */
-#define CAN_ERRN_3                         ERR_ERRN(3U)                  /*!< ACK error */
-#define CAN_ERRN_4                         ERR_ERRN(4U)                  /*!< bit recessive error */
-#define CAN_ERRN_5                         ERR_ERRN(5U)                  /*!< bit dominant error */
-#define CAN_ERRN_6                         ERR_ERRN(6U)                  /*!< CRC error */
-#define CAN_ERRN_7                         ERR_ERRN(7U)                  /*!< software error */
+#define CAN_ERRN_0                         ERR_ERRN(0U)                 /*!< no error */
+#define CAN_ERRN_1                         ERR_ERRN(1U)                 /*!< fill error */
+#define CAN_ERRN_2                         ERR_ERRN(2U)                 /*!< format error */
+#define CAN_ERRN_3                         ERR_ERRN(3U)                 /*!< ACK error */
+#define CAN_ERRN_4                         ERR_ERRN(4U)                 /*!< bit recessive error */
+#define CAN_ERRN_5                         ERR_ERRN(5U)                 /*!< bit dominant error */
+#define CAN_ERRN_6                         ERR_ERRN(6U)                 /*!< CRC error */
+#define CAN_ERRN_7                         ERR_ERRN(7U)                 /*!< software error */
 
 #define CAN_STATE_PENDING                  ((uint32_t)0x00000000U)      /*!< CAN pending */
 
 /* CAN communication mode */
-#define GD32_CAN_NORMAL_MODE               ((uint8_t)0x00U)             /*!< normal communication mode */
-#define GD32_CAN_LOOPBACK_MODE             ((uint8_t)0x01U)             /*!< loopback communication mode */
-#define GD32_CAN_SILENT_MODE               ((uint8_t)0x02U)             /*!< silent communication mode */
-#define GD32_CAN_SILENT_LOOPBACK_MODE      ((uint8_t)0x03U)             /*!< loopback and silent communication mode */
+#define CAN_NORMAL_MODE                    ((uint8_t)0x00U)             /*!< normal communication mode */
+#define CAN_LOOPBACK_MODE                  ((uint8_t)0x01U)             /*!< loopback communication mode */
+#define CAN_SILENT_MODE                    ((uint8_t)0x02U)             /*!< silent communication mode */
+#define CAN_SILENT_LOOPBACK_MODE           ((uint8_t)0x03U)             /*!< loopback and silent communication mode */
 
 /* CAN resynchronisation jump width */
 #define CAN_BT_SJW_1TQ                     ((uint8_t)0x00U)             /*!< 1 time quanta */
@@ -643,11 +635,11 @@ typedef enum
 #define CAN_FF_STANDARD                    ((uint32_t)0x00000000U)      /*!< standard frame */
 #define CAN_FF_EXTENDED                    ((uint32_t)0x00000004U)      /*!< extended frame */
 
-/* CAN receive fifo */
+/* CAN receive FIFO */
 #define CAN_FIFO0                          ((uint8_t)0x00U)             /*!< receive FIFO0 */
 #define CAN_FIFO1                          ((uint8_t)0x01U)             /*!< receive FIFO1 */
 
-/* frame number of receive fifo */
+/* frame number of receive FIFO */
 #define CAN_RFIF_RFL_MASK                  ((uint32_t)0x00000003U)      /*!< mask for frame number in receive FIFOx */
 
 #define CAN_SFID_MASK                      ((uint32_t)0x000007FFU)      /*!< mask of standard identifier */
@@ -674,7 +666,7 @@ typedef enum
 #define CAN_FT_REMOTE                      ((uint32_t)0x00000002U)      /*!< remote frame */
 
 /* CAN timeout */
-#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */
@@ -693,15 +685,18 @@ typedef enum
 #define CAN_INT_SLPW                       CAN_INTEN_SLPWIE             /*!< sleep working interrupt enable */
 
 /* function declarations */
+/* initialization functions */
 /* deinitialize CAN */
 void can_deinit(uint32_t can_periph);
-/* initialize CAN struct */
-void can_struct_para_init(can_struct_type_enum type, void* p_struct);
+/* initialize CAN structure */
+void can_struct_para_init(can_struct_type_enum type, void *p_struct);
 /* initialize CAN */
-ErrStatus can_init(uint32_t can_periph, can_parameter_struct* can_parameter_init);
-/* CAN filter init */
-void can_filter_init(can_filter_parameter_struct* can_filter_parameter_init);
-/* set can1 fliter start bank number */
+ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init);
+/* CAN filter initialization */
+void can_filter_init(can_filter_parameter_struct *can_filter_parameter_init);
+
+/* function configuration */
+/* set can1 filter start bank number */
 void can1_filter_start_bank(uint8_t start_bank);
 /* enable functions */
 /* CAN debug freeze enable */
@@ -715,14 +710,14 @@ void can_time_trigger_mode_disable(uint32_t can_periph);
 
 /* transmit functions */
 /* transmit CAN message */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message);
+uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct *transmit_message);
 /* get CAN transmit state */
 can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox_number);
 /* stop CAN transmission */
 void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number);
 /* CAN receive message */
-void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct* receive_message);
-/* CAN release fifo */
+void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct *receive_message);
+/* CAN release FIFO */
 void can_fifo_release(uint32_t can_periph, uint8_t fifo_number);
 /* CAN receive message length */
 uint8_t can_receive_message_length_get(uint32_t can_periph, uint8_t fifo_number);
@@ -731,21 +726,22 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode);
 /* CAN wakeup from sleep mode */
 ErrStatus can_wakeup(uint32_t can_periph);
 
-/* CAN get error */
+/* CAN get error type */
 can_error_enum can_error_get(uint32_t can_periph);
 /* get CAN receive error number */
 uint8_t can_receive_error_number_get(uint32_t can_periph);
 /* get CAN transmit error number */
 uint8_t can_transmit_error_number_get(uint32_t can_periph);
 
-/* CAN interrupt enable */
-void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt);
-/* CAN interrupt disable */
-void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt);
+/* interrupt & flag functions */
 /* CAN get flag state */
 FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag);
 /* CAN clear flag state */
 void can_flag_clear(uint32_t can_periph, can_flag_enum flag);
+/* CAN interrupt enable */
+void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt);
+/* CAN interrupt disable */
+void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt);
 /* CAN get interrupt flag state */
 FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum flag);
 /* CAN clear interrupt flag state */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
@@ -586,10 +586,10 @@ typedef enum {
 #define CAN_STATE_PENDING                  ((uint32_t)0x00000000U)      /*!< CAN pending */
 
 /* CAN communication mode */
-#define CAN_NORMAL_MODE                    ((uint8_t)0x00U)             /*!< normal communication mode */
-#define CAN_LOOPBACK_MODE                  ((uint8_t)0x01U)             /*!< loopback communication mode */
-#define CAN_SILENT_MODE                    ((uint8_t)0x02U)             /*!< silent communication mode */
-#define CAN_SILENT_LOOPBACK_MODE           ((uint8_t)0x03U)             /*!< loopback and silent communication mode */
+#define GD32_CAN_NORMAL_MODE               ((uint8_t)0x00U)             /*!< normal communication mode */
+#define GD32_CAN_LOOPBACK_MODE             ((uint8_t)0x01U)             /*!< loopback communication mode */
+#define GD32_CAN_SILENT_MODE               ((uint8_t)0x02U)             /*!< silent communication mode */
+#define GD32_CAN_SILENT_LOOPBACK_MODE      ((uint8_t)0x03U)             /*!< loopback and silent communication mode */
 
 /* CAN resynchronisation jump width */
 #define CAN_BT_SJW_1TQ                     ((uint8_t)0x00U)             /*!< 1 time quanta */
@@ -666,7 +666,7 @@ typedef enum {
 #define CAN_FT_REMOTE                      ((uint32_t)0x00000002U)      /*!< remote frame */
 
 /* CAN timeout */
-#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_crc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_crc.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -40,12 +41,12 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* CRC definitions */
-#define CRC                            CRC_BASE
+#define CRC                            CRC_BASE                        /*!< CRC base address */
 
 /* registers definitions */
-#define CRC_DATA                       REG32(CRC + 0x00U)              /*!< CRC data register */
-#define CRC_FDATA                      REG32(CRC + 0x04U)              /*!< CRC free data register */
-#define CRC_CTL                        REG32(CRC + 0x08U)              /*!< CRC control register */
+#define CRC_DATA                       REG32(CRC + 0x00000000U)        /*!< CRC data register */
+#define CRC_FDATA                      REG32(CRC + 0x00000004U)        /*!< CRC free data register */
+#define CRC_CTL                        REG32(CRC + 0x00000008U)        /*!< CRC control register */
 
 /* bits definitions */
 /* CRC_DATA */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_ctc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_ctc.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_dac.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_dac.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -254,14 +255,14 @@ void dac_concurrent_interrupt_enable(void);
 void dac_concurrent_interrupt_disable(void);
 
 /* DAC interrupt configuration */
-/* enable DAC interrupt(DAC DMA underrun interrupt) */
-void dac_interrupt_enable(uint32_t dac_periph);
-/* disable DAC interrupt(DAC DMA underrun interrupt) */
-void dac_interrupt_disable(uint32_t dac_periph);
 /* get the specified DAC flag(DAC DMA underrun flag) */
 FlagStatus dac_flag_get(uint32_t dac_periph);
 /* clear the specified DAC flag(DAC DMA underrun flag) */
 void dac_flag_clear(uint32_t dac_periph);
+/* enable DAC interrupt(DAC DMA underrun interrupt) */
+void dac_interrupt_enable(uint32_t dac_periph);
+/* disable DAC interrupt(DAC DMA underrun interrupt) */
+void dac_interrupt_disable(uint32_t dac_periph);
 /* get the specified DAC interrupt flag(DAC DMA underrun interrupt flag) */
 FlagStatus dac_interrupt_flag_get(uint32_t dac_periph);
 /* clear the specified DAC interrupt flag(DAC DMA underrun interrupt flag) */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_dbg.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_dbg.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -57,7 +58,6 @@ OF SUCH DAMAGE.
 #define DBG_CTL0_DSLP_HOLD       BIT(1)                     /*!< keep debugger connection during deepsleep mode */
 #define DBG_CTL0_STB_HOLD        BIT(2)                     /*!< keep debugger connection during standby mode */
 #define DBG_CTL0_TRACE_IOEN      BIT(5)                     /*!< enable trace pin assignment */
-#define DBG_CTL0_TRACE_MODE      BITS(6,7)                  /*!< trace pin mode selection */
 
 /* DBG_CTL1 */
 #define DBG_CTL1_TIMER1_HOLD     BIT(0)                     /*!< hold TIMER1 counter when core is halted */
@@ -122,18 +122,12 @@ typedef enum
     DBG_I2C2_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 23U),                   /*!< hold I2C2 smbus when core is halted */
     DBG_CAN0_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 25U),                   /*!< debug CAN0 kept when core is halted */
     DBG_CAN1_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 26U),                   /*!< debug CAN1 kept when core is halted */
-    DBG_TIMER0_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 0U),        /*!< hold TIMER0 counter when core is halted */
-    DBG_TIMER7_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 1U),        /*!< hold TIMER7 counter when core is halted */
-    DBG_TIMER8_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 16U),       /*!< hold TIMER8 counter when core is halted */
-    DBG_TIMER9_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 17U),       /*!< hold TIMER9 counter when core is halted */
-    DBG_TIMER10_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL2, 18U)       /*!< hold TIMER10 counter when core is halted */
+    DBG_TIMER0_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 0U),                    /*!< hold TIMER0 counter when core is halted */
+    DBG_TIMER7_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 1U),                    /*!< hold TIMER7 counter when core is halted */
+    DBG_TIMER8_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 16U),                   /*!< hold TIMER8 counter when core is halted */
+    DBG_TIMER9_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 17U),                   /*!< hold TIMER9 counter when core is halted */
+    DBG_TIMER10_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL2, 18U)                    /*!< hold TIMER10 counter when core is halted */
 }dbg_periph_enum;
-
-#define CTL0_TRACE_MODE(regval)       (BITS(6,7)&((uint32_t)(regval)<<6))
-#define TRACE_MODE_ASYNC              CTL0_TRACE_MODE(0)    /*!< trace pin used for async mode */
-#define TRACE_MODE_SYNC_DATASIZE_1    CTL0_TRACE_MODE(1)    /*!< trace pin used for sync mode and data size is 1 */
-#define TRACE_MODE_SYNC_DATASIZE_2    CTL0_TRACE_MODE(2)    /*!< trace pin used for sync mode and data size is 2 */
-#define TRACE_MODE_SYNC_DATASIZE_4    CTL0_TRACE_MODE(3)    /*!< trace pin used for sync mode and data size is 4 */
 
 /* function declarations */
 /* deinitialize the DBG */
@@ -155,7 +149,5 @@ void dbg_periph_disable(dbg_periph_enum dbg_periph);
 void dbg_trace_pin_enable(void);
 /* disable trace pin assignment */
 void dbg_trace_pin_disable(void);
-/* set trace pin mode */
-void dbg_trace_pin_mode_set(uint32_t trace_mode);
 
 #endif /* GD32F4XX_DBG_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_dci.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_dci.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_dma.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_dma.h
@@ -1,14 +1,14 @@
 /*!
-    \file    gd32f4xx_dma.c
+    \file    gd32f4xx_dma.h
     \brief   definitions for the DMA
-
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -40,70 +40,70 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* DMA definitions */
-#define DMA0                              (DMA_BASE)                    /*!< DMA0 base address */
-#define DMA1                              (DMA_BASE + 0x0400U)          /*!< DMA1 base address */
+#define DMA0                              (DMA_BASE)                          /*!< DMA0 base address */
+#define DMA1                              (DMA_BASE + 0x00000400U)            /*!< DMA1 base address */
 
 /* registers definitions */
-#define DMA_INTF0(dmax)                    REG32((dmax) + 0x00U)        /*!< DMA interrupt flag register 0 */
-#define DMA_INTF1(dmax)                    REG32((dmax) + 0x04U)        /*!< DMA interrupt flag register 1 */
-#define DMA_INTC0(dmax)                    REG32((dmax) + 0x08U)        /*!< DMA interrupt flag clear register 0 */
-#define DMA_INTC1(dmax)                    REG32((dmax) + 0x0CU)        /*!< DMA interrupt flag clear register 1 */
+#define DMA_INTF0(dmax)                    REG32((dmax) + 0x00000000U)        /*!< DMA interrupt flag register 0 */
+#define DMA_INTF1(dmax)                    REG32((dmax) + 0x00000004U)        /*!< DMA interrupt flag register 1 */
+#define DMA_INTC0(dmax)                    REG32((dmax) + 0x00000008U)        /*!< DMA interrupt flag clear register 0 */
+#define DMA_INTC1(dmax)                    REG32((dmax) + 0x0000000CU)        /*!< DMA interrupt flag clear register 1 */
 
-#define DMA_CH0CTL(dmax)                   REG32((dmax) + 0x10U)        /*!< DMA channel 0 control register */
-#define DMA_CH0CNT(dmax)                   REG32((dmax) + 0x14U)        /*!< DMA channel 0 counter register */
-#define DMA_CH0PADDR(dmax)                 REG32((dmax) + 0x18U)        /*!< DMA channel 0 peripheral base address register */
-#define DMA_CH0M0ADDR(dmax)                REG32((dmax) + 0x1CU)        /*!< DMA channel 0 memory 0 base address register */
-#define DMA_CH0M1ADDR(dmax)                REG32((dmax) + 0x20U)        /*!< DMA channel 0 memory 1 base address register */
-#define DMA_CH0FCTL(dmax)                  REG32((dmax) + 0x24U)        /*!< DMA channel 0 FIFO control register */
+#define DMA_CH0CTL(dmax)                   REG32((dmax) + 0x00000010U)        /*!< DMA channel 0 control register */
+#define DMA_CH0CNT(dmax)                   REG32((dmax) + 0x00000014U)        /*!< DMA channel 0 counter register */
+#define DMA_CH0PADDR(dmax)                 REG32((dmax) + 0x00000018U)        /*!< DMA channel 0 peripheral base address register */
+#define DMA_CH0M0ADDR(dmax)                REG32((dmax) + 0x0000001CU)        /*!< DMA channel 0 memory 0 base address register */
+#define DMA_CH0M1ADDR(dmax)                REG32((dmax) + 0x00000020U)        /*!< DMA channel 0 memory 1 base address register */
+#define DMA_CH0FCTL(dmax)                  REG32((dmax) + 0x00000024U)        /*!< DMA channel 0 FIFO control register */
 
-#define DMA_CH1CTL(dmax)                   REG32((dmax) + 0x28U)        /*!< DMA channel 1 control register */
-#define DMA_CH1CNT(dmax)                   REG32((dmax) + 0x2CU)        /*!< DMA channel 1 counter register */
-#define DMA_CH1PADDR(dmax)                 REG32((dmax) + 0x30U)        /*!< DMA channel 1 peripheral base address register */
-#define DMA_CH1M0ADDR(dmax)                REG32((dmax) + 0x34U)        /*!< DMA channel 1 memory 0 base address register */
-#define DMA_CH1M1ADDR(dmax)                REG32((dmax) + 0x38U)        /*!< DMA channel 1 memory 1 base address register */
-#define DMA_CH1FCTL(dmax)                  REG32((dmax) + 0x3CU)        /*!< DMA channel 1 FIFO control register */
+#define DMA_CH1CTL(dmax)                   REG32((dmax) + 0x00000028U)        /*!< DMA channel 1 control register */
+#define DMA_CH1CNT(dmax)                   REG32((dmax) + 0x0000002CU)        /*!< DMA channel 1 counter register */
+#define DMA_CH1PADDR(dmax)                 REG32((dmax) + 0x00000030U)        /*!< DMA channel 1 peripheral base address register */
+#define DMA_CH1M0ADDR(dmax)                REG32((dmax) + 0x00000034U)        /*!< DMA channel 1 memory 0 base address register */
+#define DMA_CH1M1ADDR(dmax)                REG32((dmax) + 0x00000038U)        /*!< DMA channel 1 memory 1 base address register */
+#define DMA_CH1FCTL(dmax)                  REG32((dmax) + 0x0000003CU)        /*!< DMA channel 1 FIFO control register */
 
-#define DMA_CH2CTL(dmax)                   REG32((dmax) + 0x40U)        /*!< DMA channel 2 control register */
-#define DMA_CH2CNT(dmax)                   REG32((dmax) + 0x44U)        /*!< DMA channel 2 counter register */
-#define DMA_CH2PADDR(dmax)                 REG32((dmax) + 0x48U)        /*!< DMA channel 2 peripheral base address register */
-#define DMA_CH2M0ADDR(dmax)                REG32((dmax) + 0x4CU)        /*!< DMA channel 2 memory 0 base address register */
-#define DMA_CH2M1ADDR(dmax)                REG32((dmax) + 0x50U)        /*!< DMA channel 2 memory 1 base address register */
-#define DMA_CH2FCTL(dmax)                  REG32((dmax) + 0x54U)        /*!< DMA channel 2 FIFO control register */
+#define DMA_CH2CTL(dmax)                   REG32((dmax) + 0x00000040U)        /*!< DMA channel 2 control register */
+#define DMA_CH2CNT(dmax)                   REG32((dmax) + 0x00000044U)        /*!< DMA channel 2 counter register */
+#define DMA_CH2PADDR(dmax)                 REG32((dmax) + 0x00000048U)        /*!< DMA channel 2 peripheral base address register */
+#define DMA_CH2M0ADDR(dmax)                REG32((dmax) + 0x0000004CU)        /*!< DMA channel 2 memory 0 base address register */
+#define DMA_CH2M1ADDR(dmax)                REG32((dmax) + 0x00000050U)        /*!< DMA channel 2 memory 1 base address register */
+#define DMA_CH2FCTL(dmax)                  REG32((dmax) + 0x00000054U)        /*!< DMA channel 2 FIFO control register */
 
-#define DMA_CH3CTL(dmax)                   REG32((dmax) + 0x58U)        /*!< DMA channel 3 control register */
-#define DMA_CH3CNT(dmax)                   REG32((dmax) + 0x5CU)        /*!< DMA channel 3 counter register */
-#define DMA_CH3PADDR(dmax)                 REG32((dmax) + 0x60U)        /*!< DMA channel 3 peripheral base address register */
-#define DMA_CH3M0ADDR(dmax)                REG32((dmax) + 0x64U)        /*!< DMA channel 3 memory 0 base address register */
-#define DMA_CH3M1ADDR(dmax)                REG32((dmax) + 0x68U)        /*!< DMA channel 3 memory 1 base address register */
-#define DMA_CH3FCTL(dmax)                  REG32((dmax) + 0x6CU)        /*!< DMA channel 3 FIFO control register */
+#define DMA_CH3CTL(dmax)                   REG32((dmax) + 0x00000058U)        /*!< DMA channel 3 control register */
+#define DMA_CH3CNT(dmax)                   REG32((dmax) + 0x0000005CU)        /*!< DMA channel 3 counter register */
+#define DMA_CH3PADDR(dmax)                 REG32((dmax) + 0x00000060U)        /*!< DMA channel 3 peripheral base address register */
+#define DMA_CH3M0ADDR(dmax)                REG32((dmax) + 0x00000064U)        /*!< DMA channel 3 memory 0 base address register */
+#define DMA_CH3M1ADDR(dmax)                REG32((dmax) + 0x00000068U)        /*!< DMA channel 3 memory 1 base address register */
+#define DMA_CH3FCTL(dmax)                  REG32((dmax) + 0x0000006CU)        /*!< DMA channel 3 FIFO control register */
 
-#define DMA_CH4CTL(dmax)                   REG32((dmax) + 0x70U)        /*!< DMA channel 4 control register */
-#define DMA_CH4CNT(dmax)                   REG32((dmax) + 0x74U)        /*!< DMA channel 4 counter register */
-#define DMA_CH4PADDR(dmax)                 REG32((dmax) + 0x78U)        /*!< DMA channel 4 peripheral base address register */
-#define DMA_CH4M0ADDR(dmax)                REG32((dmax) + 0x7CU)        /*!< DMA channel 4 memory 0 base address register */
-#define DMA_CH4M1ADDR(dmax)                REG32((dmax) + 0x80U)        /*!< DMA channel 4 memory 1 base address register */
-#define DMA_CH4FCTL(dmax)                  REG32((dmax) + 0x84U)        /*!< DMA channel 4 FIFO control register */
+#define DMA_CH4CTL(dmax)                   REG32((dmax) + 0x00000070U)        /*!< DMA channel 4 control register */
+#define DMA_CH4CNT(dmax)                   REG32((dmax) + 0x00000074U)        /*!< DMA channel 4 counter register */
+#define DMA_CH4PADDR(dmax)                 REG32((dmax) + 0x00000078U)        /*!< DMA channel 4 peripheral base address register */
+#define DMA_CH4M0ADDR(dmax)                REG32((dmax) + 0x0000007CU)        /*!< DMA channel 4 memory 0 base address register */
+#define DMA_CH4M1ADDR(dmax)                REG32((dmax) + 0x00000080U)        /*!< DMA channel 4 memory 1 base address register */
+#define DMA_CH4FCTL(dmax)                  REG32((dmax) + 0x00000084U)        /*!< DMA channel 4 FIFO control register */
 
-#define DMA_CH5CTL(dmax)                   REG32((dmax) + 0x88U)        /*!< DMA channel 5 control register */
-#define DMA_CH5CNT(dmax)                   REG32((dmax) + 0x8CU)        /*!< DMA channel 5 counter register */
-#define DMA_CH5PADDR(dmax)                 REG32((dmax) + 0x90U)        /*!< DMA channel 5 peripheral base address register */
-#define DMA_CH5M0ADDR(dmax)                REG32((dmax) + 0x94U)        /*!< DMA channel 5 memory 0 base address register */
-#define DMA_CH5M1ADDR(dmax)                REG32((dmax) + 0x98U)        /*!< DMA channel 5 memory 1 base address register */
-#define DMA_CH5FCTL(dmax)                  REG32((dmax) + 0x9CU)        /*!< DMA channel 5 FIFO control register */
+#define DMA_CH5CTL(dmax)                   REG32((dmax) + 0x00000088U)        /*!< DMA channel 5 control register */
+#define DMA_CH5CNT(dmax)                   REG32((dmax) + 0x0000008CU)        /*!< DMA channel 5 counter register */
+#define DMA_CH5PADDR(dmax)                 REG32((dmax) + 0x00000090U)        /*!< DMA channel 5 peripheral base address register */
+#define DMA_CH5M0ADDR(dmax)                REG32((dmax) + 0x00000094U)        /*!< DMA channel 5 memory 0 base address register */
+#define DMA_CH5M1ADDR(dmax)                REG32((dmax) + 0x00000098U)        /*!< DMA channel 5 memory 1 base address register */
+#define DMA_CH5FCTL(dmax)                  REG32((dmax) + 0x0000009CU)        /*!< DMA channel 5 FIFO control register */
 
-#define DMA_CH6CTL(dmax)                   REG32((dmax) + 0xA0U)        /*!< DMA channel 6 control register */
-#define DMA_CH6CNT(dmax)                   REG32((dmax) + 0xA4U)        /*!< DMA channel 6 counter register */
-#define DMA_CH6PADDR(dmax)                 REG32((dmax) + 0xA8U)        /*!< DMA channel 6 peripheral base address register */
-#define DMA_CH6M0ADDR(dmax)                REG32((dmax) + 0xACU)        /*!< DMA channel 6 memory 0 base address register */
-#define DMA_CH6M1ADDR(dmax)                REG32((dmax) + 0xB0U)        /*!< DMA channel 6 memory 1 base address register */
-#define DMA_CH6FCTL(dmax)                  REG32((dmax) + 0xB4U)        /*!< DMA channel 6 FIFO control register */
+#define DMA_CH6CTL(dmax)                   REG32((dmax) + 0x000000A0U)        /*!< DMA channel 6 control register */
+#define DMA_CH6CNT(dmax)                   REG32((dmax) + 0x000000A4U)        /*!< DMA channel 6 counter register */
+#define DMA_CH6PADDR(dmax)                 REG32((dmax) + 0x000000A8U)        /*!< DMA channel 6 peripheral base address register */
+#define DMA_CH6M0ADDR(dmax)                REG32((dmax) + 0x000000ACU)        /*!< DMA channel 6 memory 0 base address register */
+#define DMA_CH6M1ADDR(dmax)                REG32((dmax) + 0x000000B0U)        /*!< DMA channel 6 memory 1 base address register */
+#define DMA_CH6FCTL(dmax)                  REG32((dmax) + 0x000000B4U)        /*!< DMA channel 6 FIFO control register */
 
-#define DMA_CH7CTL(dmax)                   REG32((dmax) + 0xB8U)        /*!< DMA channel 7 control register */
-#define DMA_CH7CNT(dmax)                   REG32((dmax) + 0xBCU)        /*!< DMA channel 7 counter register */
-#define DMA_CH7PADDR(dmax)                 REG32((dmax) + 0xC0U)        /*!< DMA channel 7 peripheral base address register */
-#define DMA_CH7M0ADDR(dmax)                REG32((dmax) + 0xC4U)        /*!< DMA channel 7 memory 0 base address register */
-#define DMA_CH7M1ADDR(dmax)                REG32((dmax) + 0xC8U)        /*!< DMA channel 7 memory 1 base address register */
-#define DMA_CH7FCTL(dmax)                  REG32((dmax) + 0xCCU)        /*!< DMA channel 7 FIFO control register */
+#define DMA_CH7CTL(dmax)                   REG32((dmax) + 0x000000B8U)        /*!< DMA channel 7 control register */
+#define DMA_CH7CNT(dmax)                   REG32((dmax) + 0x000000BCU)        /*!< DMA channel 7 counter register */
+#define DMA_CH7PADDR(dmax)                 REG32((dmax) + 0x000000C0U)        /*!< DMA channel 7 peripheral base address register */
+#define DMA_CH7M0ADDR(dmax)                REG32((dmax) + 0x000000C4U)        /*!< DMA channel 7 memory 0 base address register */
+#define DMA_CH7M1ADDR(dmax)                REG32((dmax) + 0x000000C8U)        /*!< DMA channel 7 memory 1 base address register */
+#define DMA_CH7FCTL(dmax)                  REG32((dmax) + 0x000000CCU)        /*!< DMA channel 7 FIFO control register */
 
 /* bits definitions */
 /* DMA_INTF */
@@ -416,13 +416,13 @@ uint32_t dma_fifo_status_get(uint32_t dma_periph, dma_channel_enum channelx);
 FlagStatus dma_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag);
 /* clear DMA a channel flag */
 void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag);
-/* check DMA flag is set or not */
-FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
-/* clear DMA a channel flag */
-void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
 /* enable DMA interrupt */
 void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
 /* disable DMA interrupt */
 void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
+/* check DMA flag is set or not */
+FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
+/* clear DMA a channel flag */
+void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
 
 #endif /* GD32F4XX_DMA_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_enet.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_enet.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_exmc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_exmc.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -113,13 +114,13 @@ OF SUCH DAMAGE.
 #define EXMC_SNCTL_NRWTPOL                  BIT(9)                        /*!< NWAIT signal polarity */
 #define EXMC_SNCTL_WRAPEN                   BIT(10)                       /*!< wrapped burst mode enable */
 #define EXMC_SNCTL_NRWTCFG                  BIT(11)                       /*!< NWAIT signal configuration, only work in synchronous mode */
-#define EXMC_SNCTL_WREN                     BIT(12)                       /*!< write enable */
+#define EXMC_SNCTL_WEN                      BIT(12)                       /*!< write enable */
 #define EXMC_SNCTL_NRWTEN                   BIT(13)                       /*!< NWAIT signal enable */
 #define EXMC_SNCTL_EXMODEN                  BIT(14)                       /*!< extended mode enable */
-#define EXMC_SNCTL_ASYNCWAIT                BIT(15)                       /*!< asynchronous wait enable */
+#define EXMC_SNCTL_ASYNCWTEN                BIT(15)                       /*!< asynchronous wait enable */
 #define EXMC_SNCTL_CPS                      BITS(16,18)                   /*!< CRAM page size */
-#define EXMC_SNCTL_SYNCWR                   BIT(19)                       /*!< synchronous write config */
-#define EXMC_SNCTL_CCK                      BIT(20)                       /*!< consecutive clock config */
+#define EXMC_SNCTL_SYNCWR                   BIT(19)                       /*!< synchronous write configuration */
+#define EXMC_SNCTL_CCK                      BIT(20)                       /*!< consecutive clock configuration */
 
 /* EXMC_SNTCFGx,x=0..3 */
 #define EXMC_SNTCFG_ASET                    BITS(0,3)                     /*!< asynchronous address setup time */
@@ -278,7 +279,7 @@ typedef struct
     exmc_norsram_timing_parameter_struct* write_timing;                 /*!< timing parameters for write when the extendedmode is used. */
 }exmc_norsram_parameter_struct;
 
-/* EXMC NAND/PC card timing initialize struct */
+/* EXMC NAND/PC card timing initialize structure */
 typedef struct
 {
     uint32_t databus_hiztime;                                           /*!< configure the dadtabus HiZ time for write operation */
@@ -287,7 +288,7 @@ typedef struct
     uint32_t setuptime;                                                 /*!< configure the address setup time */
 }exmc_nand_pccard_timing_parameter_struct;
 
-/* EXMC NAND initialize struct */
+/* EXMC NAND initialize structure */
 typedef struct
 {
     uint32_t nand_bank;                                                 /*!< select the bank of NAND */ 
@@ -301,7 +302,7 @@ typedef struct
     exmc_nand_pccard_timing_parameter_struct* attribute_space_timing;   /*!< the timing parameters for NAND flash attribute space */
 }exmc_nand_parameter_struct;
 
-/* EXMC PC card initialize struct */
+/* EXMC PC card initialize structure */
 typedef struct
 {
     uint32_t atr_latency;                                               /*!< configure the latency of ALE low to RB low */
@@ -312,7 +313,7 @@ typedef struct
     exmc_nand_pccard_timing_parameter_struct*  io_space_timing;         /*!< the timing parameters for PC card IO space */
 }exmc_pccard_parameter_struct;
 
-/* EXMC SDRAM timing initialize struct */
+/* EXMC SDRAM timing initialize structure */
 typedef struct
 {
     uint32_t row_to_column_delay;                                       /*!< configure the row to column delay */
@@ -324,7 +325,7 @@ typedef struct
     uint32_t load_mode_register_delay;                                  /*!< configure the load mode register delay */
 }exmc_sdram_timing_parameter_struct;
 
-/* EXMC SDRAM initialize struct */
+/* EXMC SDRAM initialize structure */
 typedef struct
 {
     uint32_t sdram_device;                                              /*!< device of SDRAM */
@@ -340,7 +341,7 @@ typedef struct
     exmc_sdram_timing_parameter_struct* timing;                         /*!< the timing parameters for write and read SDRAM */
 }exmc_sdram_parameter_struct;
 
-/* EXMC SDRAM command initialize struct */
+/* EXMC SDRAM command initialize structure */
 typedef struct
 {
     uint32_t mode_register_content;                                     /*!< the SDRAM mode register content */
@@ -349,7 +350,7 @@ typedef struct
     uint32_t command;                                                   /*!< the commands that will be sent to SDRAM */
 }exmc_sdram_command_parameter_struct;
 
-/* EXMC SQPISRAM initialize struct */
+/* EXMC SQPISRAM initialize structure */
 typedef struct{
     uint32_t sample_polarity;                                           /*!< read data sample polarity */
     uint32_t id_length;                                                 /*!< SPI PSRAM ID length */
@@ -357,7 +358,7 @@ typedef struct{
     uint32_t command_bits;                                              /*!< bit number of SPI PSRAM command phase */
 }exmc_sqpipsram_parameter_struct;
 
-/* EXMC_register address */
+/* EXMC register address */
 #define EXMC_SNCTL(region)                    REG32(EXMC + 0x08U*((uint32_t)(region)))                      /*!< EXMC SRAM/NOR flash control registers, region = 0,1,2,3 */
 #define EXMC_SNTCFG(region)                   REG32(EXMC + 0x04U + 0x08U*((uint32_t)(region)))              /*!< EXMC SRAM/NOR flash timing configuration registers, region = 0,1,2,3 */
 #define EXMC_SNWTCFG(region)                  REG32(EXMC + 0x104U + 0x08U*((uint32_t)(region)))             /*!< EXMC SRAM/NOR flash write timing configuration registers, region = 0,1,2,3 */
@@ -418,6 +419,7 @@ typedef struct{
 
 /* synchronous clock divide ratio */
 #define SNTCFG_CKDIV(regval)                (BITS(20,23) & ((uint32_t)(regval) << 20))
+#define EXMC_SYN_CLOCK_RATIO_DISABLE        SNTCFG_CKDIV(0)               /*!< EXMC_CLK disable */
 #define EXMC_SYN_CLOCK_RATIO_2_CLK          SNTCFG_CKDIV(1)               /*!< EXMC_CLK = 2*HCLK */
 #define EXMC_SYN_CLOCK_RATIO_3_CLK          SNTCFG_CKDIV(2)               /*!< EXMC_CLK = 3*HCLK */
 #define EXMC_SYN_CLOCK_RATIO_4_CLK          SNTCFG_CKDIV(3)               /*!< EXMC_CLK = 4*HCLK */
@@ -430,7 +432,7 @@ typedef struct{
 #define EXMC_SYN_CLOCK_RATIO_11_CLK         SNTCFG_CKDIV(10)              /*!< EXMC_CLK = 11*HCLK */
 #define EXMC_SYN_CLOCK_RATIO_12_CLK         SNTCFG_CKDIV(11)              /*!< EXMC_CLK = 12*HCLK */
 #define EXMC_SYN_CLOCK_RATIO_13_CLK         SNTCFG_CKDIV(12)              /*!< EXMC_CLK = 13*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_14_CLK         SNTCFG_CKDIV(13)              /*!< EXMC_CLK = 14*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_14_CLK         SNTCFG_CKDIV(13)              /*!< EXMC_CLK = 14*HCLK*/
 #define EXMC_SYN_CLOCK_RATIO_15_CLK         SNTCFG_CKDIV(14)              /*!< EXMC_CLK = 15*HCLK */
 #define EXMC_SYN_CLOCK_RATIO_16_CLK         SNTCFG_CKDIV(15)              /*!< EXMC_CLK = 16*HCLK */
 
@@ -541,7 +543,7 @@ typedef struct{
 #define EXMC_SDRAM_AUTO_REFLESH_14_SDCLK    SDCMD_NARF(13)                /*!< 14 auto-refresh cycles */
 #define EXMC_SDRAM_AUTO_REFLESH_15_SDCLK    SDCMD_NARF(14)                /*!< 15 auto-refresh cycles */
 
-/* SDRAM command select */
+/* SDRAM command selection */
 #define SDCMD_CMD(regval)                   (BITS(0,2) & ((uint32_t)(regval) << 0))
 #define EXMC_SDRAM_NORMAL_OPERATION         SDCMD_CMD(0)                  /*!< normal operation command */
 #define EXMC_SDRAM_CLOCK_ENABLE             SDCMD_CMD(1)                  /*!< clock enable command */
@@ -661,13 +663,13 @@ typedef struct{
 #define EXMC_SDRAM_2_INTER_BANK             ((uint32_t)0x00000000U)       /*!< 2 internal banks */
 #define EXMC_SDRAM_4_INTER_BANK             EXMC_SDCTL_NBK                /*!< 4 internal banks */
 
-/* SDRAM device0 select */
-#define EXMC_SDRAM_DEVICE0_UNSELECT         ((uint32_t)0x00000000U)       /*!< SDRAM device0 unselect */
-#define EXMC_SDRAM_DEVICE0_SELECT           EXMC_SDCMD_DS0                /*!< SDRAM device0 select */
+/* SDRAM device0 selection */
+#define EXMC_SDRAM_DEVICE0_UNSELECT         ((uint32_t)0x00000000U)       /*!< unselect SDRAM device0 */
+#define EXMC_SDRAM_DEVICE0_SELECT           EXMC_SDCMD_DS0                /*!< select SDRAM device0 */
 
-/* SDRAM device1 select */
-#define EXMC_SDRAM_DEVICE1_UNSELECT         ((uint32_t)0x00000000U)       /*!< SDRAM device1 unselect */
-#define EXMC_SDRAM_DEVICE1_SELECT           EXMC_SDCMD_DS1                /*!< SDRAM device1 select */
+/* SDRAM device1 selection */
+#define EXMC_SDRAM_DEVICE1_UNSELECT         ((uint32_t)0x00000000U)       /*!< unselect SDRAM device1 */
+#define EXMC_SDRAM_DEVICE1_SELECT           EXMC_SDCMD_DS1                /*!< select SDRAM device1 */
 
 /* SDRAM device status */
 #define EXMC_SDRAM_DEVICE_NORMAL            ((uint32_t)0x00000000U)       /*!< normal status */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_exti.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_exti.h
@@ -1,14 +1,14 @@
 /*!
     \file    gd32f4xx_exti.h
     \brief   definitions for the EXTI
-
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
-    \version 2018-12-12, V2.0.1, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_fmc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_fmc.h
@@ -6,10 +6,11 @@
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
     \version 2020-12-20, V2.1.1, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -46,15 +47,17 @@ OF SUCH DAMAGE.
 #define OB                         OB_BASE                        /*!< option byte base address */
 
 /* registers definitions */
-#define FMC_WS                     REG32((FMC) + 0x0000U)           /*!< FMC wait state register */
-#define FMC_KEY                    REG32((FMC) + 0x0004U)           /*!< FMC unlock key register */
-#define FMC_OBKEY                  REG32((FMC) + 0x0008U)           /*!< FMC option byte unlock key register */
-#define FMC_STAT                   REG32((FMC) + 0x000CU)           /*!< FMC status register */
-#define FMC_CTL                    REG32((FMC) + 0x0010U)           /*!< FMC control register */
-#define FMC_OBCTL0                 REG32((FMC) + 0x0014U)           /*!< FMC option byte control register 0 */
-#define FMC_OBCTL1                 REG32((FMC) + 0x0018U)           /*!< FMC option byte control register 1 */
-#define FMC_WSEN                   REG32((FMC) + 0x00FCU)           /*!< FMC wait state enable register */
-#define FMC_PID                    REG32((FMC) + 0x0100U)           /*!< FMC product ID register */
+#define FMC_WS                     REG32((FMC) + 0x00000000U)     /*!< FMC wait state register */
+#define FMC_KEY                    REG32((FMC) + 0x00000004U)     /*!< FMC unlock key register */
+#define FMC_OBKEY                  REG32((FMC) + 0x00000008U)     /*!< FMC option byte unlock key register */
+#define FMC_STAT                   REG32((FMC) + 0x0000000CU)     /*!< FMC status register */
+#define FMC_CTL                    REG32((FMC) + 0x00000010U)     /*!< FMC control register */
+#define FMC_OBCTL0                 REG32((FMC) + 0x00000014U)     /*!< FMC option byte control register 0 */
+#define FMC_OBCTL1                 REG32((FMC) + 0x00000018U)     /*!< FMC option byte control register 1 */
+#define FMC_PECFG                  REG32((FMC) + 0x00000020U)     /*!< FMC page erase configuration register */
+#define FMC_PEKEY                  REG32((FMC) + 0x00000024U)     /*!< FMC unlock page erase key register */
+#define FMC_WSEN                   REG32((FMC) + 0x000000FCU)     /*!< FMC wait state enable register */
+#define FMC_PID                    REG32((FMC) + 0x00000100U)     /*!< FMC product ID register */
 
 #define OB_WP1                     REG32((OB) + 0x00000008U)      /*!< option byte write protection 1 */
 #define OB_USER                    REG32((OB) + 0x00010000U)      /*!< option byte user value*/
@@ -108,6 +111,13 @@ OF SUCH DAMAGE.
 /* FMC_OBCTL1 */
 #define FMC_OBCTL1_WP1             BITS(16,27)                    /*!< erase/program protection of each sector when DRP is 0 */
 
+/* FMC_PECFG */
+#define FMC_PE_EN                  BIT(31)                        /*!< the enable bit of page erase function */
+#define FMC_PE_ADDR                BITS(0,28)                     /*!< page erase address */
+
+/* FMC_PEKEY */
+#define FMC_PE_KEY                 BITS(0,31)                     /*!< FMC_PECFG unlock key value */
+
 /* FMC_WSEN */
 #define FMC_WSEN_WSEN              BIT(0)                         /*!< FMC wait state enable bit */
 
@@ -125,13 +135,13 @@ typedef enum
     FMC_PGMERR,                                                   /*!< program size not match error */
     FMC_WPERR,                                                    /*!< erase/program protection error */
     FMC_OPERR,                                                    /*!< operation error */
-    FMC_PGERR,                                                    /*!< program error */
     FMC_TOERR,                                                    /*!< timeout error */
 }fmc_state_enum;
 
 /* unlock key */
 #define UNLOCK_KEY0                ((uint32_t)0x45670123U)        /*!< unlock key 0 */
 #define UNLOCK_KEY1                ((uint32_t)0xCDEF89ABU)        /*!< unlock key 1 */
+#define UNLOCK_PE_KEY              ((uint32_t)0xA9B8C7D6U)        /*!< unlock page erase function key */
 
 #define OB_UNLOCK_KEY0             ((uint32_t)0x08192A3BU)        /*!< ob unlock key 0 */
 #define OB_UNLOCK_KEY1             ((uint32_t)0x4C5D6E7FU)        /*!< ob unlock key 1 */
@@ -243,14 +253,15 @@ typedef enum
 #define OB_DRP_21                  ((uint32_t)0x02000000U)        /*!< D-bus read protection protection of sector 21 */
 #define OB_DRP_22                  ((uint32_t)0x04000000U)        /*!< D-bus read protection protection of sector 22 */
 #define OB_DRP_23_27               ((uint32_t)0x08000000U)        /*!< D-bus read protection protection of sector 23~27 */
+#define OB_DRP_ALL                 ((uint32_t)0x0FFF0FFFU)        /*!< D-bus read protection protection of all sectors */
 
 /* double banks or single bank selection when flash size is 1M bytes */  
-#define OBCTL0_DBS(regval)         (BIT(30) & ((uint32_t)(regval)<<30))
+#define OBCTL0_DBS(regval)         (BIT(30) & ((uint32_t)(regval) << 30U))
 #define OB_DBS_DISABLE             OBCTL0_DBS(0)                  /*!< single bank when flash size is 1M bytes */
 #define OB_DBS_ENABLE              OBCTL0_DBS(1)                  /*!< double bank when flash size is 1M bytes */
 
 /* option bytes D-bus read protection mode */  
-#define OBCTL0_DRP(regval)         (BIT(31) & ((uint32_t)(regval)<<31))
+#define OBCTL0_DRP(regval)         (BIT(31) & ((uint32_t)(regval) << 31U))
 #define OB_DRP_DISABLE             OBCTL0_DRP(0)                  /*!< the WPx bits used as erase/program protection of each sector */
 #define OB_DRP_ENABLE              OBCTL0_DRP(1)                  /*!< the WPx bits used as erase/program protection and D-bus read protection of each sector */
 
@@ -287,7 +298,7 @@ typedef enum
 
 
 /* FMC program size */ 
-#define CTL_PSZ(regval)            (BITS(8,9) & ((uint32_t)(regval))<< 8)
+#define CTL_PSZ(regval)            (BITS(8,9) & ((uint32_t)(regval))<< 8U)
 #define CTL_PSZ_BYTE               CTL_PSZ(0)                     /*!< FMC program by byte access */
 #define CTL_PSZ_HALF_WORD          CTL_PSZ(1)                     /*!< FMC program by half-word access */
 #define CTL_PSZ_WORD               CTL_PSZ(2)                     /*!< FMC program by word access */
@@ -297,16 +308,25 @@ typedef enum
 #define FMC_INT_ERR                ((uint32_t)0x02000000U)        /*!< enable FMC error interrupt */
 
 /* FMC flags */
-#define FMC_FLAG_END               ((uint32_t)0x00000001U)        /*!< FMC end of operation flag bit */
-#define FMC_FLAG_OPERR             ((uint32_t)0x00000002U)        /*!< FMC operation error flag bit */
-#define FMC_FLAG_WPERR             ((uint32_t)0x00000010U)        /*!< FMC erase/program protection error flag bit */
-#define FMC_FLAG_PGMERR            ((uint32_t)0x00000040U)        /*!< FMC program size not match error flag bit */
-#define FMC_FLAG_PGSERR            ((uint32_t)0x00000080U)        /*!< FMC program sequence error flag bit */
-#define FMC_FLAG_RDDERR            ((uint32_t)0x00000100U)        /*!< FMC read D-bus protection error flag bit */
-#define FMC_FLAG_BUSY              ((uint32_t)0x00010000U)        /*!< FMC busy flag */
+#define FMC_FLAG_END               FMC_STAT_END                   /*!< FMC end of operation flag bit */
+#define FMC_FLAG_OPERR             FMC_STAT_OPERR                 /*!< FMC operation error flag bit */
+#define FMC_FLAG_WPERR             FMC_STAT_WPERR                 /*!< FMC erase/program protection error flag bit */
+#define FMC_FLAG_PGMERR            FMC_STAT_PGMERR                /*!< FMC program size not match error flag bit */
+#define FMC_FLAG_PGSERR            FMC_STAT_PGSERR                /*!< FMC program sequence error flag bit */
+#define FMC_FLAG_RDDERR            FMC_STAT_RDDERR                /*!< FMC read D-bus protection error flag bit */
+#define FMC_FLAG_BUSY              FMC_STAT_BUSY                  /*!< FMC busy flag */
+
+/* FMC interrupt flags */
+#define FMC_INT_FLAG_END           FMC_STAT_END                   /*!< FMC end of operation interrupt flag */
+#define FMC_INT_FLAG_OPERR         FMC_STAT_OPERR                 /*!< FMC operation error interrupt flag */
+#define FMC_INT_FLAG_WPERR         FMC_STAT_WPERR                 /*!< FMC erase/program protection error interrupt flag */
+#define FMC_INT_FLAG_PGMERR        FMC_STAT_PGMERR                /*!< FMC program size not match error interrupt flag */
+#define FMC_INT_FLAG_PGSERR        FMC_STAT_PGSERR                /*!< FMC program sequence error interrupt flag */
+#define FMC_INT_FLAG_RDDERR        FMC_STAT_RDDERR                /*!< FMC read D-bus protection error interrupt flag */
+
 
 /* FMC time out */
-#define FMC_TIMEOUT_COUNT          ((uint32_t)0xFFFFFFFFU)        /*!< count to judge of FMC timeout */
+#define FMC_TIMEOUT_COUNT          ((uint32_t)0x4FFFFFFFU)        /*!< count to judge of FMC timeout */
 
 /* function declarations */
 /* FMC main memory programming functions */
@@ -316,6 +336,10 @@ void fmc_wscnt_set(uint32_t wscnt);
 void fmc_unlock(void);
 /* lock the main FMC operation */
 void fmc_lock(void);
+#if defined (GD32F425) || defined (GD32F427) || defined (GD32F470)
+/* FMC erase page */
+fmc_state_enum fmc_page_erase(uint32_t page_addr);
+#endif
 /* FMC erase sector */
 fmc_state_enum fmc_sector_erase(uint32_t fmc_sector);
 /* FMC erase whole chip */
@@ -341,13 +365,13 @@ void ob_start(void);
 /* erase option byte */
 void ob_erase(void);
 /* enable write protect */
-void ob_write_protection_enable(uint32_t ob_wp);
+ErrStatus ob_write_protection_enable(uint32_t ob_wp);
 /* disable write protect */
-void ob_write_protection_disable(uint32_t ob_wp);
+ErrStatus ob_write_protection_disable(uint32_t ob_wp);
 /* enable erase/program protection and D-bus read protection */
 void ob_drp_enable(uint32_t ob_drp);
 /* disable erase/program protection and D-bus read protection */
-void ob_drp_disable(uint32_t ob_drp);
+void ob_drp_disable(void);
 /* set the option byte security protection level */
 void ob_security_protection_config(uint8_t ob_spc);
 /* write the FMC option byte user */
@@ -372,14 +396,18 @@ FlagStatus ob_spc_get(void);
 uint8_t ob_user_bor_threshold_get(void);
 
 /* FMC interrupts and flags management functions */
-/* enable FMC interrupt */
-void fmc_interrupt_enable(uint32_t fmc_int);
-/* disable FMC interrupt */
-void fmc_interrupt_disable(uint32_t fmc_int);
 /* get flag set or reset */
 FlagStatus fmc_flag_get(uint32_t fmc_flag);
 /* clear the FMC pending flag */
 void fmc_flag_clear(uint32_t fmc_flag);
+/* enable FMC interrupt */
+void fmc_interrupt_enable(uint32_t fmc_int);
+/* disable FMC interrupt */
+void fmc_interrupt_disable(uint32_t fmc_int);
+/* get FMC interrupt flag set or reset */
+FlagStatus fmc_interrupt_flag_get(uint32_t fmc_int_flag);
+/* clear the FMC interrupt flag */
+void fmc_interrupt_flag_clear(uint32_t fmc_int_flag);
 /* return the FMC state */
 fmc_state_enum fmc_state_get(void);
 /* check FMC ready or not */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_fwdgt.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_fwdgt.h
@@ -1,14 +1,15 @@
 /*!
     \file    gd32f4xx_fwdgt.h
     \brief   definitions for the FWDGT
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_gpio.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_gpio.h
@@ -1,14 +1,15 @@
 /*!
     \file    gd32f4xx_gpio.h
     \brief   definitions for the GPIO
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -57,7 +58,7 @@ OF SUCH DAMAGE.
 #define GPIO_PUD(gpiox)            REG32((gpiox) + 0x0CU)    /*!< GPIO port pull-up/pull-down register */
 #define GPIO_ISTAT(gpiox)          REG32((gpiox) + 0x10U)    /*!< GPIO port input status register */
 #define GPIO_OCTL(gpiox)           REG32((gpiox) + 0x14U)    /*!< GPIO port output control register */
-#define GPIO_BOP(gpiox)            REG32((gpiox) + 0x18U)    /*!< GPIO port bit operation register */
+#define GPIO_BOP(gpiox)            REG32((gpiox) + 0x18U)    /*!< GPIO port bit operate register */
 #define GPIO_LOCK(gpiox)           REG32((gpiox) + 0x1CU)    /*!< GPIO port configuration lock register */
 #define GPIO_AFSEL0(gpiox)         REG32((gpiox) + 0x20U)    /*!< GPIO alternate function selected register 0 */
 #define GPIO_AFSEL1(gpiox)         REG32((gpiox) + 0x24U)    /*!< GPIO alternate function selected register 1 */
@@ -156,22 +157,22 @@ OF SUCH DAMAGE.
 #define GPIO_ISTAT_ISTAT15         BIT(15)                   /*!< pin 15 input status */
 
 /* GPIO_OCTL */
-#define GPIO_OCTL_OCTL0            BIT(0)                    /*!< pin 0 output bit */
-#define GPIO_OCTL_OCTL1            BIT(1)                    /*!< pin 1 output bit */
-#define GPIO_OCTL_OCTL2            BIT(2)                    /*!< pin 2 output bit */
-#define GPIO_OCTL_OCTL3            BIT(3)                    /*!< pin 3 output bit */
-#define GPIO_OCTL_OCTL4            BIT(4)                    /*!< pin 4 output bit */
-#define GPIO_OCTL_OCTL5            BIT(5)                    /*!< pin 5 output bit */
-#define GPIO_OCTL_OCTL6            BIT(6)                    /*!< pin 6 output bit */
-#define GPIO_OCTL_OCTL7            BIT(7)                    /*!< pin 7 output bit */
-#define GPIO_OCTL_OCTL8            BIT(8)                    /*!< pin 8 output bit */
-#define GPIO_OCTL_OCTL9            BIT(9)                    /*!< pin 9 output bit */
-#define GPIO_OCTL_OCTL10           BIT(10)                   /*!< pin 10 output bit */
-#define GPIO_OCTL_OCTL11           BIT(11)                   /*!< pin 11 output bit */
-#define GPIO_OCTL_OCTL12           BIT(12)                   /*!< pin 12 output bit */
-#define GPIO_OCTL_OCTL13           BIT(13)                   /*!< pin 13 output bit */
-#define GPIO_OCTL_OCTL14           BIT(14)                   /*!< pin 14 output bit */
-#define GPIO_OCTL_OCTL15           BIT(15)                   /*!< pin 15 output bit */
+#define GPIO_OCTL_OCTL0            BIT(0)                    /*!< pin 0 output control bit */
+#define GPIO_OCTL_OCTL1            BIT(1)                    /*!< pin 1 output control bit */
+#define GPIO_OCTL_OCTL2            BIT(2)                    /*!< pin 2 output control bit */
+#define GPIO_OCTL_OCTL3            BIT(3)                    /*!< pin 3 output control bit */
+#define GPIO_OCTL_OCTL4            BIT(4)                    /*!< pin 4 output control bit */
+#define GPIO_OCTL_OCTL5            BIT(5)                    /*!< pin 5 output control bit */
+#define GPIO_OCTL_OCTL6            BIT(6)                    /*!< pin 6 output control bit */
+#define GPIO_OCTL_OCTL7            BIT(7)                    /*!< pin 7 output control bit */
+#define GPIO_OCTL_OCTL8            BIT(8)                    /*!< pin 8 output control bit */
+#define GPIO_OCTL_OCTL9            BIT(9)                    /*!< pin 9 output control bit */
+#define GPIO_OCTL_OCTL10           BIT(10)                   /*!< pin 10 output control bit */
+#define GPIO_OCTL_OCTL11           BIT(11)                   /*!< pin 11 output control bit */
+#define GPIO_OCTL_OCTL12           BIT(12)                   /*!< pin 12 output control bit */
+#define GPIO_OCTL_OCTL13           BIT(13)                   /*!< pin 13 output control bit */
+#define GPIO_OCTL_OCTL14           BIT(14)                   /*!< pin 14 output control bit */
+#define GPIO_OCTL_OCTL15           BIT(15)                   /*!< pin 15 output control bit */
 
 /* GPIO_BOP */
 #define GPIO_BOP_BOP0              BIT(0)                    /*!< pin 0 set bit */
@@ -224,7 +225,7 @@ OF SUCH DAMAGE.
 #define GPIO_LOCK_LK13             BIT(13)                   /*!< pin 13 lock bit */
 #define GPIO_LOCK_LK14             BIT(14)                   /*!< pin 14 lock bit */
 #define GPIO_LOCK_LK15             BIT(15)                   /*!< pin 15 lock bit */
-#define GPIO_LOCK_LKK              BIT(16)                   /*!< pin sequence lock key */
+#define GPIO_LOCK_LKK              BIT(16)                   /*!< pin lock sequence key */
 
 /* GPIO_AFSEL0 */
 #define GPIO_AFSEL0_SEL0           BITS(0,3)                 /*!< pin 0 alternate function selected */
@@ -344,7 +345,7 @@ typedef FlagStatus bit_status;
 #define GPIO_OSPEED_2MHZ           GPIO_OSPEED_LEVEL0        /*!< output max speed 2MHz */
 #define GPIO_OSPEED_25MHZ          GPIO_OSPEED_LEVEL1        /*!< output max speed 25MHz */
 #define GPIO_OSPEED_50MHZ          GPIO_OSPEED_LEVEL2        /*!< output max speed 50MHz */
-#define GPIO_OSPEED_200MHZ         GPIO_OSPEED_LEVEL3        /*!< output max speed 200MHz */
+#define GPIO_OSPEED_MAX            GPIO_OSPEED_LEVEL3        /*!< GPIO very high output speed, max speed more than 50MHz */
 
 /* GPIO alternate function values */
 #define GPIO_AFR_SET(n, af)        ((uint32_t)((uint32_t)(af) << (4U * (n))))

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
@@ -327,6 +327,12 @@ typedef enum {
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)           /*!< address format is 7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT              /*!< address format is 10 bits */
 
+/* I2C clock frequency, MHz */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003CU)           /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)           /*!< i2cclk minimum value */
+#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)           /*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)           /*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* initialization functions */
 /* reset I2C */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_i2c.h
@@ -1,40 +1,40 @@
 /*!
     \file    gd32f4xx_i2c.h
     \brief   definitions for the I2C
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2019-04-16, V2.0.1, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
-
 
 #ifndef GD32F4XX_I2C_H
 #define GD32F4XX_I2C_H
@@ -42,285 +42,276 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* I2Cx(x=0,1,2) definitions */
-#define I2C0                          I2C_BASE                   /*!< I2C0 base address */
-#define I2C1                          (I2C_BASE+0x400U)          /*!< I2C1 base address */
-#define I2C2                          (I2C_BASE+0x800U)          /*!< I2C2 base address */
+#define I2C0                          I2C_BASE                          /*!< I2C0 base address */
+#define I2C1                          (I2C_BASE + 0x00000400U)          /*!< I2C1 base address */
+#define I2C2                          (I2C_BASE + 0x00000800U)          /*!< I2C2 base address */
 
 /* registers definitions */
-#define I2C_CTL0(i2cx)                REG32((i2cx) + 0x00U)      /*!< I2C control register 0 */
-#define I2C_CTL1(i2cx)                REG32((i2cx) + 0x04U)      /*!< I2C control register 1 */
-#define I2C_SADDR0(i2cx)              REG32((i2cx) + 0x08U)      /*!< I2C slave address register 0 */
-#define I2C_SADDR1(i2cx)              REG32((i2cx) + 0x0CU)      /*!< I2C slave address register 1 */
-#define I2C_DATA(i2cx)                REG32((i2cx) + 0x10U)      /*!< I2C transfer buffer register */
-#define I2C_STAT0(i2cx)               REG32((i2cx) + 0x14U)      /*!< I2C transfer status register 0 */
-#define I2C_STAT1(i2cx)               REG32((i2cx) + 0x18U)      /*!< I2C transfer status register */
-#define I2C_CKCFG(i2cx)               REG32((i2cx) + 0x1CU)      /*!< I2C clock configure register */
-#define I2C_RT(i2cx)                  REG32((i2cx) + 0x20U)      /*!< I2C rise time register */
-#define I2C_FCTL(i2cx)                REG32((i2cx) + 0x24U)      /*!< I2C filter control register */
-#define I2C_SAMCS(i2cx)               REG32((i2cx) + 0x80U)      /*!< I2C SAM control and status register */
+#define I2C_CTL0(i2cx)                REG32((i2cx) + 0x00000000U)       /*!< I2C control register 0 */
+#define I2C_CTL1(i2cx)                REG32((i2cx) + 0x00000004U)       /*!< I2C control register 1 */
+#define I2C_SADDR0(i2cx)              REG32((i2cx) + 0x00000008U)       /*!< I2C slave address register 0 */
+#define I2C_SADDR1(i2cx)              REG32((i2cx) + 0x0000000CU)       /*!< I2C slave address register 1 */
+#define I2C_DATA(i2cx)                REG32((i2cx) + 0x00000010U)       /*!< I2C transfer buffer register */
+#define I2C_STAT0(i2cx)               REG32((i2cx) + 0x00000014U)       /*!< I2C transfer status register 0 */
+#define I2C_STAT1(i2cx)               REG32((i2cx) + 0x00000018U)       /*!< I2C transfer status register */
+#define I2C_CKCFG(i2cx)               REG32((i2cx) + 0x0000001CU)       /*!< I2C clock configure register */
+#define I2C_RT(i2cx)                  REG32((i2cx) + 0x00000020U)       /*!< I2C rise time register */
+#define I2C_FCTL(i2cx)                REG32((i2cx) + 0x00000024U)       /*!< I2C filter control register */
+#define I2C_SAMCS(i2cx)               REG32((i2cx) + 0x00000080U)       /*!< I2C SAM control and status register */
 
 /* bits definitions */
 /* I2Cx_CTL0 */
-#define I2C_CTL0_I2CEN                BIT(0)        /*!< peripheral enable */
-#define I2C_CTL0_SMBEN                BIT(1)        /*!< SMBus mode */
-#define I2C_CTL0_SMBSEL               BIT(3)        /*!< SMBus type */
-#define I2C_CTL0_ARPEN                BIT(4)        /*!< ARP enable */
-#define I2C_CTL0_PECEN                BIT(5)        /*!< PEC enable */
-#define I2C_CTL0_GCEN                 BIT(6)        /*!< general call enable */
-#define I2C_CTL0_SS                   BIT(7)        /*!< clock stretching disable (slave mode) */
-#define I2C_CTL0_START                BIT(8)        /*!< start generation */
-#define I2C_CTL0_STOP                 BIT(9)        /*!< stop generation */
-#define I2C_CTL0_ACKEN                BIT(10)       /*!< acknowledge enable */
-#define I2C_CTL0_POAP                 BIT(11)       /*!< acknowledge/PEC position (for data reception) */
-#define I2C_CTL0_PECTRANS             BIT(12)       /*!< packet error checking */
-#define I2C_CTL0_SALT                 BIT(13)       /*!< SMBus alert */
-#define I2C_CTL0_SRESET               BIT(15)       /*!< software reset */
+#define I2C_CTL0_I2CEN                BIT(0)                            /*!< peripheral enable */
+#define I2C_CTL0_SMBEN                BIT(1)                            /*!< SMBus mode */
+#define I2C_CTL0_SMBSEL               BIT(3)                            /*!< SMBus type */
+#define I2C_CTL0_ARPEN                BIT(4)                            /*!< ARP enable */
+#define I2C_CTL0_PECEN                BIT(5)                            /*!< PEC enable */
+#define I2C_CTL0_GCEN                 BIT(6)                            /*!< general call enable */
+#define I2C_CTL0_SS                   BIT(7)                            /*!< clock stretching disable (slave mode) */
+#define I2C_CTL0_START                BIT(8)                            /*!< start generation */
+#define I2C_CTL0_STOP                 BIT(9)                            /*!< stop generation */
+#define I2C_CTL0_ACKEN                BIT(10)                           /*!< acknowledge enable */
+#define I2C_CTL0_POAP                 BIT(11)                           /*!< acknowledge/PEC position (for data reception) */
+#define I2C_CTL0_PECTRANS             BIT(12)                           /*!< packet error checking */
+#define I2C_CTL0_SALT                 BIT(13)                           /*!< SMBus alert */
+#define I2C_CTL0_SRESET               BIT(15)                           /*!< software reset */
 
 /* I2Cx_CTL1 */
-#define I2C_CTL1_I2CCLK               BITS(0,5)     /*!< I2CCLK[5:0] bits (peripheral clock frequency) */
-#define I2C_CTL1_ERRIE                BIT(8)        /*!< error interrupt enable */
-#define I2C_CTL1_EVIE                 BIT(9)        /*!< event interrupt enable */
-#define I2C_CTL1_BUFIE                BIT(10)       /*!< buffer interrupt enable */
-#define I2C_CTL1_DMAON                BIT(11)       /*!< DMA requests enable */
-#define I2C_CTL1_DMALST               BIT(12)       /*!< DMA last transfer */
+#define I2C_CTL1_I2CCLK               BITS(0,5)                         /*!< I2CCLK[5:0] bits (peripheral clock frequency) */
+#define I2C_CTL1_ERRIE                BIT(8)                            /*!< error interrupt enable */
+#define I2C_CTL1_EVIE                 BIT(9)                            /*!< event interrupt enable */
+#define I2C_CTL1_BUFIE                BIT(10)                           /*!< buffer interrupt enable */
+#define I2C_CTL1_DMAON                BIT(11)                           /*!< DMA requests enable */
+#define I2C_CTL1_DMALST               BIT(12)                           /*!< DMA last transfer */
 
 /* I2Cx_SADDR0 */
-#define I2C_SADDR0_ADDRESS0           BIT(0)        /*!< bit 0 of a 10-bit address */
-#define I2C_SADDR0_ADDRESS            BITS(1,7)     /*!< 7-bit address or bits 7:1 of a 10-bit address */
-#define I2C_SADDR0_ADDRESS_H          BITS(8,9)     /*!< highest two bits of a 10-bit address */
-#define I2C_SADDR0_ADDFORMAT          BIT(15)       /*!< address mode for the I2C slave */
+#define I2C_SADDR0_ADDRESS0           BIT(0)                            /*!< bit 0 of a 10-bit address */
+#define I2C_SADDR0_ADDRESS            BITS(1,7)                         /*!< 7-bit address or bits 7:1 of a 10-bit address */
+#define I2C_SADDR0_ADDRESS_H          BITS(8,9)                         /*!< highest two bits of a 10-bit address */
+#define I2C_SADDR0_ADDFORMAT          BIT(15)                           /*!< address mode for the I2C slave */
 
 /* I2Cx_SADDR1 */
-#define I2C_SADDR1_DUADEN             BIT(0)        /*!< aual-address mode switch */
-#define I2C_SADDR1_ADDRESS2           BITS(1,7)     /*!< second I2C address for the slave in dual-address mode */
+#define I2C_SADDR1_DUADEN             BIT(0)                            /*!< aual-address mode switch */
+#define I2C_SADDR1_ADDRESS2           BITS(1,7)                         /*!< second I2C address for the slave in dual-address mode */
 
 /* I2Cx_DATA */
-#define I2C_DATA_TRB                  BITS(0,7)     /*!< 8-bit data register */
+#define I2C_DATA_TRB                  BITS(0,7)                         /*!< 8-bit data register */
 
 /* I2Cx_STAT0 */
-#define I2C_STAT0_SBSEND              BIT(0)        /*!< start bit (master mode) */
-#define I2C_STAT0_ADDSEND             BIT(1)        /*!< address sent (master mode)/matched (slave mode) */
-#define I2C_STAT0_BTC                 BIT(2)        /*!< byte transfer finished */
-#define I2C_STAT0_ADD10SEND           BIT(3)        /*!< 10-bit header sent (master mode) */
-#define I2C_STAT0_STPDET              BIT(4)        /*!< stop detection (slave mode) */
-#define I2C_STAT0_RBNE                BIT(6)        /*!< data register not empty (receivers) */
-#define I2C_STAT0_TBE                 BIT(7)        /*!< data register empty (transmitters) */
-#define I2C_STAT0_BERR                BIT(8)        /*!< bus error */
-#define I2C_STAT0_LOSTARB             BIT(9)        /*!< arbitration lost (master mode) */
-#define I2C_STAT0_AERR                BIT(10)       /*!< acknowledge failure */
-#define I2C_STAT0_OUERR               BIT(11)       /*!< overrun/underrun */
-#define I2C_STAT0_PECERR              BIT(12)       /*!< PEC error in reception */
-#define I2C_STAT0_SMBTO               BIT(14)       /*!< timeout signal in SMBus mode */
-#define I2C_STAT0_SMBALT              BIT(15)       /*!< SMBus alert status */
+#define I2C_STAT0_SBSEND              BIT(0)                            /*!< start bit (master mode) */
+#define I2C_STAT0_ADDSEND             BIT(1)                            /*!< address sent (master mode)/matched (slave mode) */
+#define I2C_STAT0_BTC                 BIT(2)                            /*!< byte transfer finished */
+#define I2C_STAT0_ADD10SEND           BIT(3)                            /*!< 10-bit header sent (master mode) */
+#define I2C_STAT0_STPDET              BIT(4)                            /*!< stop detection (slave mode) */
+#define I2C_STAT0_RBNE                BIT(6)                            /*!< data register not empty (receivers) */
+#define I2C_STAT0_TBE                 BIT(7)                            /*!< data register empty (transmitters) */
+#define I2C_STAT0_BERR                BIT(8)                            /*!< bus error */
+#define I2C_STAT0_LOSTARB             BIT(9)                            /*!< arbitration lost (master mode) */
+#define I2C_STAT0_AERR                BIT(10)                           /*!< acknowledge failure */
+#define I2C_STAT0_OUERR               BIT(11)                           /*!< overrun/underrun */
+#define I2C_STAT0_PECERR              BIT(12)                           /*!< PEC error in reception */
+#define I2C_STAT0_SMBTO               BIT(14)                           /*!< timeout signal in SMBus mode */
+#define I2C_STAT0_SMBALT              BIT(15)                           /*!< SMBus alert status */
 
 /* I2Cx_STAT1 */
-#define I2C_STAT1_MASTER              BIT(0)        /*!< master/slave */
-#define I2C_STAT1_I2CBSY              BIT(1)        /*!< bus busy */
-#define I2C_STAT1_TR                  BIT(2)        /*!< transmitter/receiver */
-#define I2C_STAT1_RXGC                BIT(4)        /*!< general call address (slave mode) */
-#define I2C_STAT1_DEFSMB              BIT(5)        /*!< SMBus device default address (slave mode) */
-#define I2C_STAT1_HSTSMB              BIT(6)        /*!< SMBus host header (slave mode) */
-#define I2C_STAT1_DUMODF              BIT(7)        /*!< dual flag (slave mode) */
-#define I2C_STAT1_PECV                BITS(8,15)    /*!< packet error checking value */
+#define I2C_STAT1_MASTER              BIT(0)                            /*!< master/slave */
+#define I2C_STAT1_I2CBSY              BIT(1)                            /*!< bus busy */
+#define I2C_STAT1_TR                  BIT(2)                            /*!< transmitter/receiver */
+#define I2C_STAT1_RXGC                BIT(4)                            /*!< general call address (slave mode) */
+#define I2C_STAT1_DEFSMB              BIT(5)                            /*!< SMBus device default address (slave mode) */
+#define I2C_STAT1_HSTSMB              BIT(6)                            /*!< SMBus host header (slave mode) */
+#define I2C_STAT1_DUMODF              BIT(7)                            /*!< dual flag (slave mode) */
+#define I2C_STAT1_PECV                BITS(8,15)                        /*!< packet error checking value */
 
 /* I2Cx_CKCFG */
-#define I2C_CKCFG_CLKC                BITS(0,11)    /*!< clock control register in fast/standard mode (master mode) */
-#define I2C_CKCFG_DTCY                BIT(14)       /*!< fast mode duty cycle */
-#define I2C_CKCFG_FAST                BIT(15)       /*!< I2C speed selection in master mode */
+#define I2C_CKCFG_CLKC                BITS(0,11)                        /*!< clock control register in fast/standard mode (master mode) */
+#define I2C_CKCFG_DTCY                BIT(14)                           /*!< fast mode duty cycle */
+#define I2C_CKCFG_FAST                BIT(15)                           /*!< I2C speed selection in master mode */
 
 /* I2Cx_RT */
-#define I2C_RT_RISETIME               BITS(0,5)     /*!< maximum rise time in fast/standard mode (Master mode) */
+#define I2C_RT_RISETIME               BITS(0,5)                         /*!< maximum rise time in fast/standard mode (Master mode) */
 
 /* I2Cx_FCTL */
-#define I2C_FCTL_DF                   BITS(0,3)     /*!< digital noise filter */
-#define I2C_FCTL_AFD                  BIT(4)        /*!< analog noise filter disable */
+#define I2C_FCTL_DF                   BITS(0,3)                         /*!< digital noise filter */
+#define I2C_FCTL_AFD                  BIT(4)                            /*!< analog noise filter disable */
 
 /* I2Cx_SAMCS */
-#define I2C_SAMCS_SAMEN               BIT(0)        /*!< SAM_V interface enable */
-#define I2C_SAMCS_STOEN               BIT(1)        /*!< SAM_V interface timeout detect enable */
-#define I2C_SAMCS_TFFIE               BIT(4)        /*!< txframe fall interrupt enable */
-#define I2C_SAMCS_TFRIE               BIT(5)        /*!< txframe rise interrupt enable */
-#define I2C_SAMCS_RFFIE               BIT(6)        /*!< rxframe fall interrupt enable */
-#define I2C_SAMCS_RFRIE               BIT(7)        /*!< rxframe rise interrupt enable */
-#define I2C_SAMCS_TXF                 BIT(8)        /*!< level of txframe signal */
-#define I2C_SAMCS_RXF                 BIT(9)        /*!< level of rxframe signal */
-#define I2C_SAMCS_TFF                 BIT(12)       /*!< txframe fall flag, cleared by software write 0 */
-#define I2C_SAMCS_TFR                 BIT(13)       /*!< txframe rise flag, cleared by software write 0 */
-#define I2C_SAMCS_RFF                 BIT(14)       /*!< rxframe fall flag, cleared by software write 0 */
-#define I2C_SAMCS_RFR                 BIT(15)       /*!< rxframe rise flag, cleared by software write 0 */
-
-/* constants definitions */
-
-/* the digital noise filter can filter spikes's length */
-typedef enum {
-    I2C_DF_DISABLE,                                     /*!< disable digital noise filter */
-    I2C_DF_1PCLK,                                       /*!< enable digital noise filter and the maximum filtered spiker's length 1 PCLK1 */
-    I2C_DF_2PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 2 PCLK1 */
-    I2C_DF_3PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 3 PCLK1 */
-    I2C_DF_4PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 4 PCLK1 */
-    I2C_DF_5PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 5 PCLK1 */
-    I2C_DF_6PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 6 PCLK1 */
-    I2C_DF_7PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 7 PCLK1 */
-    I2C_DF_8PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 8 PCLK1 */
-    I2C_DF_9PCLKS,                                      /*!< enable digital noise filter and the maximum filtered spiker's length 9 PCLK1 */
-    I2C_DF_10PCLKS,                                     /*!< enable digital noise filter and the maximum filtered spiker's length 10 PCLK1 */
-    I2C_DF_11PCLKS,                                     /*!< enable digital noise filter and the maximum filtered spiker's length 11 PCLK1 */
-    I2C_DF_12PCLKS,                                     /*!< enable digital noise filter and the maximum filtered spiker's length 12 PCLK1 */
-    I2C_DF_13PCLKS,                                     /*!< enable digital noise filter and the maximum filtered spiker's length 13 PCLK1 */
-    I2C_DF_14PCLKS,                                     /*!< enable digital noise filter and the maximum filtered spiker's length 14 PCLK1 */
-    I2C_DF_15PCLKS                                      /*!< enable digital noise filter and the maximum filtered spiker's length 15 PCLK1 */
-}i2c_digital_filter_enum;
+#define I2C_SAMCS_SAMEN               BIT(0)                            /*!< SAM_V interface enable */
+#define I2C_SAMCS_STOEN               BIT(1)                            /*!< SAM_V interface timeout detect enable */
+#define I2C_SAMCS_TFFIE               BIT(4)                            /*!< txframe fall interrupt enable */
+#define I2C_SAMCS_TFRIE               BIT(5)                            /*!< txframe rise interrupt enable */
+#define I2C_SAMCS_RFFIE               BIT(6)                            /*!< rxframe fall interrupt enable */
+#define I2C_SAMCS_RFRIE               BIT(7)                            /*!< rxframe rise interrupt enable */
+#define I2C_SAMCS_TXF                 BIT(8)                            /*!< level of txframe signal */
+#define I2C_SAMCS_RXF                 BIT(9)                            /*!< level of rxframe signal */
+#define I2C_SAMCS_TFF                 BIT(12)                           /*!< txframe fall flag, cleared by software write 0 */
+#define I2C_SAMCS_TFR                 BIT(13)                           /*!< txframe rise flag, cleared by software write 0 */
+#define I2C_SAMCS_RFF                 BIT(14)                           /*!< rxframe fall flag, cleared by software write 0 */
+#define I2C_SAMCS_RFR                 BIT(15)                           /*!< rxframe rise flag, cleared by software write 0 */
 
 /* constants definitions */
 /* define the I2C bit position and its register index offset */
 #define I2C_REGIDX_BIT(regidx, bitpos)  (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
-#define I2C_REG_VAL(i2cx, offset)       (REG32((i2cx) + (((uint32_t)(offset) & 0xFFFFU) >> 6)))
-#define I2C_BIT_POS(val)                ((uint32_t)(val) & 0x1FU)
+#define I2C_REG_VAL(i2cx, offset)       (REG32((i2cx) + (((uint32_t)(offset) & 0x0000FFFFU) >> 6)))
+#define I2C_BIT_POS(val)                ((uint32_t)(val) & 0x0000001FU)
 #define I2C_REGIDX_BIT2(regidx, bitpos, regidx2, bitpos2)   (((uint32_t)(regidx2) << 22) | (uint32_t)((bitpos2) << 16)\
-                                                              | (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos)))
+                                                            | (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos)))
 #define I2C_REG_VAL2(i2cx, offset)      (REG32((i2cx) + ((uint32_t)(offset) >> 22)))
-#define I2C_BIT_POS2(val)               (((uint32_t)(val) & 0x1F0000U) >> 16)
+#define I2C_BIT_POS2(val)               (((uint32_t)(val) & 0x001F0000U) >> 16)
 
 /* register offset */
-#define I2C_CTL1_REG_OFFSET           0x04U         /*!< CTL1 register offset */
-#define I2C_STAT0_REG_OFFSET          0x14U         /*!< STAT0 register offset */
-#define I2C_STAT1_REG_OFFSET          0x18U         /*!< STAT1 register offset */
-#define I2C_SAMCS_REG_OFFSET          0x80U         /*!< SAMCS register offset */
+#define I2C_CTL1_REG_OFFSET           ((uint32_t)0x00000004U)           /*!< CTL1 register offset */
+#define I2C_STAT0_REG_OFFSET          ((uint32_t)0x00000014U)           /*!< STAT0 register offset */
+#define I2C_STAT1_REG_OFFSET          ((uint32_t)0x00000018U)           /*!< STAT1 register offset */
+#define I2C_SAMCS_REG_OFFSET          ((uint32_t)0x00000080U)           /*!< SAMCS register offset */
 
 /* I2C flags */
-typedef enum
-{
+typedef enum {
     /* flags in STAT0 register */
-    I2C_FLAG_SBSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 0U),                /*!< start condition sent out in master mode */
-    I2C_FLAG_ADDSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 1U),               /*!< address is sent in master mode or received and matches in slave mode */
-    I2C_FLAG_BTC = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 2U),                   /*!< byte transmission finishes */
-    I2C_FLAG_ADD10SEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 3U),             /*!< header of 10-bit address is sent in master mode */
-    I2C_FLAG_STPDET = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 4U),                /*!< stop condition detected in slave mode */
-    I2C_FLAG_RBNE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 6U),                  /*!< I2C_DATA is not Empty during receiving */
-    I2C_FLAG_TBE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 7U),                   /*!< I2C_DATA is empty during transmitting */
-    I2C_FLAG_BERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 8U),                  /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus */
-    I2C_FLAG_LOSTARB = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 9U),               /*!< arbitration lost in master mode */
-    I2C_FLAG_AERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 10U),                 /*!< acknowledge error */
-    I2C_FLAG_OUERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 11U),                /*!< over-run or under-run situation occurs in slave mode */
-    I2C_FLAG_PECERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 12U),               /*!< PEC error when receiving data */
-    I2C_FLAG_SMBTO = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 14U),                /*!< timeout signal in SMBus mode */
-    I2C_FLAG_SMBALT = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 15U),               /*!< SMBus alert status */
+    I2C_FLAG_SBSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 0U),         /*!< start condition sent out in master mode */
+    I2C_FLAG_ADDSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 1U),        /*!< address is sent in master mode or received and matches in slave mode */
+    I2C_FLAG_BTC = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 2U),            /*!< byte transmission finishes */
+    I2C_FLAG_ADD10SEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 3U),      /*!< header of 10-bit address is sent in master mode */
+    I2C_FLAG_STPDET = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 4U),         /*!< stop condition detected in slave mode */
+    I2C_FLAG_RBNE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 6U),           /*!< I2C_DATA is not empty during receiving */
+    I2C_FLAG_TBE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 7U),            /*!< I2C_DATA is empty during transmitting */
+    I2C_FLAG_BERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 8U),           /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus */
+    I2C_FLAG_LOSTARB = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 9U),        /*!< arbitration lost in master mode */
+    I2C_FLAG_AERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 10U),          /*!< acknowledge error */
+    I2C_FLAG_OUERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 11U),         /*!< over-run or under-run situation occurs in slave mode */
+    I2C_FLAG_PECERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 12U),        /*!< PEC error when receiving data */
+    I2C_FLAG_SMBTO = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 14U),         /*!< timeout signal in SMBus mode */
+    I2C_FLAG_SMBALT = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 15U),        /*!< SMBus alert status */
     /* flags in STAT1 register */
-    I2C_FLAG_MASTER = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 0U),                /*!< a flag indicating whether I2C block is in master or slave mode */
-    I2C_FLAG_I2CBSY = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 1U),                /*!< busy flag */
-    I2C_FLAG_TRS = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 2U),                   /*!< whether the I2C is a transmitter or a receiver */
-    I2C_FLAG_RXGC = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 4U),                  /*!< general call address (00h) received */
-    I2C_FLAG_DEFSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 5U),                /*!< default address of SMBus device */
-    I2C_FLAG_HSTSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 6U),                /*!< SMBus host header detected in slave mode */
-    I2C_FLAG_DUMOD = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 7U),                 /*!< dual flag in slave mode indicating which address is matched in dual-address mode */
+    I2C_FLAG_MASTER = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 0U),         /*!< a flag indicating whether I2C block is in master or slave mode */
+    I2C_FLAG_I2CBSY = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 1U),         /*!< busy flag */
+    I2C_FLAG_TR = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 2U),             /*!< whether the I2C is a transmitter or a receiver */
+    I2C_FLAG_RXGC = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 4U),           /*!< general call address (00h) received */
+    I2C_FLAG_DEFSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 5U),         /*!< default address of SMBus device */
+    I2C_FLAG_HSTSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 6U),         /*!< SMBus host header detected in slave mode */
+    I2C_FLAG_DUMOD = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 7U),          /*!< dual flag in slave mode indicating which address is matched in dual-address mode */
     /* flags in SAMCS register */
-    I2C_FLAG_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 12U),                  /*!< txframe fall flag */
-    I2C_FLAG_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 13U),                  /*!< txframe rise flag */
-    I2C_FLAG_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 14U),                  /*!< rxframe fall flag */
-    I2C_FLAG_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 15U)                  /*!< rxframe rise flag */
-}i2c_flag_enum;
+    I2C_FLAG_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 12U),           /*!< txframe fall flag */
+    I2C_FLAG_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 13U),           /*!< txframe rise flag */
+    I2C_FLAG_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 14U),           /*!< rxframe fall flag */
+    I2C_FLAG_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 15U)            /*!< rxframe rise flag */
+} i2c_flag_enum;
 
 /* I2C interrupt flags */
-typedef enum
-{
+typedef enum {
     /* interrupt flags in CTL1 register */
     I2C_INT_FLAG_SBSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 0U),        /*!< start condition sent out in master mode interrupt flag */
     I2C_INT_FLAG_ADDSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 1U),       /*!< address is sent in master mode or received and matches in slave mode interrupt flag */
-    I2C_INT_FLAG_BTC =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 2U),          /*!< byte transmission finishes */
+    I2C_INT_FLAG_BTC =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 2U),          /*!< byte transmission finishes interrupt flag */
     I2C_INT_FLAG_ADD10SEND =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 3U),    /*!< header of 10-bit address is sent in master mode interrupt flag */
     I2C_INT_FLAG_STPDET = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 4U),        /*!< stop condition detected in slave mode interrupt flag */
     I2C_INT_FLAG_RBNE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 6U),          /*!< I2C_DATA is not Empty during receiving interrupt flag */
-    I2C_INT_FLAG_TBE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 7U),           /*!< I2C_DATA is empty during transmitting interrupt flag */    
+    I2C_INT_FLAG_TBE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 7U),           /*!< I2C_DATA is empty during transmitting interrupt flag */
     I2C_INT_FLAG_BERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 8U),          /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag */
     I2C_INT_FLAG_LOSTARB = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 9U),       /*!< arbitration lost in master mode interrupt flag */
     I2C_INT_FLAG_AERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 10U),         /*!< acknowledge error interrupt flag */
     I2C_INT_FLAG_OUERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 11U),        /*!< over-run or under-run situation occurs in slave mode interrupt flag */
     I2C_INT_FLAG_PECERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 12U),       /*!< PEC error when receiving data interrupt flag */
     I2C_INT_FLAG_SMBTO = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 14U),        /*!< timeout signal in SMBus mode interrupt flag */
-    I2C_INT_FLAG_SMBALT = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 15U),       /*!< SMBus Alert status interrupt flag */
+    I2C_INT_FLAG_SMBALT = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 15U),       /*!< SMBus alert status interrupt flag */
     /* interrupt flags in SAMCS register */
-    I2C_INT_FLAG_TFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 4U, I2C_SAMCS_REG_OFFSET, 12U),         /*!< txframe fall interrupt flag */ 
-    I2C_INT_FLAG_TFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 5U, I2C_SAMCS_REG_OFFSET, 13U),         /*!< txframe rise interrupt  flag */
+    I2C_INT_FLAG_TFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 4U, I2C_SAMCS_REG_OFFSET, 12U),         /*!< txframe fall interrupt flag */
+    I2C_INT_FLAG_TFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 5U, I2C_SAMCS_REG_OFFSET, 13U),         /*!< txframe rise interrupt flag */
     I2C_INT_FLAG_RFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 6U, I2C_SAMCS_REG_OFFSET, 14U),         /*!< rxframe fall interrupt flag */
-    I2C_INT_FLAG_RFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 7U, I2C_SAMCS_REG_OFFSET, 15U)         /*!< rxframe rise interrupt flag */
-}i2c_interrupt_flag_enum;
+    I2C_INT_FLAG_RFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 7U, I2C_SAMCS_REG_OFFSET, 15U)          /*!< rxframe rise interrupt flag */
+} i2c_interrupt_flag_enum;
 
-/* I2C interrupt enable or disable */
-typedef enum
-{
+/* I2C interrupt */
+typedef enum {
     /* interrupt in CTL1 register */
-    I2C_INT_ERR = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 8U),                     /*!< error interrupt enable */
-    I2C_INT_EV = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 9U),                      /*!< event interrupt enable */
-    I2C_INT_BUF = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 10U),                    /*!< buffer interrupt enable */
+    I2C_INT_ERR = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 8U),              /*!< error interrupt */
+    I2C_INT_EV = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 9U),               /*!< event interrupt */
+    I2C_INT_BUF = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 10U),             /*!< buffer interrupt */
     /* interrupt in SAMCS register */
-    I2C_INT_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 4U),                    /*!< txframe fall interrupt enable  */
-    I2C_INT_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 5U),                    /*!< txframe rise interrupt  enable */
-    I2C_INT_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 6U),                    /*!< rxframe fall interrupt enable */
-    I2C_INT_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 7U)                     /*!< rxframe rise interrupt enable */
-}i2c_interrupt_enum;
+    I2C_INT_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 4U),             /*!< txframe fall interrupt */
+    I2C_INT_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 5U),             /*!< txframe rise interrupt */
+    I2C_INT_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 6U),             /*!< rxframe fall interrupt */
+    I2C_INT_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 7U)              /*!< rxframe rise interrupt */
+} i2c_interrupt_enum;
+
+/* the digital noise filter can filter spikes's length */
+typedef enum {
+    I2C_DF_DISABLE = 0,                                                 /*!< disable digital noise filter */
+    I2C_DF_1PCLK,                                                       /*!< enable digital noise filter and the maximum filtered spiker's length 1 PCLK1 */
+    I2C_DF_2PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 2 PCLK1 */
+    I2C_DF_3PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 3 PCLK1 */
+    I2C_DF_4PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 4 PCLK1 */
+    I2C_DF_5PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 5 PCLK1 */
+    I2C_DF_6PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 6 PCLK1 */
+    I2C_DF_7PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 7 PCLK1 */
+    I2C_DF_8PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 8 PCLK1 */
+    I2C_DF_9PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 9 PCLK1 */
+    I2C_DF_10PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 10 PCLK1 */
+    I2C_DF_11PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 11 PCLK1 */
+    I2C_DF_12PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 12 PCLK1 */
+    I2C_DF_13PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 13 PCLK1 */
+    I2C_DF_14PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 14 PCLK1 */
+    I2C_DF_15PCLKS                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 15 PCLK1 */
+} i2c_digital_filter_enum;
 
 /* SMBus/I2C mode switch and SMBus type selection */
-#define I2C_I2CMODE_ENABLE            ((uint32_t)0x00000000U)                  /*!< I2C mode */
-#define I2C_SMBUSMODE_ENABLE          I2C_CTL0_SMBEN                           /*!< SMBus mode */
+#define I2C_I2CMODE_ENABLE            ((uint32_t)0x00000000U)           /*!< I2C mode */
+#define I2C_SMBUSMODE_ENABLE          I2C_CTL0_SMBEN                    /*!< SMBus mode */
 
 /* SMBus/I2C mode switch and SMBus type selection */
-#define I2C_SMBUS_DEVICE              ((uint32_t)0x00000000U)                  /*!< SMBus mode device type */
-#define I2C_SMBUS_HOST                I2C_CTL0_SMBSEL                          /*!< SMBus mode host type */
+#define I2C_SMBUS_DEVICE              ((uint32_t)0x00000000U)           /*!< SMBus mode device type */
+#define I2C_SMBUS_HOST                I2C_CTL0_SMBSEL                   /*!< SMBus mode host type */
 
 /* I2C transfer direction */
-#define I2C_RECEIVER                  ((uint32_t)0x00000001U)                  /*!< receiver */
-#define I2C_TRANSMITTER               ((uint32_t)0xFFFFFFFEU)                  /*!< transmitter */
+#define I2C_RECEIVER                  ((uint32_t)0x00000001U)           /*!< receiver */
+#define I2C_TRANSMITTER               ((uint32_t)0xFFFFFFFEU)           /*!< transmitter */
 
 /* whether or not to send an ACK */
-#define I2C_ACK_DISABLE               ((uint32_t)0x00000000U)                  /*!< ACK will be not sent */
-#define I2C_ACK_ENABLE                ((uint32_t)0x00000001U)                  /*!< ACK will be sent */
+#define I2C_ACK_DISABLE               ((uint32_t)0x00000000U)           /*!< ACK will be not sent */
+#define I2C_ACK_ENABLE                I2C_CTL0_ACKEN                    /*!< ACK will be sent */
 
 /* I2C POAP position*/
-#define I2C_ACKPOS_NEXT               ((uint32_t)0x00000000U)                  /*!< ACKEN bit decides whether or not to send ACK for the next byte */
-#define I2C_ACKPOS_CURRENT            ((uint32_t)0x00000001U)                  /*!< ACKEN bit decides whether or not to send ACK or not for the current byte */
-
-/* I2C dual-address mode switch */
-#define I2C_DUADEN_DISABLE            ((uint32_t)0x00000000U)                  /*!< dual-address mode disabled */
-#define I2C_DUADEN_ENABLE             ((uint32_t)0x00000001U)                  /*!< dual-address mode enabled */
+#define I2C_ACKPOS_CURRENT            ((uint32_t)0x00000000U)           /*!< ACKEN bit decides whether or not to send ACK or not for the current byte */
+#define I2C_ACKPOS_NEXT               I2C_CTL0_POAP                     /*!< ACKEN bit decides whether or not to send ACK for the next byte */
 
 /* whether or not to stretch SCL low */
-#define I2C_SCLSTRETCH_ENABLE         ((uint32_t)0x00000000U)                  /*!< SCL stretching is enabled */
-#define I2C_SCLSTRETCH_DISABLE        I2C_CTL0_SS                              /*!< SCL stretching is disabled */
+#define I2C_SCLSTRETCH_ENABLE         ((uint32_t)0x00000000U)           /*!< enable SCL stretching */
+#define I2C_SCLSTRETCH_DISABLE        I2C_CTL0_SS                       /*!< disable SCL stretching */
 
 /* whether or not to response to a general call */
-#define I2C_GCEN_ENABLE               I2C_CTL0_GCEN                            /*!< slave will response to a general call */
-#define I2C_GCEN_DISABLE              ((uint32_t)0x00000000U)                  /*!< slave will not response to a general call */
+#define I2C_GCEN_ENABLE               I2C_CTL0_GCEN                     /*!< slave will response to a general call */
+#define I2C_GCEN_DISABLE              ((uint32_t)0x00000000U)           /*!< slave will not response to a general call */
 
 /* software reset I2C */
-#define I2C_SRESET_SET                I2C_CTL0_SRESET                          /*!< I2C is under reset */
-#define I2C_SRESET_RESET              ((uint32_t)0x00000000U)                  /*!< I2C is not under reset */
+#define I2C_SRESET_RESET              ((uint32_t)0x00000000U)           /*!< I2C is not under reset */
+#define I2C_SRESET_SET                I2C_CTL0_SRESET                   /*!< I2C is under reset */
 
 /* I2C DMA mode configure */
 /* DMA mode switch */
-#define I2C_DMA_ON                    I2C_CTL1_DMAON                           /*!< DMA mode enabled */
-#define I2C_DMA_OFF                   ((uint32_t)0x00000000U)                  /*!< DMA mode disabled */
+#define I2C_DMA_OFF                   ((uint32_t)0x00000000U)           /*!< disable DMA mode */
+#define I2C_DMA_ON                    I2C_CTL1_DMAON                    /*!< enable DMA mode */
 
 /* flag indicating DMA last transfer */
-#define I2C_DMALST_ON                 I2C_CTL1_DMALST                          /*!< next DMA EOT is the last transfer */
-#define I2C_DMALST_OFF                ((uint32_t)0x00000000U)                  /*!< next DMA EOT is not the last transfer */
+#define I2C_DMALST_OFF                ((uint32_t)0x00000000U)           /*!< next DMA EOT is not the last transfer */
+#define I2C_DMALST_ON                 I2C_CTL1_DMALST                   /*!< next DMA EOT is the last transfer */
 
 /* I2C PEC configure */
 /* PEC enable */
-#define I2C_PEC_ENABLE                I2C_CTL0_PECEN                           /*!< PEC calculation on */
-#define I2C_PEC_DISABLE              ((uint32_t)0x00000000U)                   /*!< PEC calculation off */
+#define I2C_PEC_DISABLE              ((uint32_t)0x00000000U)            /*!< PEC calculation off */
+#define I2C_PEC_ENABLE                I2C_CTL0_PECEN                    /*!< PEC calculation on */
 
 /* PEC transfer */
-#define I2C_PECTRANS_ENABLE           I2C_CTL0_PECTRANS                        /*!< transfer PEC */
-#define I2C_PECTRANS_DISABLE          ((uint32_t)0x00000000U)                  /*!< not transfer PEC value */
+#define I2C_PECTRANS_DISABLE          ((uint32_t)0x00000000U)           /*!< not transfer PEC value */
+#define I2C_PECTRANS_ENABLE           I2C_CTL0_PECTRANS                 /*!< transfer PEC value */
 
 /* I2C SMBus configure */
 /* issue or not alert through SMBA pin */
-#define I2C_SALTSEND_ENABLE           I2C_CTL0_SALT                            /*!< issue alert through SMBA pin */
-#define I2C_SALTSEND_DISABLE          ((uint32_t)0x00000000U)                  /*!< not issue alert through SMBA */
+#define I2C_SALTSEND_DISABLE          ((uint32_t)0x00000000U)           /*!< not issue alert through SMBA */
+#define I2C_SALTSEND_ENABLE           I2C_CTL0_SALT                     /*!< issue alert through SMBA pin */
 
 /* ARP protocol in SMBus switch */
-#define I2C_ARP_ENABLE                I2C_CTL0_ARPEN                           /*!< ARP is enabled */
-#define I2C_ARP_DISABLE               ((uint32_t)0x00000000U)                  /*!< ARP is disabled */
+#define I2C_ARP_DISABLE               ((uint32_t)0x00000000U)           /*!< disable ARP */
+#define I2C_ARP_ENABLE                I2C_CTL0_ARPEN                    /*!< enable ARP */
 
 /* transmit I2C data */
 #define DATA_TRANS(regval)            (BITS(0,7) & ((uint32_t)(regval) << 0))
@@ -329,27 +320,24 @@ typedef enum
 #define DATA_RECV(regval)             GET_BITS((uint32_t)(regval), 0, 7)
 
 /* I2C duty cycle in fast mode */
-#define I2C_DTCY_2                    ((uint32_t)0x00000000U)                  /*!< I2C fast mode Tlow/Thigh = 2 */
-#define I2C_DTCY_16_9                 I2C_CKCFG_DTCY                           /*!< I2C fast mode Tlow/Thigh = 16/9 */
+#define I2C_DTCY_2                    ((uint32_t)0x00000000U)           /*!< T_low/T_high = 2 in fast mode */
+#define I2C_DTCY_16_9                 I2C_CKCFG_DTCY                    /*!< T_low/T_high = 16/9 in fast mode */
 
 /* address mode for the I2C slave */
-#define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
-#define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
-
-/* I2C clock frequency, MHz */
-#define I2CCLK_MAX                    ((uint32_t)0x00000032U)                  /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
-#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
-#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+#define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)           /*!< address format is 7 bits */
+#define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT              /*!< address format is 10 bits */
 
 /* function declarations */
+/* initialization functions */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);
 /* configure I2C clock */
 void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc);
 /* configure I2C address */
 void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat, uint32_t addr);
-/* SMBus type selection */
+
+/* application function declarations */
+/* select SMBus type */
 void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type);
 /* whether or not to send an ACK */
 void i2c_ack_config(uint32_t i2c_periph, uint32_t ack);
@@ -365,7 +353,6 @@ void i2c_dualaddr_disable(uint32_t i2c_periph);
 void i2c_enable(uint32_t i2c_periph);
 /* disable I2C */
 void i2c_disable(uint32_t i2c_periph);
-
 /* generate a START condition on I2C bus */
 void i2c_start_on_bus(uint32_t i2c_periph);
 /* generate a STOP condition on I2C bus */
@@ -374,35 +361,32 @@ void i2c_stop_on_bus(uint32_t i2c_periph);
 void i2c_data_transmit(uint32_t i2c_periph, uint8_t data);
 /* I2C receive data function */
 uint8_t i2c_data_receive(uint32_t i2c_periph);
-/* enable I2C DMA mode */
-void i2c_dma_enable(uint32_t i2c_periph, uint32_t dmastate);
+/* configure I2C DMA mode */
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate);
 /* configure whether next DMA EOT is DMA last transfer or not */
 void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast);
 /* whether to stretch SCL low when data is not ready in slave mode */
 void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara);
 /* whether or not to response to a general call */
 void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara);
-/* software reset I2C */
+/* configure software reset of I2C */
 void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset);
-
-/* I2C PEC calculation on or off */
-void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate);
-/* I2C whether to transfer PEC value */
-void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara);
-/* packet error checking value */
+/* configure I2C PEC calculation */
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate);
+/* configure whether to transfer PEC value */
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara);
+/* get packet error checking value */
 uint8_t i2c_pec_value_get(uint32_t i2c_periph);
-/* I2C issue alert through SMBA pin */
-void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara);
-/* I2C ARP protocol in SMBus switch */
-void i2c_smbus_arp_enable(uint32_t i2c_periph, uint32_t arpstate);
-
-/* I2C analog noise filter disable */
+/* configure I2C alert through SMBA pin */
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara);
+/* configure I2C ARP protocol in SMBus */
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate);
+/* disable analog noise filter */
 void i2c_analog_noise_filter_disable(uint32_t i2c_periph);
-/* I2C analog noise filter enable */
+/* enable analog noise filter */
 void i2c_analog_noise_filter_enable(uint32_t i2c_periph);
-/* digital noise filter */
-void i2c_digital_noise_filter_config(uint32_t i2c_periph,i2c_digital_filter_enum dfilterpara);
-
+/* configure digital noise filter */
+void i2c_digital_noise_filter_config(uint32_t i2c_periph, i2c_digital_filter_enum dfilterpara);
 /* enable SAM_V interface */
 void i2c_sam_enable(uint32_t i2c_periph);
 /* disable SAM_V interface */
@@ -412,17 +396,18 @@ void i2c_sam_timeout_enable(uint32_t i2c_periph);
 /* disable SAM_V interface timeout detect */
 void i2c_sam_timeout_disable(uint32_t i2c_periph);
 
-/* check I2C flag is set or not */
+/* interrupt & flag functions */
+/* get I2C flag status */
 FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag);
-/* clear I2C flag */
+/* clear I2C flag status */
 void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag);
 /* enable I2C interrupt */
 void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
 /* disable I2C interrupt */
 void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
-/* check I2C interrupt flag */
+/* get I2C interrupt flag status */
 FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
-/* clear I2C interrupt flag */
+/* clear I2C interrupt flag status */
 void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
 
 #endif /* GD32F4XX_I2C_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_ipa.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_ipa.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_ipa.h
     \brief   definitions for the IPA
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -40,30 +41,30 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* TLI definitions */
-#define IPA                               IPA_BASE               /*!< IPA base address */
+#define IPA                               IPA_BASE                     /*!< IPA base address */
 
 /* bits definitions */
 /* registers definitions */
-#define IPA_CTL                           REG32(IPA + 0x00U)     /*!< IPA control register */
-#define IPA_INTF                          REG32(IPA + 0x04U)     /*!< IPA interrupt flag register */
-#define IPA_INTC                          REG32(IPA + 0x08U)     /*!< IPA interrupt flag clear register */
-#define IPA_FMADDR                        REG32(IPA + 0x0CU)     /*!< IPA foreground memory base address register */
-#define IPA_FLOFF                         REG32(IPA + 0x10U)     /*!< IPA foreground line offset register */
-#define IPA_BMADDR                        REG32(IPA + 0x14U)     /*!< IPA background memory base address register */
-#define IPA_BLOFF                         REG32(IPA + 0x18U)     /*!< IPA background line offset register */
-#define IPA_FPCTL                         REG32(IPA + 0x1CU)     /*!< IPA foreground pixel control register */
-#define IPA_FPV                           REG32(IPA + 0x20U)     /*!< IPA foreground pixel value register */
-#define IPA_BPCTL                         REG32(IPA + 0x24U)     /*!< IPA background pixel control register */
-#define IPA_BPV                           REG32(IPA + 0x28U)     /*!< IPA background pixel value register */
-#define IPA_FLMADDR                       REG32(IPA + 0x2CU)     /*!< IPA foreground LUT memory base address register */
-#define IPA_BLMADDR                       REG32(IPA + 0x30U)     /*!< IPA background LUT memory base address register */
-#define IPA_DPCTL                         REG32(IPA + 0x34U)     /*!< IPA destination pixel control register */
-#define IPA_DPV                           REG32(IPA + 0x38U)     /*!< IPA destination pixel value register */
-#define IPA_DMADDR                        REG32(IPA + 0x3CU)     /*!< IPA destination memory base address register */
-#define IPA_DLOFF                         REG32(IPA + 0x40U)     /*!< IPA destination line offset register */
-#define IPA_IMS                           REG32(IPA + 0x44U)     /*!< IPA image size register */
-#define IPA_LM                            REG32(IPA + 0x48U)     /*!< IPA line mark register */
-#define IPA_ITCTL                         REG32(IPA + 0x4CU)     /*!< IPA inter-timer control register */
+#define IPA_CTL                           REG32(IPA + 0x00000000U)     /*!< IPA control register */
+#define IPA_INTF                          REG32(IPA + 0x00000004U)     /*!< IPA interrupt flag register */
+#define IPA_INTC                          REG32(IPA + 0x00000008U)     /*!< IPA interrupt flag clear register */
+#define IPA_FMADDR                        REG32(IPA + 0x0000000CU)     /*!< IPA foreground memory base address register */
+#define IPA_FLOFF                         REG32(IPA + 0x00000010U)     /*!< IPA foreground line offset register */
+#define IPA_BMADDR                        REG32(IPA + 0x00000014U)     /*!< IPA background memory base address register */
+#define IPA_BLOFF                         REG32(IPA + 0x00000018U)     /*!< IPA background line offset register */
+#define IPA_FPCTL                         REG32(IPA + 0x0000001CU)     /*!< IPA foreground pixel control register */
+#define IPA_FPV                           REG32(IPA + 0x00000020U)     /*!< IPA foreground pixel value register */
+#define IPA_BPCTL                         REG32(IPA + 0x00000024U)     /*!< IPA background pixel control register */
+#define IPA_BPV                           REG32(IPA + 0x00000028U)     /*!< IPA background pixel value register */
+#define IPA_FLMADDR                       REG32(IPA + 0x0000002CU)     /*!< IPA foreground LUT memory base address register */
+#define IPA_BLMADDR                       REG32(IPA + 0x00000030U)     /*!< IPA background LUT memory base address register */
+#define IPA_DPCTL                         REG32(IPA + 0x00000034U)     /*!< IPA destination pixel control register */
+#define IPA_DPV                           REG32(IPA + 0x00000038U)     /*!< IPA destination pixel value register */
+#define IPA_DMADDR                        REG32(IPA + 0x0000003CU)     /*!< IPA destination memory base address register */
+#define IPA_DLOFF                         REG32(IPA + 0x00000040U)     /*!< IPA destination line offset register */
+#define IPA_IMS                           REG32(IPA + 0x00000044U)     /*!< IPA image size register */
+#define IPA_LM                            REG32(IPA + 0x00000048U)     /*!< IPA line mark register */
+#define IPA_ITCTL                         REG32(IPA + 0x0000004CU)     /*!< IPA inter-timer control register */
 
 /* IPA_CTL */
 #define IPA_CTL_TEN                       BIT(0)           /*!< transfer enable */
@@ -189,8 +190,7 @@ OF SUCH DAMAGE.
 
 /* constants definitions */
 /* IPA foreground parameter struct definitions */
-typedef struct
-{   
+typedef struct {
     uint32_t foreground_memaddr;                          /*!< foreground memory base address */
     uint32_t foreground_lineoff;                          /*!< foreground line offset */
     uint32_t foreground_prealpha;                         /*!< foreground pre-defined alpha value */
@@ -199,11 +199,10 @@ typedef struct
     uint32_t foreground_prered;                           /*!< foreground pre-defined red value */
     uint32_t foreground_pregreen;                         /*!< foreground pre-defined green value */
     uint32_t foreground_preblue;                          /*!< foreground pre-defined blue value */
-}ipa_foreground_parameter_struct; 
+} ipa_foreground_parameter_struct;
 
 /* IPA background parameter struct definitions */
-typedef struct
-{   
+typedef struct {
     uint32_t background_memaddr;                          /*!< background memory base address */
     uint32_t background_lineoff;                          /*!< background line offset */
     uint32_t background_prealpha;                         /*!< background pre-defined alpha value */
@@ -212,11 +211,10 @@ typedef struct
     uint32_t background_prered;                           /*!< background pre-defined red value */
     uint32_t background_pregreen;                         /*!< background pre-defined green value */
     uint32_t background_preblue;                          /*!< background pre-defined blue value */
-}ipa_background_parameter_struct; 
+} ipa_background_parameter_struct;
 
 /* IPA destination parameter struct definitions */
-typedef struct
-{
+typedef struct {
     uint32_t destination_memaddr;                         /*!< destination memory base address */
     uint32_t destination_lineoff;                         /*!< destination line offset */
     uint32_t destination_prealpha;                        /*!< destination pre-defined alpha value */
@@ -226,11 +224,10 @@ typedef struct
     uint32_t destination_preblue;                         /*!< destination pre-defined blue value */
     uint32_t image_width;                                 /*!< width of the image to be processed */
     uint32_t image_height;                                /*!< height of the image to be processed */
-}ipa_destination_parameter_struct; 
+} ipa_destination_parameter_struct;
 
 /* destination pixel format */
-typedef enum 
-{
+typedef enum {
     IPA_DPF_ARGB8888,                                     /*!< destination pixel format ARGB8888 */
     IPA_DPF_RGB888,                                       /*!< destination pixel format RGB888 */
     IPA_DPF_RGB565,                                       /*!< destination pixel format RGB565 */
@@ -339,21 +336,21 @@ void ipa_background_lut_loading_enable(void);
 void ipa_pixel_format_convert_mode_set(uint32_t pfcm);
 
 /* structure initialization, foreground, background, destination and LUT initialization */
-/* initialize the structure of IPA foreground parameter struct with the default values, it is 
+/* initialize the structure of IPA foreground parameter struct with the default values, it is
   suggested that call this function after an ipa_foreground_parameter_struct structure is defined */
-void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct* foreground_struct);
+void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct *foreground_struct);
 /* initialize foreground parameters */
-void ipa_foreground_init(ipa_foreground_parameter_struct* foreground_struct);
-/* initialize the structure of IPA background parameter struct with the default values, it is 
+void ipa_foreground_init(ipa_foreground_parameter_struct *foreground_struct);
+/* initialize the structure of IPA background parameter struct with the default values, it is
   suggested that call this function after an ipa_background_parameter_struct structure is defined */
-void ipa_background_struct_para_init(ipa_background_parameter_struct* background_struct);
+void ipa_background_struct_para_init(ipa_background_parameter_struct *background_struct);
 /* initialize background parameters */
-void ipa_background_init(ipa_background_parameter_struct* background_struct);
-/* initialize the structure of IPA destination parameter struct with the default values, it is 
+void ipa_background_init(ipa_background_parameter_struct *background_struct);
+/* initialize the structure of IPA destination parameter struct with the default values, it is
   suggested that call this function after an ipa_destination_parameter_struct structure is defined */
-void ipa_destination_struct_para_init(ipa_destination_parameter_struct* destination_struct);
+void ipa_destination_struct_para_init(ipa_destination_parameter_struct *destination_struct);
 /* initialize destination parameters */
-void ipa_destination_init(ipa_destination_parameter_struct* destination_struct);
+void ipa_destination_init(ipa_destination_parameter_struct *destination_struct);
 /* initialize IPA foreground LUT parameters */
 void ipa_foreground_lut_init(uint8_t fg_lut_num, uint8_t fg_lut_pf, uint32_t fg_lut_addr);
 /* initialize IPA background LUT parameters */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_iref.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_iref.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -167,7 +168,7 @@ OF SUCH DAMAGE.
 #define IREF_SINK_CURRENT               IREF_CURRENT(1)        /*!< IREF sink current */
 
 /* function declarations */
-/* deinit IREF */
+/* deinitialize IREF */
 void iref_deinit(void);
 /* enable IREF */
 void iref_enable(void);

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_misc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_misc.h
@@ -1,14 +1,14 @@
 /*!
     \file    gd32f4xx_misc.h
     \brief   definitions for the MISC
-    
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_pmu.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_pmu.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -41,159 +42,165 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* PMU definitions */
-#define PMU                           PMU_BASE                 /*!< PMU base address */
+#define PMU                           PMU_BASE                          /*!< PMU base address */
 
 /* registers definitions */
-#define PMU_CTL                       REG32((PMU) + 0x00U)     /*!< PMU control register */
-#define PMU_CS                        REG32((PMU) + 0x04U)     /*!< PMU control and status register */
+#define PMU_CTL                       REG32((PMU) + 0x00000000U)        /*!< PMU control register */
+#define PMU_CS                        REG32((PMU) + 0x00000004U)        /*!< PMU control and status register */
 
 /* bits definitions */
 /* PMU_CTL */
-#define PMU_CTL_LDOLP                 BIT(0)                   /*!< LDO low power mode */
-#define PMU_CTL_STBMOD                BIT(1)                   /*!< standby mode */
-#define PMU_CTL_WURST                 BIT(2)                   /*!< wakeup flag reset */
-#define PMU_CTL_STBRST                BIT(3)                   /*!< standby flag reset */
-#define PMU_CTL_LVDEN                 BIT(4)                   /*!< low voltage detector enable */
-#define PMU_CTL_LVDT                  BITS(5,7)                /*!< low voltage detector threshold */
-#define PMU_CTL_BKPWEN                BIT(8)                   /*!< backup domain write enable */
-#define PMU_CTL_LDLP                  BIT(10)                  /*!< low-driver mode when use low power LDO */
-#define PMU_CTL_LDNP                  BIT(11)                  /*!< low-driver mode when use normal power LDO */
-#define PMU_CTL_LDOVS                 BITS(14,15)              /*!< LDO output voltage select */
-#define PMU_CTL_HDEN                  BIT(16)                  /*!< high-driver mode enable */
-#define PMU_CTL_HDS                   BIT(17)                  /*!< high-driver mode switch */
-#define PMU_CTL_LDEN                  BITS(18,19)              /*!< low-driver mode enable in deep-sleep mode */
+#define PMU_CTL_LDOLP                 BIT(0)                            /*!< LDO low power mode */
+#define PMU_CTL_STBMOD                BIT(1)                            /*!< standby mode */
+#define PMU_CTL_WURST                 BIT(2)                            /*!< wakeup flag reset */
+#define PMU_CTL_STBRST                BIT(3)                            /*!< standby flag reset */
+#define PMU_CTL_LVDEN                 BIT(4)                            /*!< low voltage detector enable */
+#define PMU_CTL_LVDT                  BITS(5,7)                         /*!< low voltage detector threshold */
+#define PMU_CTL_BKPWEN                BIT(8)                            /*!< backup domain write enable */
+#define PMU_CTL_LDLP                  BIT(10)                           /*!< low-driver mode when use low power LDO */
+#define PMU_CTL_LDNP                  BIT(11)                           /*!< low-driver mode when use normal power LDO */
+#define PMU_CTL_LDOVS                 BITS(14,15)                       /*!< LDO output voltage select */
+#define PMU_CTL_HDEN                  BIT(16)                           /*!< high-driver mode enable */
+#define PMU_CTL_HDS                   BIT(17)                           /*!< high-driver mode switch */
+#define PMU_CTL_LDEN                  BITS(18,19)                       /*!< low-driver mode enable in deep-sleep mode */
 
 /* PMU_CS */
-#define PMU_CS_WUF                    BIT(0)                   /*!< wakeup flag */
-#define PMU_CS_STBF                   BIT(1)                   /*!< standby flag */
-#define PMU_CS_LVDF                   BIT(2)                   /*!< low voltage detector status flag */
-#define PMU_CS_BLDORF                 BIT(3)                   /*!< backup SRAM LDO ready flag */
-#define PMU_CS_WUPEN                  BIT(8)                   /*!< wakeup pin enable */
-#define PMU_CS_BLDOON                 BIT(9)                   /*!< backup SRAM LDO on */
-#define PMU_CS_LDOVSRF                BIT(14)                  /*!< LDO voltage select ready flag */
-#define PMU_CS_HDRF                   BIT(16)                  /*!< high-driver ready flag */
-#define PMU_CS_HDSRF                  BIT(17)                  /*!< high-driver switch ready flag */
-#define PMU_CS_LDRF                   BITS(18,19)              /*!< Low-driver mode ready flag */
+#define PMU_CS_WUF                    BIT(0)                            /*!< wakeup flag */
+#define PMU_CS_STBF                   BIT(1)                            /*!< standby flag */
+#define PMU_CS_LVDF                   BIT(2)                            /*!< low voltage detector status flag */
+#define PMU_CS_BLDORF                 BIT(3)                            /*!< backup SRAM LDO ready flag */
+#define PMU_CS_WUPEN                  BIT(8)                            /*!< wakeup pin enable */
+#define PMU_CS_BLDOON                 BIT(9)                            /*!< backup SRAM LDO on */
+#define PMU_CS_LDOVSRF                BIT(14)                           /*!< LDO voltage select ready flag */
+#define PMU_CS_HDRF                   BIT(16)                           /*!< high-driver ready flag */
+#define PMU_CS_HDSRF                  BIT(17)                           /*!< high-driver switch ready flag */
+#define PMU_CS_LDRF                   BITS(18,19)                       /*!< low-driver mode ready flag */
 
 /* constants definitions */
+/* PMU ldo definitions */
+#define PMU_LDO_NORMAL                ((uint32_t)0x00000000U)           /*!< LDO normal work when PMU enter deep-sleep mode */
+#define PMU_LDO_LOWPOWER              PMU_CTL_LDOLP                     /*!< LDO work at low power status when PMU enter deep-sleep mode */
+
 /* PMU low voltage detector threshold definitions */
 #define CTL_LVDT(regval)              (BITS(5,7)&((uint32_t)(regval)<<5))
-#define PMU_LVDT_0                    CTL_LVDT(0)              /*!< voltage threshold is 2.1V */
-#define PMU_LVDT_1                    CTL_LVDT(1)              /*!< voltage threshold is 2.3V */
-#define PMU_LVDT_2                    CTL_LVDT(2)              /*!< voltage threshold is 2.4V */
-#define PMU_LVDT_3                    CTL_LVDT(3)              /*!< voltage threshold is 2.6V */
-#define PMU_LVDT_4                    CTL_LVDT(4)              /*!< voltage threshold is 2.7V */
-#define PMU_LVDT_5                    CTL_LVDT(5)              /*!< voltage threshold is 2.9V */
-#define PMU_LVDT_6                    CTL_LVDT(6)              /*!< voltage threshold is 3.0V */
-#define PMU_LVDT_7                    CTL_LVDT(7)              /*!< voltage threshold is 3.1V */
-
-/* PMU LDO output voltage select definitions */
-#define CTL_LDOVS(regval)             (BITS(14,15)&((uint32_t)(regval)<<14))
-#define PMU_LDOVS_LOW                 CTL_LDOVS(1)             /*!< LDO output voltage low mode */
-#define PMU_LDOVS_MID                 CTL_LDOVS(2)             /*!< LDO output voltage mid mode */
-#define PMU_LDOVS_HIGH                CTL_LDOVS(3)             /*!< LDO output voltage high mode */
-
-/* PMU low-driver mode enable in deep-sleep mode */
-#define CTL_LDEN(regval)              (BITS(18,19)&((uint32_t)(regval)<<18))
-#define PMU_LOWDRIVER_DISABLE         CTL_LDEN(0)              /*!< low-driver mode disable in deep-sleep mode */
-#define PMU_LOWDRIVER_ENABLE          CTL_LDEN(3)              /*!< low-driver mode enable in deep-sleep mode */
-
-/* PMU high-driver mode switch */
-#define CTL_HDS(regval)               (BIT(17)&((uint32_t)(regval)<<17))
-#define PMU_HIGHDR_SWITCH_NONE        CTL_HDS(0)               /*!< no high-driver mode switch */
-#define PMU_HIGHDR_SWITCH_EN          CTL_HDS(1)               /*!< high-driver mode switch */
+#define PMU_LVDT_0                    CTL_LVDT(0)                       /*!< voltage threshold is 2.1V */
+#define PMU_LVDT_1                    CTL_LVDT(1)                       /*!< voltage threshold is 2.3V */
+#define PMU_LVDT_2                    CTL_LVDT(2)                       /*!< voltage threshold is 2.4V */
+#define PMU_LVDT_3                    CTL_LVDT(3)                       /*!< voltage threshold is 2.6V */
+#define PMU_LVDT_4                    CTL_LVDT(4)                       /*!< voltage threshold is 2.7V */
+#define PMU_LVDT_5                    CTL_LVDT(5)                       /*!< voltage threshold is 2.9V */
+#define PMU_LVDT_6                    CTL_LVDT(6)                       /*!< voltage threshold is 3.0V */
+#define PMU_LVDT_7                    CTL_LVDT(7)                       /*!< voltage threshold is 3.1V */
 
 /* PMU low-driver mode when use low power LDO */
 #define CTL_LDLP(regval)              (BIT(10)&((uint32_t)(regval)<<10))
-#define PMU_NORMALDR_LOWPWR           CTL_LDLP(0)              /*!< normal driver when use low power LDO */
-#define PMU_LOWDR_LOWPWR              CTL_LDLP(1)              /*!< low-driver mode enabled when LDEN is 11 and use low power LDO */
+#define PMU_NORMALDR_LOWPWR           CTL_LDLP(0)                       /*!< normal driver when use low power LDO */
+#define PMU_LOWDR_LOWPWR              CTL_LDLP(1)                       /*!< low-driver mode enabled when LDEN is 11 and use low power LDO */
 
 /* PMU low-driver mode when use normal power LDO */
 #define CTL_LDNP(regval)              (BIT(11)&((uint32_t)(regval)<<11))
-#define PMU_NORMALDR_NORMALPWR        CTL_LDNP(0)              /*!< normal driver when use normal power LDO */
-#define PMU_LOWDR_NORMALPWR           CTL_LDNP(1)              /*!< low-driver mode enabled when LDEN is 11 and use normal power LDO */
+#define PMU_NORMALDR_NORMALPWR        CTL_LDNP(0)                       /*!< normal driver when use normal power LDO */
+#define PMU_LOWDR_NORMALPWR           CTL_LDNP(1)                       /*!< low-driver mode enabled when LDEN is 11 and use normal power LDO */
 
-/* PMU low power mode ready flag definitions */
-#define CS_LDRF(regval)               (BITS(18,19)&((uint32_t)(regval)<<18))
-#define PMU_LDRF_NORMAL               CS_LDRF(0)               /*!< normal driver in deep-sleep mode */
-#define PMU_LDRF_LOWDRIVER            CS_LDRF(3)               /*!< low-driver mode in deep-sleep mode */
+/* PMU LDO output voltage select definitions */
+#define CTL_LDOVS(regval)             (BITS(14,15)&((uint32_t)(regval)<<14))
+#define PMU_LDOVS_LOW                 CTL_LDOVS(1)                      /*!< LDO output voltage low mode */
+#define PMU_LDOVS_MID                 CTL_LDOVS(2)                      /*!< LDO output voltage mid mode */
+#define PMU_LDOVS_HIGH                CTL_LDOVS(3)                      /*!< LDO output voltage high mode */
+
+
+/* PMU high-driver mode switch */
+#define CTL_HDS(regval)               (BIT(17)&((uint32_t)(regval)<<17))
+#define PMU_HIGHDR_SWITCH_NONE        CTL_HDS(0)                        /*!< no high-driver mode switch */
+#define PMU_HIGHDR_SWITCH_EN          CTL_HDS(1)                        /*!< high-driver mode switch */
+
+/* PMU low-driver mode enable in deep-sleep mode */
+#define CTL_LDEN(regval)              (BITS(18,19)&((uint32_t)(regval)<<18))
+#define PMU_LOWDRIVER_DISABLE         CTL_LDEN(0)                       /*!< low-driver mode disable in deep-sleep mode */
+#define PMU_LOWDRIVER_ENABLE          CTL_LDEN(3)                       /*!< low-driver mode enable in deep-sleep mode */
 
 /* PMU backup SRAM LDO on or off */
 #define CS_BLDOON(regval)             (BIT(9)&((uint32_t)(regval)<<9))
-#define PMU_BLDOON_OFF                CS_BLDOON(0)             /*!< backup SRAM LDO off */
-#define PMU_BLDOON_ON                 CS_BLDOON(1)             /*!< the backup SRAM LDO on */
+#define PMU_BLDOON_OFF                CS_BLDOON(0)                      /*!< backup SRAM LDO off */
+#define PMU_BLDOON_ON                 CS_BLDOON(1)                      /*!< the backup SRAM LDO on */
+
+/* PMU low power mode ready flag definitions */
+#define CS_LDRF(regval)               (BITS(18,19)&((uint32_t)(regval)<<18))
+#define PMU_LDRF_NORMAL               CS_LDRF(0)                        /*!< normal driver in deep-sleep mode */
+#define PMU_LDRF_LOWDRIVER            CS_LDRF(3)                        /*!< low-driver mode in deep-sleep mode */
 
 /* PMU flag definitions */
-#define PMU_FLAG_WAKEUP               PMU_CS_WUF               /*!< wakeup flag status */
-#define PMU_FLAG_STANDBY              PMU_CS_STBF              /*!< standby flag status */
-#define PMU_FLAG_LVD                  PMU_CS_LVDF              /*!< lvd flag status */
-#define PMU_FLAG_BLDORF               PMU_CS_BLDORF            /*!< backup SRAM LDO ready flag */
-#define PMU_FLAG_LDOVSRF              PMU_CS_LDOVSRF           /*!< LDO voltage select ready flag */
-#define PMU_FLAG_HDRF                 PMU_CS_HDRF              /*!< high-driver ready flag */
-#define PMU_FLAG_HDSRF                PMU_CS_HDSRF             /*!< high-driver switch ready flag */
-#define PMU_FLAG_LDRF                 PMU_CS_LDRF              /*!< low-driver mode ready flag */
-
-/* PMU ldo definitions */
-#define PMU_LDO_NORMAL                ((uint32_t)0x00000000U)  /*!< LDO normal work when PMU enter deepsleep mode */
-#define PMU_LDO_LOWPOWER              PMU_CTL_LDOLP            /*!< LDO work at low power status when PMU enter deepsleep mode */
+#define PMU_FLAG_WAKEUP               PMU_CS_WUF                        /*!< wakeup flag status */
+#define PMU_FLAG_STANDBY              PMU_CS_STBF                       /*!< standby flag status */
+#define PMU_FLAG_LVD                  PMU_CS_LVDF                       /*!< lvd flag status */
+#define PMU_FLAG_BLDORF               PMU_CS_BLDORF                     /*!< backup SRAM LDO ready flag */
+#define PMU_FLAG_LDOVSRF              PMU_CS_LDOVSRF                    /*!< LDO voltage select ready flag */
+#define PMU_FLAG_HDRF                 PMU_CS_HDRF                       /*!< high-driver ready flag */
+#define PMU_FLAG_HDSRF                PMU_CS_HDSRF                      /*!< high-driver switch ready flag */
+#define PMU_FLAG_LDRF                 PMU_CS_LDRF                       /*!< low-driver mode ready flag */
 
 /* PMU flag reset definitions */
-#define PMU_FLAG_RESET_WAKEUP         ((uint8_t)0x00U)         /*!< wakeup flag reset */
-#define PMU_FLAG_RESET_STANDBY        ((uint8_t)0x01U)         /*!< standby flag reset */
+#define PMU_FLAG_RESET_WAKEUP         ((uint8_t)0x00U)                  /*!< wakeup flag reset */
+#define PMU_FLAG_RESET_STANDBY        ((uint8_t)0x01U)                  /*!< standby flag reset */
 
 /* PMU command constants definitions */
-#define WFI_CMD                       ((uint8_t)0x00U)         /*!< use WFI command */
-#define WFE_CMD                       ((uint8_t)0x01U)         /*!< use WFE command */
+#define WFI_CMD                       ((uint8_t)0x00U)                  /*!< use WFI command */
+#define WFE_CMD                       ((uint8_t)0x01U)                  /*!< use WFE command */
 
 /* function declarations */
-/* reset PMU register */
+/* reset PMU registers */
 void pmu_deinit(void);
 
+/* LVD functions */
 /* select low voltage detector threshold */
 void pmu_lvd_select(uint32_t lvdt_n);
-/* LDO output voltage select */
-void pmu_ldo_output_select(uint32_t ldo_output);
-/* PMU lvd disable */
+/* disable PMU lvd */
 void pmu_lvd_disable(void);
 
-/* functions of low-driver mode and high-driver mode in deep-sleep mode */
-/* high-driver mode switch */
-void pmu_highdriver_switch_select(uint32_t highdr_switch);
-/* high-driver mode enable */
+/* LDO functions */
+/* select LDO output voltage */
+void pmu_ldo_output_select(uint32_t ldo_output);
+
+/* functions of low-driver mode and high-driver mode */
+/* enable high-driver mode */
 void pmu_highdriver_mode_enable(void);
-/* high-driver mode disable */
+/* disable high-driver mode */
 void pmu_highdriver_mode_disable(void);
-/* low-driver mode enable in deep-sleep mode */
-void pmu_low_driver_mode_enable(uint32_t lowdr_mode);
-/* in deep-sleep mode, low-driver mode when use low power LDO */
-void pmu_lowdriver_lowpower_config(uint32_t mode);
-/* in deep-sleep mode, low-driver mode when use normal power LDO */
-void pmu_lowdriver_normalpower_config(uint32_t mode);
+/* switch high-driver mode */
+void pmu_highdriver_switch_select(uint32_t highdr_switch);
+/* enable low-driver mode in deep-sleep */
+void pmu_lowdriver_mode_enable(void);
+/* disable low-driver mode in deep-sleep */
+void pmu_lowdriver_mode_disable(void);
+/* in deep-sleep mode, driver mode when use low power LDO */
+void pmu_lowpower_driver_config(uint32_t mode);
+/* in deep-sleep mode, driver mode when use normal power LDO */
+void pmu_normalpower_driver_config(uint32_t mode);
 
 /* set PMU mode */
-/* PMU work at sleep mode */
+/* PMU work in sleep mode */
 void pmu_to_sleepmode(uint8_t sleepmodecmd);
-/* PMU work at deepsleep mode */
-void pmu_to_deepsleepmode(uint32_t ldo, uint8_t deepsleepmodecmd);
-/* PMU work at standby mode */
+/* PMU work in deepsleep mode */
+void pmu_to_deepsleepmode(uint32_t ldo, uint32_t lowdrive, uint8_t deepsleepmodecmd);
+/* PMU work in standby mode */
 void pmu_to_standbymode(uint8_t standbymodecmd);
-/* PMU wakeup pin enable */
+/* enable PMU wakeup pin */
 void pmu_wakeup_pin_enable(void);
-/* PMU wakeup pin disable */
+/* disable PMU wakeup pin */
 void pmu_wakeup_pin_disable(void);
 
 /* backup related functions */
 /* backup SRAM LDO on */
 void pmu_backup_ldo_config(uint32_t bkp_ldo);
-/* backup domain write enable */
+/* enable write access to the registers in backup domain */
 void pmu_backup_write_enable(void);
-/* backup domain write disable */
+/* disable write access to the registers in backup domain */
 void pmu_backup_write_disable(void);
 
 /* flag functions */
-/* reset flag bit */
-void pmu_flag_reset(uint32_t flag_reset);
-/* get flag status */
-FlagStatus pmu_flag_get(uint32_t pmu_flag);
+/* get flag state */
+FlagStatus pmu_flag_get(uint32_t flag);
+/* clear flag bit */
+void pmu_flag_clear(uint32_t flag);
 
 #endif /* GD32F4XX_PMU_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_rcu.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_rcu.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -1068,10 +1069,10 @@ typedef enum
 
 /* Deep-sleep mode voltage */
 #define DSV_DSLPVS(regval)              (BITS(0,2) & ((uint32_t)(regval) << 0))
-#define RCU_DEEPSLEEP_V_1_2             DSV_DSLPVS(0)                      /*!< core voltage is 1.2V in deep-sleep mode */
-#define RCU_DEEPSLEEP_V_1_1             DSV_DSLPVS(1)                      /*!< core voltage is 1.1V in deep-sleep mode */
-#define RCU_DEEPSLEEP_V_1_0             DSV_DSLPVS(2)                      /*!< core voltage is 1.0V in deep-sleep mode */
-#define RCU_DEEPSLEEP_V_0_9             DSV_DSLPVS(3)                      /*!< core voltage is 0.9V in deep-sleep mode */
+#define RCU_DEEPSLEEP_V_0               DSV_DSLPVS(0)                      /*!< core voltage is default value in deep-sleep mode */
+#define RCU_DEEPSLEEP_V_1               DSV_DSLPVS(1)                      /*!< core voltage is (default value-0.1)V in deep-sleep mode(customers are not recommended to use it)*/
+#define RCU_DEEPSLEEP_V_2               DSV_DSLPVS(2)                      /*!< core voltage is (default value-0.2)V in deep-sleep mode(customers are not recommended to use it)*/
+#define RCU_DEEPSLEEP_V_3               DSV_DSLPVS(3)                      /*!< core voltage is (default value-0.3)V in deep-sleep mode(customers are not recommended to use it)*/
 
 
 /* function declarations */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_rtc.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_rtc.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -524,7 +525,7 @@ typedef struct
 #define RTC_AF1_TAMPER0                    RTC_TAMP_TP0SEL                            /*!< RTC_AF1 use for tamper0 */
 
 /* RTC flags */
-#define RTC_FLAG_ALRM0W										 RTC_STAT_ALRM0WF                           /*!< alarm0 configuration can be write flag */
+#define RTC_FLAG_ALRM0W                    RTC_STAT_ALRM0WF                           /*!< alarm0 configuration can be write flag */
 #define RTC_FLAG_ALRM1W                    RTC_STAT_ALRM1WF                           /*!< alarm1 configuration can be write flag */
 #define RTC_FLAG_WTW                       RTC_STAT_WTWF                              /*!< wakeup timer can be write flag */
 #define RTC_FLAG_SOP                       RTC_STAT_SOPF                              /*!< shift function operation pending flag */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_sdio.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_sdio.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_sdio.h
     \brief   definitions for the SDIO
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -43,24 +44,24 @@ OF SUCH DAMAGE.
 #define SDIO                            SDIO_BASE
 
 /* registers definitions */
-#define SDIO_PWRCTL                     REG32(SDIO + 0x00U)    /*!< SDIO power control register */
-#define SDIO_CLKCTL                     REG32(SDIO + 0x04U)    /*!< SDIO clock control register */
-#define SDIO_CMDAGMT                    REG32(SDIO + 0x08U)    /*!< SDIO command argument register */
-#define SDIO_CMDCTL                     REG32(SDIO + 0x0CU)    /*!< SDIO command control register */
-#define SDIO_RSPCMDIDX                  REG32(SDIO + 0x10U)    /*!< SDIO command index response register */
-#define SDIO_RESP0                      REG32(SDIO + 0x14U)    /*!< SDIO response register 0 */
-#define SDIO_RESP1                      REG32(SDIO + 0x18U)    /*!< SDIO response register 1 */
-#define SDIO_RESP2                      REG32(SDIO + 0x1CU)    /*!< SDIO response register 2 */
-#define SDIO_RESP3                      REG32(SDIO + 0x20U)    /*!< SDIO response register 3 */
-#define SDIO_DATATO                     REG32(SDIO + 0x24U)    /*!< SDIO data timeout register */
-#define SDIO_DATALEN                    REG32(SDIO + 0x28U)    /*!< SDIO data length register */
-#define SDIO_DATACTL                    REG32(SDIO + 0x2CU)    /*!< SDIO data control register */
-#define SDIO_DATACNT                    REG32(SDIO + 0x30U)    /*!< SDIO data counter register */
-#define SDIO_STAT                       REG32(SDIO + 0x34U)    /*!< SDIO status register */
-#define SDIO_INTC                       REG32(SDIO + 0x38U)    /*!< SDIO interrupt clear register */
-#define SDIO_INTEN                      REG32(SDIO + 0x3CU)    /*!< SDIO interrupt enable register */
-#define SDIO_FIFOCNT                    REG32(SDIO + 0x48U)    /*!< SDIO FIFO counter register */
-#define SDIO_FIFO                       REG32(SDIO + 0x80U)    /*!< SDIO FIFO data register */
+#define SDIO_PWRCTL                     REG32(SDIO + 0x00000000U)    /*!< SDIO power control register */
+#define SDIO_CLKCTL                     REG32(SDIO + 0x00000004U)    /*!< SDIO clock control register */
+#define SDIO_CMDAGMT                    REG32(SDIO + 0x00000008U)    /*!< SDIO command argument register */
+#define SDIO_CMDCTL                     REG32(SDIO + 0x0000000CU)    /*!< SDIO command control register */
+#define SDIO_RSPCMDIDX                  REG32(SDIO + 0x00000010U)    /*!< SDIO command index response register */
+#define SDIO_RESP0                      REG32(SDIO + 0x00000014U)    /*!< SDIO response register 0 */
+#define SDIO_RESP1                      REG32(SDIO + 0x00000018U)    /*!< SDIO response register 1 */
+#define SDIO_RESP2                      REG32(SDIO + 0x0000001CU)    /*!< SDIO response register 2 */
+#define SDIO_RESP3                      REG32(SDIO + 0x00000020U)    /*!< SDIO response register 3 */
+#define SDIO_DATATO                     REG32(SDIO + 0x00000024U)    /*!< SDIO data timeout register */
+#define SDIO_DATALEN                    REG32(SDIO + 0x00000028U)    /*!< SDIO data length register */
+#define SDIO_DATACTL                    REG32(SDIO + 0x0000002CU)    /*!< SDIO data control register */
+#define SDIO_DATACNT                    REG32(SDIO + 0x00000030U)    /*!< SDIO data counter register */
+#define SDIO_STAT                       REG32(SDIO + 0x00000034U)    /*!< SDIO status register */
+#define SDIO_INTC                       REG32(SDIO + 0x00000038U)    /*!< SDIO interrupt clear register */
+#define SDIO_INTEN                      REG32(SDIO + 0x0000003CU)    /*!< SDIO interrupt enable register */
+#define SDIO_FIFOCNT                    REG32(SDIO + 0x00000048U)    /*!< SDIO FIFO counter register */
+#define SDIO_FIFO                       REG32(SDIO + 0x00000080U)    /*!< SDIO FIFO data register */
 
 /* bits definitions */
 /* SDIO_PWRCTL */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_spi.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_spi.h
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -146,8 +147,7 @@ OF SUCH DAMAGE.
 
 /* constants definitions */
 /* SPI and I2S parameter struct definitions */
-typedef struct
-{   
+typedef struct {
     uint32_t device_mode;                                                       /*!< SPI master or slave */
     uint32_t trans_mode;                                                        /*!< SPI transtype */
     uint32_t frame_size;                                                        /*!< SPI frame size */
@@ -155,7 +155,7 @@ typedef struct
     uint32_t endian;                                                            /*!< SPI big endian or little endian */
     uint32_t clock_polarity_phase;                                              /*!< SPI clock phase and polarity */
     uint32_t prescale;                                                          /*!< SPI prescale factor */
-}spi_parameter_struct;
+} spi_parameter_struct;
 
 /* SPI mode definitions */
 #define SPI_MASTER                      (SPI_CTL0_MSTMOD | SPI_CTL0_SWNSS)      /*!< SPI as master */
@@ -241,7 +241,7 @@ typedef struct
 #define I2S_CKPL_LOW                    ((uint32_t)0x00000000U)                 /*!< I2S clock polarity low level */
 #define I2S_CKPL_HIGH                   SPI_I2SCTL_CKPL                         /*!< I2S clock polarity high level */
 
-/* SPI DMA constants definitions */                                    
+/* SPI DMA constants definitions */
 #define SPI_DMA_TRANSMIT                ((uint8_t)0x00U)                        /*!< SPI transmit data use DMA */
 #define SPI_DMA_RECEIVE                 ((uint8_t)0x01U)                        /*!< SPI receive data use DMA */
 
@@ -263,7 +263,7 @@ typedef struct
 #define I2S_INT_FLAG_TXURERR            ((uint8_t)0x05U)                        /*!< underrun error interrupt flag */
 #define SPI_I2S_INT_FLAG_FERR           ((uint8_t)0x06U)                        /*!< format error interrupt flag */
 
-/* SPI/I2S flag definitions */                                                  
+/* SPI/I2S flag definitions */
 #define SPI_FLAG_RBNE                   SPI_STAT_RBNE                           /*!< receive buffer not empty flag */
 #define SPI_FLAG_TBE                    SPI_STAT_TBE                            /*!< transmit buffer empty flag */
 #define SPI_FLAG_CRCERR                 SPI_STAT_CRCERR                         /*!< CRC error flag */
@@ -283,19 +283,19 @@ typedef struct
 /* initialization functions */
 /* deinitialize SPI and I2S */
 void spi_i2s_deinit(uint32_t spi_periph);
-/* initialize the parameters of SPI struct with the default values */
-void spi_struct_para_init(spi_parameter_struct* spi_struct);
+/* initialize the parameters of SPI struct with default values */
+void spi_struct_para_init(spi_parameter_struct *spi_struct);
 /* initialize SPI parameter */
-void spi_init(uint32_t spi_periph,spi_parameter_struct* spi_struct);
+void spi_init(uint32_t spi_periph, spi_parameter_struct *spi_struct);
 /* enable SPI */
 void spi_enable(uint32_t spi_periph);
 /* disable SPI */
 void spi_disable(uint32_t spi_periph);
 
 /* initialize I2S parameter */
-void i2s_init(uint32_t spi_periph,uint32_t i2s_mode,uint32_t i2s_standard,uint32_t i2s_ckpl);
+void i2s_init(uint32_t spi_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl);
 /* configure I2S prescale */
-void i2s_psc_config(uint32_t spi_periph,uint32_t i2s_audiosample,uint32_t i2s_frameformat,uint32_t i2s_mckout);
+void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_frameformat, uint32_t i2s_mckout);
 /* enable I2S */
 void i2s_enable(uint32_t spi_periph);
 /* disable I2S */
@@ -312,24 +312,24 @@ void spi_nss_internal_high(uint32_t spi_periph);
 void spi_nss_internal_low(uint32_t spi_periph);
 
 /* SPI DMA functions */
-/* enable SPI DMA */
-void spi_dma_enable(uint32_t spi_periph,uint8_t spi_dma);
-/* disable SPI DMA */
-void spi_dma_disable(uint32_t spi_periph,uint8_t spi_dma);
+/* enable SPI DMA send or receive */
+void spi_dma_enable(uint32_t spi_periph, uint8_t spi_dma);
+/* diable SPI DMA send or receive */
+void spi_dma_disable(uint32_t spi_periph, uint8_t spi_dma);
 
 /* SPI/I2S transfer configure functions */
 /* configure SPI/I2S data frame format */
-void spi_i2s_data_frame_format_config(uint32_t spi_periph,uint16_t frame_format);
+void spi_i2s_data_frame_format_config(uint32_t spi_periph, uint16_t frame_format);
 /* SPI transmit data */
-void spi_i2s_data_transmit(uint32_t spi_periph,uint16_t data);
+void spi_i2s_data_transmit(uint32_t spi_periph, uint16_t data);
 /* SPI receive data */
 uint16_t spi_i2s_data_receive(uint32_t spi_periph);
 /* configure SPI bidirectional transfer direction  */
-void spi_bidirectional_transfer_config(uint32_t spi_periph,uint32_t transfer_direction);
+void spi_bidirectional_transfer_config(uint32_t spi_periph, uint32_t transfer_direction);
 
 /* SPI CRC functions */
 /* set SPI CRC polynomial */
-void spi_crc_polynomial_set(uint32_t spi_periph,uint16_t crc_poly);
+void spi_crc_polynomial_set(uint32_t spi_periph, uint16_t crc_poly);
 /* get SPI CRC polynomial */
 uint16_t spi_crc_polynomial_get(uint32_t spi_periph);
 /* turn on SPI CRC function */
@@ -339,7 +339,7 @@ void spi_crc_off(uint32_t spi_periph);
 /* SPI next data is CRC value */
 void spi_crc_next(uint32_t spi_periph);
 /* get SPI CRC send value or receive value */
-uint16_t spi_crc_get(uint32_t spi_periph,uint8_t spi_crc);
+uint16_t spi_crc_get(uint32_t spi_periph, uint8_t spi_crc);
 
 /* SPI TI mode functions */
 /* enable SPI TI mode */
@@ -348,7 +348,7 @@ void spi_ti_mode_enable(uint32_t spi_periph);
 void spi_ti_mode_disable(uint32_t spi_periph);
 
 /* configure i2s full duplex mode */
-void i2s_full_duplex_mode_config(uint32_t i2s_add_periph,uint32_t i2s_mode,uint32_t i2s_standard,uint32_t i2s_ckpl,uint32_t i2s_frameformat);
+void i2s_full_duplex_mode_config(uint32_t i2s_add_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl, uint32_t i2s_frameformat);
 
 /* quad wire SPI functions */
 /* enable quad wire SPI */
@@ -359,20 +359,20 @@ void qspi_disable(uint32_t spi_periph);
 void qspi_write_enable(uint32_t spi_periph);
 /* enable quad wire SPI read */
 void qspi_read_enable(uint32_t spi_periph);
-/* enable quad wire SPI_IO2 and SPI_IO3 pin output */
+/* enable SPI_IO2 and SPI_IO3 pin output */
 void qspi_io23_output_enable(uint32_t spi_periph);
-/* disable quad wire SPI_IO2 and SPI_IO3 pin output */
+/* disable SPI_IO2 and SPI_IO3 pin output */
 void qspi_io23_output_disable(uint32_t spi_periph);
 
 /* flag & interrupt functions */
-/* enable SPI interrupt */
-void spi_i2s_interrupt_enable(uint32_t spi_periph,uint8_t spi_i2s_int);
-/* disable SPI interrupt */
-void spi_i2s_interrupt_disable(uint32_t spi_periph,uint8_t spi_i2s_int);
+/* enable SPI and I2S interrupt */
+void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int);
+/* disable SPI and I2S interrupt */
+void spi_i2s_interrupt_disable(uint32_t spi_periph, uint8_t spi_i2s_int);
 /* get SPI and I2S interrupt status*/
-FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph,uint8_t spi_i2s_int);
+FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int);
 /* get SPI and I2S flag status */
-FlagStatus spi_i2s_flag_get(uint32_t spi_periph,uint32_t spi_i2s_flag);
+FlagStatus spi_i2s_flag_get(uint32_t spi_periph, uint32_t spi_i2s_flag);
 /* clear SPI CRC error flag status */
 void spi_crc_error_clear(uint32_t spi_periph);
 

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_syscfg.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_syscfg.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_timer.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_timer.h
@@ -622,7 +622,7 @@ void timer_deinit(uint32_t timer_periph);
 /* initialize TIMER init parameter struct */
 void timer_struct_para_init(timer_parameter_struct* initpara);
 /* initialize TIMER counter */
-void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
+void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
 /* enable a TIMER */
 void timer_enable(uint32_t timer_periph);
 /* disable a TIMER */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_timer.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_timer.h
@@ -5,11 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
-    All rights reserved.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -341,8 +341,6 @@ typedef struct
 #define TIMER_INT_FLAG_TRG                  TIMER_INTF_TRGIF                        /*!< trigger interrupt flag */
 #define TIMER_INT_FLAG_BRK                  TIMER_INTF_BRKIF
 
-
-
 /* TIMER DMA source enable */
 #define TIMER_DMA_UPD                       ((uint16_t)TIMER_DMAINTEN_UPDEN)        /*!< update DMA enable */
 #define TIMER_DMA_CH0D                      ((uint16_t)TIMER_DMAINTEN_CH0DEN)       /*!< channel 0 DMA enable */
@@ -418,8 +416,8 @@ typedef struct
 #define TIMER_COUNTER_CENTER_BOTH           CTL0_CAM(3)                             /*!< center-aligned and counting up/down assert mode */
 
 /* TIMER prescaler reload mode */
-#define TIMER_PSC_RELOAD_NOW                ((uint32_t)0x00000000U)                        /*!< the prescaler is loaded right now */
-#define TIMER_PSC_RELOAD_UPDATE             ((uint32_t)0x00000001U)                        /*!< the prescaler is loaded at the next update event */
+#define TIMER_PSC_RELOAD_NOW                ((uint32_t)0x00000000U)                 /*!< the prescaler is loaded right now */
+#define TIMER_PSC_RELOAD_UPDATE             ((uint32_t)0x00000001U)                 /*!< the prescaler is loaded at the next update event */
 
 /* count direction */
 #define TIMER_COUNTER_UP                    ((uint16_t)0x0000U)                     /*!< counter up direction */
@@ -432,12 +430,12 @@ typedef struct
 #define TIMER_CKDIV_DIV4                    CTL0_CKDIV(2)                           /*!< clock division value is 4, fDTS= fTIMER_CK/4 */
 
 /* single pulse mode */
-#define TIMER_SP_MODE_SINGLE                ((uint32_t)0x00000000U)                        /*!< single pulse mode */
-#define TIMER_SP_MODE_REPETITIVE            ((uint32_t)0x00000001U)                        /*!< repetitive pulse mode */
+#define TIMER_SP_MODE_SINGLE                ((uint32_t)0x00000000U)                 /*!< single pulse mode */
+#define TIMER_SP_MODE_REPETITIVE            ((uint32_t)0x00000001U)                 /*!< repetitive pulse mode */
 
 /* update source */
-#define TIMER_UPDATE_SRC_REGULAR            ((uint32_t)0x00000000U)                        /*!< update generate only by counter overflow/underflow */
-#define TIMER_UPDATE_SRC_GLOBAL             ((uint32_t)0x00000001U)                        /*!< update generate by setting of UPG bit or the counter overflow/underflow,or the slave mode controller trigger */
+#define TIMER_UPDATE_SRC_REGULAR            ((uint32_t)0x00000000U)                 /*!< update generate only by counter overflow/underflow */
+#define TIMER_UPDATE_SRC_GLOBAL             ((uint32_t)0x00000001U)                 /*!< update generate by setting of UPG bit or the counter overflow/underflow,or the slave mode controller trigger */
 
 /* run mode off-state configure */
 #define TIMER_ROS_STATE_ENABLE              ((uint16_t)TIMER_CCHP_ROS)              /*!< when POEN bit is set, the channel output signals (CHx_O/CHx_ON) are enabled, with relationship to CHxEN/CHxNEN bits */
@@ -539,7 +537,7 @@ typedef struct
 #define TIMER_IC_PSC_DIV8                   ((uint16_t)0x000CU)                     /*!< divided by 8 */
 
 /* trigger selection */
-#define SMCFG_TRGSEL(regval)                (BITS(4, 6) & ((uint32_t)(regval) << 4U))
+#define SMCFG_TRGSEL(regval)                 (BITS(4, 6) & ((uint32_t)(regval) << 4U))
 #define TIMER_SMCFG_TRGSEL_ITI0              SMCFG_TRGSEL(0)                        /*!< internal trigger 0 */
 #define TIMER_SMCFG_TRGSEL_ITI1              SMCFG_TRGSEL(1)                        /*!< internal trigger 1 */
 #define TIMER_SMCFG_TRGSEL_ITI2              SMCFG_TRGSEL(2)                        /*!< internal trigger 2 */
@@ -572,8 +570,8 @@ typedef struct
 #define TIMER_SLAVE_MODE_EXTERNAL0          SMCFG_SMC(7)                            /*!< external clock mode 0 */
 
 /* master slave mode selection */ 
-#define TIMER_MASTER_SLAVE_MODE_ENABLE      ((uint32_t)0x00000000U)                        /*!< master slave mode enable */
-#define TIMER_MASTER_SLAVE_MODE_DISABLE     ((uint32_t)0x00000001U)                        /*!< master slave mode disable */
+#define TIMER_MASTER_SLAVE_MODE_ENABLE      ((uint32_t)0x00000000U)                 /*!< master slave mode enable */
+#define TIMER_MASTER_SLAVE_MODE_DISABLE     ((uint32_t)0x00000001U)                 /*!< master slave mode disable */
 
 /* external trigger prescaler */
 #define SMCFG_ETPSC(regval)                 (BITS(12, 13) & ((uint32_t)(regval) << 12U))
@@ -587,8 +585,8 @@ typedef struct
 #define TIMER_ETP_RISING                    ((uint32_t)0x00000000U)                 /*!< active high or rising edge active */
 
 /* channel 0 trigger input selection */ 
-#define TIMER_HALLINTERFACE_ENABLE          ((uint32_t)0x00000000U)                        /*!< TIMER hall sensor mode enable */
-#define TIMER_HALLINTERFACE_DISABLE         ((uint32_t)0x00000001U)                        /*!< TIMER hall sensor mode disable */
+#define TIMER_HALLINTERFACE_ENABLE          ((uint32_t)0x00000000U)                 /*!< TIMER hall sensor mode enable */
+#define TIMER_HALLINTERFACE_DISABLE         ((uint32_t)0x00000001U)                 /*!< TIMER hall sensor mode disable */
 
 /* timer1 internal trigger input1 remap */
 #define TIMER1_IRMP(regval)                 (BITS(10, 11) & ((uint32_t)(regval) << 10U))       
@@ -610,8 +608,8 @@ typedef struct
 #define TIMER10_ITI1_RMP_RTC_HXTAL_DIV      TIMER10_IRMP(2)                         /*!< timer10 internal trigger input1 remap  HXTAL _DIV(clock used for RTC which is HXTAL clock divided by RTCDIV bits in RCU_CFG0 register) */
 
 /* timerx(x=0,1,2,13,14,15,16) write cc register selection */
-#define TIMER_CHVSEL_ENABLE                  ((uint16_t)0x0002U)                     /*!< write CHxVAL register selection enable  */
-#define TIMER_CHVSEL_DISABLE                 ((uint16_t)0x0000U)                     /*!< write CHxVAL register selection disable */
+#define TIMER_CHVSEL_ENABLE                  ((uint16_t)0x0002U)                    /*!< write CHxVAL register selection enable  */
+#define TIMER_CHVSEL_DISABLE                 ((uint16_t)0x0000U)                    /*!< write CHxVAL register selection disable */
 
 /* the output value selection */
 #define TIMER_OUTSEL_ENABLE                 ((uint16_t)0x0001U)                     /*!< output value selection enable */
@@ -624,7 +622,7 @@ void timer_deinit(uint32_t timer_periph);
 /* initialize TIMER init parameter struct */
 void timer_struct_para_init(timer_parameter_struct* initpara);
 /* initialize TIMER counter */
-void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
+void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
 /* enable a TIMER */
 void timer_enable(uint32_t timer_periph);
 /* disable a TIMER */
@@ -659,20 +657,6 @@ uint16_t timer_prescaler_read(uint32_t timer_periph);
 void timer_single_pulse_mode_config(uint32_t timer_periph, uint32_t spmode);
 /* configure TIMER update source */
 void timer_update_source_config(uint32_t timer_periph, uint32_t update);
-
-/* TIMER interrupt and flag*/
-/* enable the TIMER interrupt */
-void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt);
-/* disable the TIMER interrupt */
-void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt);
-/* get timer interrupt flag */
-FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt);
-/* clear TIMER interrupt flag */
-void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt);
-/* get TIMER flags */
-FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag);
-/* clear TIMER flags */
-void timer_flag_clear(uint32_t timer_periph, uint32_t flag);
 
 /* timer DMA and event*/
 /* enable the TIMER DMA */
@@ -777,5 +761,19 @@ void timer_channel_remap_config(uint32_t timer_periph,uint32_t remap);
 void timer_write_chxval_register_config(uint32_t timer_periph, uint16_t ccsel);
 /* configure TIMER output value selection */
 void timer_output_value_selection_config(uint32_t timer_periph, uint16_t outsel);
+
+/* TIMER interrupt and flag*/
+/* get TIMER flags */
+FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag);
+/* clear TIMER flags */
+void timer_flag_clear(uint32_t timer_periph, uint32_t flag);
+/* enable the TIMER interrupt */
+void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt);
+/* disable the TIMER interrupt */
+void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt);
+/* get timer interrupt flag */
+FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt);
+/* clear TIMER interrupt flag */
+void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt);
 
 #endif /* GD32F4XX_TIMER_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_tli.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_tli.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_tli.h
     \brief   definitions for the TLI
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -40,37 +41,37 @@ OF SUCH DAMAGE.
 #include "gd32f4xx.h"
 
 /* TLI definitions */
-#define TLI                               TLI_BASE               /*!< TLI base address */
+#define TLI                               TLI_BASE                          /*!< TLI base address */
 /* TLI layer definitions */
-#define LAYER0                            TLI_BASE               /*!< TLI layer0 base address */
-#define LAYER1                            (TLI_BASE+0x80)        /*!< TLI layer1 base address */
+#define LAYER0                            TLI_BASE                          /*!< TLI layer0 base address */
+#define LAYER1                            (TLI_BASE + 0x00000080U)          /*!< TLI layer1 base address */
 
 /* registers definitions */
-#define TLI_SPSZ                          REG32(TLI + 0x08U)          /*!< TLI synchronous pulse size register */
-#define TLI_BPSZ                          REG32(TLI + 0x0CU)          /*!< TLI back-porch size register */
-#define TLI_ASZ                           REG32(TLI + 0x10U)          /*!< TLI active size register */
-#define TLI_TSZ                           REG32(TLI + 0x14U)          /*!< TLI total size register */
-#define TLI_CTL                           REG32(TLI + 0x18U)          /*!< TLI control register */
-#define TLI_RL                            REG32(TLI + 0x24U)          /*!< TLI reload Layer register */
-#define TLI_BGC                           REG32(TLI + 0x2CU)          /*!< TLI background color register */
-#define TLI_INTEN                         REG32(TLI + 0x34U)          /*!< TLI interrupt enable register */
-#define TLI_INTF                          REG32(TLI + 0x38U)          /*!< TLI interrupt flag register */
-#define TLI_INTC                          REG32(TLI + 0x3CU)          /*!< TLI interrupt flag clear register */
-#define TLI_LM                            REG32(TLI + 0x40U)          /*!< TLI line mark register */
-#define TLI_CPPOS                         REG32(TLI + 0x44U)          /*!< TLI current pixel position register */
-#define TLI_STAT                          REG32(TLI + 0x48U)          /*!< TLI status register */
-#define TLI_LxCTL(layerx)                 REG32((layerx) + 0x84U)     /*!< TLI layer x control register */
-#define TLI_LxHPOS(layerx)                REG32((layerx) + 0x88U)     /*!< TLI layer x horizontal position parameters register */
-#define TLI_LxVPOS(layerx)                REG32((layerx) + 0x8CU)     /*!< TLI layer x vertical position parameters register */
-#define TLI_LxCKEY(layerx)                REG32((layerx) + 0x90U)     /*!< TLI layer x color key register */
-#define TLI_LxPPF(layerx)                 REG32((layerx) + 0x94U)     /*!< TLI layer x packeted pixel format register */
-#define TLI_LxSA(layerx)                  REG32((layerx) + 0x98U)     /*!< TLI layer x specified alpha register */
-#define TLI_LxDC(layerx)                  REG32((layerx) + 0x9CU)     /*!< TLI layer x default color register */
-#define TLI_LxBLEND(layerx)               REG32((layerx) + 0xA0U)     /*!< TLI layer x blending register */
-#define TLI_LxFBADDR(layerx)              REG32((layerx) + 0xACU)     /*!< TLI layer x frame base address register */
-#define TLI_LxFLLEN(layerx)               REG32((layerx) + 0xB0U)     /*!< TLI layer x frame line length register */
-#define TLI_LxFTLN(layerx)                REG32((layerx) + 0xB4U)     /*!< TLI layer x frame total line number register */
-#define TLI_LxLUT(layerx)                 REG32((layerx) + 0xC4U)     /*!< TLI layer x look up table register */
+#define TLI_SPSZ                          REG32(TLI + 0x00000008U)          /*!< TLI synchronous pulse size register */
+#define TLI_BPSZ                          REG32(TLI + 0x0000000CU)          /*!< TLI back-porch size register */
+#define TLI_ASZ                           REG32(TLI + 0x00000010U)          /*!< TLI active size register */
+#define TLI_TSZ                           REG32(TLI + 0x00000014U)          /*!< TLI total size register */
+#define TLI_CTL                           REG32(TLI + 0x00000018U)          /*!< TLI control register */
+#define TLI_RL                            REG32(TLI + 0x00000024U)          /*!< TLI reload Layer register */
+#define TLI_BGC                           REG32(TLI + 0x0000002CU)          /*!< TLI background color register */
+#define TLI_INTEN                         REG32(TLI + 0x00000034U)          /*!< TLI interrupt enable register */
+#define TLI_INTF                          REG32(TLI + 0x00000038U)          /*!< TLI interrupt flag register */
+#define TLI_INTC                          REG32(TLI + 0x0000003CU)          /*!< TLI interrupt flag clear register */
+#define TLI_LM                            REG32(TLI + 0x00000040U)          /*!< TLI line mark register */
+#define TLI_CPPOS                         REG32(TLI + 0x00000044U)          /*!< TLI current pixel position register */
+#define TLI_STAT                          REG32(TLI + 0x00000048U)          /*!< TLI status register */
+#define TLI_LxCTL(layerx)                 REG32((layerx) + 0x00000084U)     /*!< TLI layer x control register */
+#define TLI_LxHPOS(layerx)                REG32((layerx) + 0x00000088U)     /*!< TLI layer x horizontal position parameters register */
+#define TLI_LxVPOS(layerx)                REG32((layerx) + 0x0000008CU)     /*!< TLI layer x vertical position parameters register */
+#define TLI_LxCKEY(layerx)                REG32((layerx) + 0x00000090U)     /*!< TLI layer x color key register */
+#define TLI_LxPPF(layerx)                 REG32((layerx) + 0x00000094U)     /*!< TLI layer x packeted pixel format register */
+#define TLI_LxSA(layerx)                  REG32((layerx) + 0x00000098U)     /*!< TLI layer x specified alpha register */
+#define TLI_LxDC(layerx)                  REG32((layerx) + 0x0000009CU)     /*!< TLI layer x default color register */
+#define TLI_LxBLEND(layerx)               REG32((layerx) + 0x000000A0U)     /*!< TLI layer x blending register */
+#define TLI_LxFBADDR(layerx)              REG32((layerx) + 0x000000ACU)     /*!< TLI layer x frame base address register */
+#define TLI_LxFLLEN(layerx)               REG32((layerx) + 0x000000B0U)     /*!< TLI layer x frame line length register */
+#define TLI_LxFTLN(layerx)                REG32((layerx) + 0x000000B4U)     /*!< TLI layer x frame total line number register */
+#define TLI_LxLUT(layerx)                 REG32((layerx) + 0x000000C4U)     /*!< TLI layer x look up table register */
 
 /* bits definitions */
 /* TLI_SPSZ */
@@ -192,8 +193,7 @@ OF SUCH DAMAGE.
 
 /* constants definitions */
 /* TLI parameter struct definitions */
-typedef struct
-{   
+typedef struct {
     uint16_t synpsz_vpsz;                     /*!< size of the vertical synchronous pulse */
     uint16_t synpsz_hpsz;                     /*!< size of the horizontal synchronous pulse */
     uint16_t backpsz_vbpsz;                   /*!< size of the vertical back porch plus synchronous pulse */
@@ -209,11 +209,10 @@ typedef struct
     uint32_t signalpolarity_vs;               /*!< vertical pulse polarity selection */
     uint32_t signalpolarity_de;               /*!< data enable polarity selection */
     uint32_t signalpolarity_pixelck;          /*!< pixel clock polarity selection */
-}tli_parameter_struct; 
+} tli_parameter_struct;
 
 /* TLI layer parameter struct definitions */
-typedef struct
-{
+typedef struct {
     uint16_t layer_window_rightpos;           /*!< window right position */
     uint16_t layer_window_leftpos;            /*!< window left position */
     uint16_t layer_window_bottompos;          /*!< window bottom position */
@@ -230,29 +229,27 @@ typedef struct
     uint16_t layer_frame_buf_stride_offset;   /*!< frame buffer stride offset */
     uint16_t layer_frame_line_length;         /*!< frame line length */
     uint16_t layer_frame_total_line_number;   /*!< frame total line number */
-}tli_layer_parameter_struct; 
+} tli_layer_parameter_struct;
 
 /* TLI layer LUT parameter struct definitions */
-typedef struct
-{
+typedef struct {
     uint32_t layer_table_addr;                /*!< look up table write address */
     uint8_t layer_lut_channel_red;            /*!< red channel of a LUT entry */
     uint8_t layer_lut_channel_green;          /*!< green channel of a LUT entry */
     uint8_t layer_lut_channel_blue;           /*!< blue channel of a LUT entry */
-}tli_layer_lut_parameter_struct; 
+} tli_layer_lut_parameter_struct;
 
 /* packeted pixel format */
-typedef enum 
-{
-     LAYER_PPF_ARGB8888,                      /*!< layerx pixel format ARGB8888 */
-     LAYER_PPF_RGB888,                        /*!< layerx pixel format RGB888 */
-     LAYER_PPF_RGB565,                        /*!< layerx pixel format RGB565 */
-     LAYER_PPF_ARGB1555,                      /*!< layerx pixel format ARGB1555 */
-     LAYER_PPF_ARGB4444,                      /*!< layerx pixel format ARGB4444 */
-     LAYER_PPF_L8,                            /*!< layerx pixel format L8 */
-     LAYER_PPF_AL44,                          /*!< layerx pixel format AL44 */
-     LAYER_PPF_AL88                           /*!< layerx pixel format AL88 */
-}tli_layer_ppf_enum;
+typedef enum {
+    LAYER_PPF_ARGB8888,                      /*!< layerx pixel format ARGB8888 */
+    LAYER_PPF_RGB888,                        /*!< layerx pixel format RGB888 */
+    LAYER_PPF_RGB565,                        /*!< layerx pixel format RGB565 */
+    LAYER_PPF_ARGB1555,                      /*!< layerx pixel format ARGB1555 */
+    LAYER_PPF_ARGB4444,                      /*!< layerx pixel format ARGB4444 */
+    LAYER_PPF_L8,                            /*!< layerx pixel format L8 */
+    LAYER_PPF_AL44,                          /*!< layerx pixel format AL44 */
+    LAYER_PPF_AL88                           /*!< layerx pixel format AL88 */
+} tli_layer_ppf_enum;
 
 /* TLI flags */
 #define TLI_FLAG_VDE                   TLI_STAT_VDE                /*!< current VDE status */
@@ -314,7 +311,7 @@ typedef enum
 /* initialization functions, TLI enable or disable, TLI reload mode configuration */
 /* deinitialize TLI registers */
 void tli_deinit(void);
-/* initialize the parameters of TLI parameter structure with the default values, it is suggested 
+/* initialize the parameters of TLI parameter structure with the default values, it is suggested
   that call this function after a tli_parameter_struct structure is defined */
 void tli_struct_para_init(tli_parameter_struct *tli_struct);
 /* initialize TLI */
@@ -329,20 +326,20 @@ void tli_disable(void);
 void tli_reload_config(uint8_t reload_mod);
 
 /* TLI layer configuration functions */
-/* initialize the parameters of TLI layer structure with the default values, it is suggested 
+/* initialize the parameters of TLI layer structure with the default values, it is suggested
   that call this function after a tli_layer_parameter_struct structure is defined */
 void tli_layer_struct_para_init(tli_layer_parameter_struct *layer_struct);
 /* initialize TLI layer */
-void tli_layer_init(uint32_t layerx,tli_layer_parameter_struct *layer_struct);
+void tli_layer_init(uint32_t layerx, tli_layer_parameter_struct *layer_struct);
 /* reconfigure window position */
-void tli_layer_window_offset_modify(uint32_t layerx,uint16_t offset_x,uint16_t offset_y);
-/* initialize the parameters of TLI layer LUT structure with the default values, it is suggested 
+void tli_layer_window_offset_modify(uint32_t layerx, uint16_t offset_x, uint16_t offset_y);
+/* initialize the parameters of TLI layer LUT structure with the default values, it is suggested
   that call this function after a tli_layer_lut_parameter_struct structure is defined */
 void tli_lut_struct_para_init(tli_layer_lut_parameter_struct *lut_struct);
 /* initialize TLI layer LUT */
-void tli_lut_init(uint32_t layerx,tli_layer_lut_parameter_struct *lut_struct);
+void tli_lut_init(uint32_t layerx, tli_layer_lut_parameter_struct *lut_struct);
 /* initialize TLI layer color key */
-void tli_color_key_init(uint32_t layerx,uint8_t redkey,uint8_t greenkey,uint8_t bluekey);
+void tli_color_key_init(uint32_t layerx, uint8_t redkey, uint8_t greenkey, uint8_t bluekey);
 /* enable TLI layer */
 void tli_layer_enable(uint32_t layerx);
 /* disable TLI layer */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_trng.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_trng.h
@@ -5,10 +5,11 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_usart.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_usart.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_usart.h
     \brief   definitions for the USART
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -127,7 +128,7 @@ OF SUCH DAMAGE.
 /* USARTx_GP */
 #define USART_GP_PSC                  BITS(0,7)    /*!< prescaler value for dividing the system clock */
 #define USART_GP_GUAT                 BITS(8,15)   /*!< guard time value in smartcard mode */
- 
+
 /* USARTx_CTL3 */
 #define USART_CTL3_RTEN               BIT(0)       /*!< receiver timeout enable */
 #define USART_CTL3_SCRTNUM            BITS(1,3)    /*!< smartcard auto-retry number */
@@ -173,8 +174,7 @@ OF SUCH DAMAGE.
 #define USART_CHC_REG_OFFSET                0xC0U        /*!< CHC register offset */
 
 /* USART flags */
-typedef enum
-{
+typedef enum {
     /* flags in STAT0 register */
     USART_FLAG_CTS = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 9U),      /*!< CTS change flag */
     USART_FLAG_LBD = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 8U),      /*!< LIN break detected flag */
@@ -192,11 +192,10 @@ typedef enum
     USART_FLAG_RT = USART_REGIDX_BIT(USART_STAT1_REG_OFFSET, 11U),      /*!< receiver timeout flag */
     /* flags in CHC register */
     USART_FLAG_EPERR = USART_REGIDX_BIT(USART_CHC_REG_OFFSET, 8U),      /*!< early parity error flag */
-}usart_flag_enum;
+} usart_flag_enum;
 
 /* USART interrupt flags */
-typedef enum
-{
+typedef enum {
     /* interrupt flags in CTL0 register */
     USART_INT_FLAG_PERR = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 8U, USART_STAT0_REG_OFFSET, 0U),       /*!< parity error interrupt and flag */
     USART_INT_FLAG_TBE = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 7U, USART_STAT0_REG_OFFSET, 7U),        /*!< transmitter buffer empty interrupt and flag */
@@ -214,11 +213,10 @@ typedef enum
     /* interrupt flags in CTL3 register */
     USART_INT_FLAG_EB = USART_REGIDX_BIT2(USART_CTL3_REG_OFFSET, 5U, USART_STAT1_REG_OFFSET, 12U),        /*!< interrupt enable bit of end of block event and flag */
     USART_INT_FLAG_RT = USART_REGIDX_BIT2(USART_CTL3_REG_OFFSET, 4U, USART_STAT1_REG_OFFSET, 11U),        /*!< interrupt enable bit of receive timeout event and flag */
-}usart_interrupt_flag_enum;
+} usart_interrupt_flag_enum;
 
 /* USART interrupt flags */
-typedef enum
-{
+typedef enum {
     /* interrupt in CTL0 register */
     USART_INT_PERR = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 8U),      /*!< parity error interrupt */
     USART_INT_TBE = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 7U),       /*!< transmitter buffer empty interrupt */
@@ -233,11 +231,10 @@ typedef enum
     /* interrupt in CTL3 register */
     USART_INT_EB = USART_REGIDX_BIT(USART_CTL3_REG_OFFSET, 5U),        /*!< interrupt enable bit of end of block event */
     USART_INT_RT = USART_REGIDX_BIT(USART_CTL3_REG_OFFSET, 4U),        /*!< interrupt enable bit of receive timeout event */
-}usart_interrupt_enum;
+} usart_interrupt_enum;
 
 /* USART invert configure */
-typedef enum
-{
+typedef enum {
     /* data bit level inversion */
     USART_DINV_ENABLE,                             /*!< data bit level inversion */
     USART_DINV_DISABLE,                            /*!< data bit level not inversion */
@@ -247,7 +244,7 @@ typedef enum
     /* RX pin level inversion */
     USART_RXPIN_ENABLE,                            /*!< RX pin level inversion */
     USART_RXPIN_DISABLE,                           /*!< RX pin level not inversion */
-}usart_invert_enum;
+} usart_invert_enum;
 
 /* USART receiver configure */
 #define CTL0_REN(regval)              (BIT(2) & ((uint32_t)(regval) << 2))
@@ -492,4 +489,4 @@ FlagStatus usart_interrupt_flag_get(uint32_t usart_periph, usart_interrupt_flag_
 /* clear interrupt flag in STAT0/STAT1 register */
 void usart_interrupt_flag_clear(uint32_t usart_periph, usart_interrupt_flag_enum int_flag);
 
-#endif /* GD32F4XX_USART_H */ 
+#endif /* GD32F4XX_USART_H */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_wwdgt.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_wwdgt.h
@@ -1,14 +1,15 @@
 /*!
     \file    gd32f4xx_wwdgt.h
     \brief   definitions for the WWDGT 
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -78,11 +79,11 @@ void wwdgt_counter_update(uint16_t counter_value);
 /* configure counter value, window value, and prescaler divider value */
 void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler);
 
-/* enable early wakeup interrupt of WWDGT */
-void wwdgt_interrupt_enable(void);
 /* check early wakeup interrupt state of WWDGT */
 FlagStatus wwdgt_flag_get(void);
 /* clear early wakeup interrupt state of WWDGT */
 void wwdgt_flag_clear(void);
+/* enable early wakeup interrupt of WWDGT */
+void wwdgt_interrupt_enable(void);
 
 #endif /* GD32F4XX_WWDGT_H */

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_adc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_adc.c
@@ -1,43 +1,44 @@
 /*!
     \file    gd32f4xx_adc.c
     \brief   ADC driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_adc.h"
 
-#define REGULAR_TRIGGER_MODE                      ((uint32_t)28U)
-#define INSERTED_TRIGGER_MODE                     ((uint32_t)20U)
+#define REGULAR_TRIGGER_MODE                        ((uint32_t)28U)
+#define INSERTED_TRIGGER_MODE                       ((uint32_t)20U)
 /* discontinuous mode macro*/
 #define  ADC_CHANNEL_LENGTH_SUBTRACT_ONE            ((uint8_t)1U)
 
@@ -73,9 +74,9 @@ void adc_deinit(void)
 }
 
 /*!
-    \brief    configure the ADC clock for all the ADCs
-    \param[in]  prescaler: configure ADCs prescaler ratio
-                only one parameter can be selected which is shown as below:
+    \brief        configure the ADC clock for all the ADCs
+    \param[in]    prescaler: configure ADCs prescaler ratio
+                  only one parameter can be selected which is shown as below:
       \arg        ADC_ADCCK_PCLK2_DIV2: PCLK2 div2
       \arg        ADC_ADCCK_PCLK2_DIV4: PCLK2 div4
       \arg        ADC_ADCCK_PCLK2_DIV6: PCLK2 div6
@@ -84,8 +85,8 @@ void adc_deinit(void)
       \arg        ADC_ADCCK_HCLK_DIV6: HCLK div6
       \arg        ADC_ADCCK_HCLK_DIV10: HCLK div10
       \arg        ADC_ADCCK_HCLK_DIV20: HCLK div20
-    \param[out] none
-    \retval     none
+    \param[out]   none
+    \retval       none
 */
 void adc_clock_config(uint32_t prescaler)
 {
@@ -94,88 +95,88 @@ void adc_clock_config(uint32_t prescaler)
 }
 
 /*!
-    \brief    enable or disable ADC special function
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  function: the function to config
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_SCAN_MODE: scan mode select
-      \arg        ADC_INSERTED_CHANNEL_AUTO: inserted channel group convert automatically
-      \arg        ADC_CONTINUOUS_MODE: continuous mode select
-    \param[in]  newvalue: ENABLE or DISABLE
-    \param[out] none
-    \retval     none
+    \brief        enable or disable ADC special function
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    function: the function to config
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_SCAN_MODE: scan mode select
+    \arg          ADC_INSERTED_CHANNEL_AUTO: inserted channel group convert automatically
+    \arg          ADC_CONTINUOUS_MODE: continuous mode select
+    \param[in]    newvalue: ENABLE or DISABLE
+    \param[out]   none
+    \retval       none
 */
-void adc_special_function_config(uint32_t adc_periph , uint32_t function , ControlStatus newvalue)
+void adc_special_function_config(uint32_t adc_periph, uint32_t function, ControlStatus newvalue)
 {
-    if(newvalue){
-        if(0U != (function & ADC_SCAN_MODE)){
+    if(newvalue) {
+        if(0U != (function & ADC_SCAN_MODE)) {
             /* enable scan mode */
             ADC_CTL0(adc_periph) |= ADC_SCAN_MODE;
         }
-        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)){
+        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)) {
             /* enable inserted channel group convert automatically */
             ADC_CTL0(adc_periph) |= ADC_INSERTED_CHANNEL_AUTO;
-        } 
-        if(0U != (function & ADC_CONTINUOUS_MODE)){
+        }
+        if(0U != (function & ADC_CONTINUOUS_MODE)) {
             /* enable continuous mode */
             ADC_CTL1(adc_periph) |= ADC_CONTINUOUS_MODE;
-        }        
-    }else{
-        if(0U != (function & ADC_SCAN_MODE)){
+        }
+    } else {
+        if(0U != (function & ADC_SCAN_MODE)) {
             /* disable scan mode */
             ADC_CTL0(adc_periph) &= ~ADC_SCAN_MODE;
         }
-        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)){
+        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)) {
             /* disable inserted channel group convert automatically */
             ADC_CTL0(adc_periph) &= ~ADC_INSERTED_CHANNEL_AUTO;
-        } 
-        if(0U != (function & ADC_CONTINUOUS_MODE)){
+        }
+        if(0U != (function & ADC_CONTINUOUS_MODE)) {
             /* disable continuous mode */
             ADC_CTL1(adc_periph) &= ~ADC_CONTINUOUS_MODE;
-        }       
+        }
     }
 }
 
 /*!
-    \brief    configure ADC data alignment 
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  data_alignment: data alignment select
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_DATAALIGN_RIGHT: LSB alignment
-      \arg        ADC_DATAALIGN_LEFT: MSB alignment
-    \param[out] none
-    \retval     none
+    \brief        configure ADC data alignment
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    data_alignment: data alignment select
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_DATAALIGN_RIGHT: LSB alignment
+    \arg          ADC_DATAALIGN_LEFT: MSB alignment
+    \param[out]   none
+    \retval       none
 */
-void adc_data_alignment_config(uint32_t adc_periph , uint32_t data_alignment)
+void adc_data_alignment_config(uint32_t adc_periph, uint32_t data_alignment)
 {
-    if(ADC_DATAALIGN_RIGHT != data_alignment){
+    if(ADC_DATAALIGN_RIGHT != data_alignment) {
         /* MSB alignment */
         ADC_CTL1(adc_periph) |= ADC_CTL1_DAL;
-    }else{
+    } else {
         /* LSB alignment */
         ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_DAL);
     }
 }
 
 /*!
-    \brief    enable ADC interface
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        enable ADC interface
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_enable(uint32_t adc_periph)
 {
-    if(RESET == (ADC_CTL1(adc_periph) & ADC_CTL1_ADCON)){
+    if(RESET == (ADC_CTL1(adc_periph) & ADC_CTL1_ADCON)) {
         /* enable ADC */
         ADC_CTL1(adc_periph) |= (uint32_t)ADC_CTL1_ADCON;
-    }       
+    }
 }
 
 /*!
-    \brief    disable ADC interface
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        disable ADC interface
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_disable(uint32_t adc_periph)
 {
@@ -184,112 +185,112 @@ void adc_disable(uint32_t adc_periph)
 }
 
 /*!
-    \brief    ADC calibration and reset calibration
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        ADC calibration and reset calibration
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_calibration_enable(uint32_t adc_periph)
 {
     /* reset the selected ADC calibration registers */
     ADC_CTL1(adc_periph) |= (uint32_t) ADC_CTL1_RSTCLB;
     /* check the RSTCLB bit state */
-    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_RSTCLB)){
+    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_RSTCLB)) {
     }
     /* enable ADC calibration process */
     ADC_CTL1(adc_periph) |= ADC_CTL1_CLB;
     /* check the CLB bit state */
-    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_CLB)){
+    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_CLB)) {
     }
 }
 
 /*!
-    \brief    configure temperature sensor and internal reference voltage channel or VBAT channel function
-    \param[in]  function: temperature sensor and internal reference voltage channel or VBAT channel
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_VBAT_CHANNEL_SWITCH: channel 18 (1/4 voltate of external battery) switch of ADC0
-      \arg        ADC_TEMP_VREF_CHANNEL_SWITCH: channel 16 (temperature sensor) and 17 (internal reference voltage) switch of ADC0
-    \param[in]  newvalue: ENABLE or DISABLE
-\param[out] none
-    \retval     none
+    \brief        configure temperature sensor and internal reference voltage channel or VBAT channel function
+    \param[in]    function: temperature sensor and internal reference voltage channel or VBAT channel
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_VBAT_CHANNEL_SWITCH: channel 18 (1/4 voltate of external battery) switch of ADC0
+    \arg          ADC_TEMP_VREF_CHANNEL_SWITCH: channel 16 (temperature sensor) and 17 (internal reference voltage) switch of ADC0
+    \param[in]    newvalue: ENABLE or DISABLE
+    \param[out]   none
+    \retval       none
 */
 void adc_channel_16_to_18(uint32_t function, ControlStatus newvalue)
 {
-    if(newvalue){
-        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)){
+    if(newvalue) {
+        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)) {
             /* enable ADC0 Vbat channel */
             ADC_SYNCCTL |= ADC_VBAT_CHANNEL_SWITCH;
         }
-        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)){
+        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)) {
             /* enable ADC0 Vref and Temperature channel */
             ADC_SYNCCTL |= ADC_TEMP_VREF_CHANNEL_SWITCH;
-        }      
-    }else{
-        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)){
+        }
+    } else {
+        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)) {
             /* disable ADC0 Vbat channel  */
             ADC_SYNCCTL &= ~ADC_VBAT_CHANNEL_SWITCH;
         }
-        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)){
+        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)) {
             /* disable ADC0 Vref and Temperature channel */
             ADC_SYNCCTL &= ~ADC_TEMP_VREF_CHANNEL_SWITCH;
-        } 
+        }
     }
 }
 
 /*!
-    \brief    configure ADC resolution
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  resolution: ADC resolution
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_RESOLUTION_12B: 12-bit ADC resolution
-      \arg        ADC_RESOLUTION_10B: 10-bit ADC resolution
-      \arg        ADC_RESOLUTION_8B: 8-bit ADC resolution
-      \arg        ADC_RESOLUTION_6B: 6-bit ADC resolution
-    \param[out] none
-    \retval     none
+    \brief        configure ADC resolution
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    resolution: ADC resolution
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_RESOLUTION_12B: 12-bit ADC resolution
+    \arg          ADC_RESOLUTION_10B: 10-bit ADC resolution
+    \arg          ADC_RESOLUTION_8B: 8-bit ADC resolution
+    \arg          ADC_RESOLUTION_6B: 6-bit ADC resolution
+    \param[out]   none
+    \retval       none
 */
-void adc_resolution_config(uint32_t adc_periph , uint32_t resolution)
+void adc_resolution_config(uint32_t adc_periph, uint32_t resolution)
 {
     ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_DRES);
     ADC_CTL0(adc_periph) |= (uint32_t)resolution;
 }
 
 /*!
-    \brief    configure ADC oversample mode
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  mode: ADC oversampling mode
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_OVERSAMPLING_ALL_CONVERT: all oversampled conversions for a channel are done consecutively after a trigger
-      \arg        ADC_OVERSAMPLING_ONE_CONVERT: each oversampled conversion for a channel needs a trigger
-    \param[in]  shift: ADC oversampling shift
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_OVERSAMPLING_SHIFT_NONE: no oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_1B: 1-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_2B: 2-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_3B: 3-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_4B: 3-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_5B: 5-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_6B: 6-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_7B: 7-bit oversampling shift
-      \arg        ADC_OVERSAMPLING_SHIFT_8B: 8-bit oversampling shift
-    \param[in]  ratio: ADC oversampling ratio
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_OVERSAMPLING_RATIO_MUL2: oversampling ratio multiple 2
-      \arg        ADC_OVERSAMPLING_RATIO_MUL4: oversampling ratio multiple 4
-      \arg        ADC_OVERSAMPLING_RATIO_MUL8: oversampling ratio multiple 8
-      \arg        ADC_OVERSAMPLING_RATIO_MUL16: oversampling ratio multiple 16
-      \arg        ADC_OVERSAMPLING_RATIO_MUL32: oversampling ratio multiple 32
-      \arg        ADC_OVERSAMPLING_RATIO_MUL64: oversampling ratio multiple 64
-      \arg        ADC_OVERSAMPLING_RATIO_MUL128: oversampling ratio multiple 128
-      \arg        ADC_OVERSAMPLING_RATIO_MUL256: oversampling ratio multiple 256
-    \param[out] none
-    \retval     none
+    \brief        configure ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    mode: ADC oversampling mode
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_ALL_CONVERT: all oversampled conversions for a channel are done consecutively after a trigger
+    \arg          ADC_OVERSAMPLING_ONE_CONVERT: each oversampled conversion for a channel needs a trigger
+    \param[in]    shift: ADC oversampling shift
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_SHIFT_NONE: no oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_1B: 1-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_2B: 2-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_3B: 3-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_4B: 3-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_5B: 5-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_6B: 6-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_7B: 7-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_8B: 8-bit oversampling shift
+    \param[in]    ratio: ADC oversampling ratio
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_RATIO_MUL2: oversampling ratio multiple 2
+    \arg          ADC_OVERSAMPLING_RATIO_MUL4: oversampling ratio multiple 4
+    \arg          ADC_OVERSAMPLING_RATIO_MUL8: oversampling ratio multiple 8
+    \arg          ADC_OVERSAMPLING_RATIO_MUL16: oversampling ratio multiple 16
+    \arg          ADC_OVERSAMPLING_RATIO_MUL32: oversampling ratio multiple 32
+    \arg          ADC_OVERSAMPLING_RATIO_MUL64: oversampling ratio multiple 64
+    \arg          ADC_OVERSAMPLING_RATIO_MUL128: oversampling ratio multiple 128
+    \arg          ADC_OVERSAMPLING_RATIO_MUL256: oversampling ratio multiple 256
+    \param[out]   none
+    \retval       none
 */
-void adc_oversample_mode_config(uint32_t adc_periph , uint32_t mode , uint16_t shift , uint8_t ratio)
+void adc_oversample_mode_config(uint32_t adc_periph, uint32_t mode, uint16_t shift, uint8_t ratio)
 {
-    if(ADC_OVERSAMPLING_ONE_CONVERT == mode){
+    if(ADC_OVERSAMPLING_ONE_CONVERT == mode) {
         ADC_OVSAMPCTL(adc_periph) |= (uint32_t)ADC_OVSAMPCTL_TOVS;
-    }else{
+    } else {
         ADC_OVSAMPCTL(adc_periph) &= ~((uint32_t)ADC_OVSAMPCTL_TOVS);
     }
     /* config the shift and ratio */
@@ -298,10 +299,10 @@ void adc_oversample_mode_config(uint32_t adc_periph , uint32_t mode , uint16_t s
 }
 
 /*!
-    \brief    enable ADC oversample mode
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        enable ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_oversample_mode_enable(uint32_t adc_periph)
 {
@@ -309,10 +310,10 @@ void adc_oversample_mode_enable(uint32_t adc_periph)
 }
 
 /*!
-    \brief    disable ADC oversample mode
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        disable ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_oversample_mode_disable(uint32_t adc_periph)
 {
@@ -320,10 +321,10 @@ void adc_oversample_mode_disable(uint32_t adc_periph)
 }
 
 /*!
-    \brief    enable DMA request
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[out] none
-    \retval     none
+    \brief        enable DMA request
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
 */
 void adc_dma_mode_enable(uint32_t adc_periph)
 {
@@ -332,7 +333,7 @@ void adc_dma_mode_enable(uint32_t adc_periph)
 }
 
 /*!
-    \brief    disable DMA request
+    \brief      disable DMA request
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[out] none
     \retval     none
@@ -366,27 +367,27 @@ void adc_dma_request_after_last_disable(uint32_t adc_periph)
 }
 
 /*!
-    \brief    configure ADC discontinuous mode
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  adc_channel_group: select the channel group
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
-      \arg        ADC_CHANNEL_DISCON_DISABLE: disable discontinuous mode of regular & inserted channel
-    \param[in]  length: number of conversions in discontinuous mode,the number can be 1..8
-                        for regular channel ,the number has no effect for inserted channel
-    \param[out] none
-    \retval     none
+    \brief        configure ADC discontinuous mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    adc_channel_group: select the channel group
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_REGULAR_CHANNEL: regular channel group
+    \arg          ADC_INSERTED_CHANNEL: inserted channel group
+    \arg          ADC_CHANNEL_DISCON_DISABLE: disable discontinuous mode of regular & inserted channel
+    \param[in]    length: number of conversions in discontinuous mode,the number can be 1..8
+                  for regular channel ,the number has no effect for inserted channel
+    \param[out]   none
+    \retval       none
 */
-void adc_discontinuous_mode_config(uint32_t adc_periph , uint8_t adc_channel_group , uint8_t length)
+void adc_discontinuous_mode_config(uint32_t adc_periph, uint8_t adc_channel_group, uint8_t length)
 {
     /* disable discontinuous mode of regular & inserted channel */
-    ADC_CTL0(adc_periph) &= ~((uint32_t)( ADC_CTL0_DISRC | ADC_CTL0_DISIC ));
-    switch(adc_channel_group){
+    ADC_CTL0(adc_periph) &= ~((uint32_t)(ADC_CTL0_DISRC | ADC_CTL0_DISIC));
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
         /* config the number of conversions in discontinuous mode  */
         ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_DISNUM);
-        if((length <= 8U) && (length >= 1U)){
+        if((length <= 8U) && (length >= 1U)) {
             ADC_CTL0(adc_periph) |= CTL0_DISNUM(((uint32_t)length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
         }
         /* enable regular channel group discontinuous mode */
@@ -397,38 +398,38 @@ void adc_discontinuous_mode_config(uint32_t adc_periph , uint8_t adc_channel_gro
         ADC_CTL0(adc_periph) |= (uint32_t)ADC_CTL0_DISIC;
         break;
     case ADC_CHANNEL_DISCON_DISABLE:
-        /* disable discontinuous mode of regular & inserted channel */
+    /* disable discontinuous mode of regular & inserted channel */
     default:
         break;
     }
 }
 
 /*!
-    \brief    configure the length of regular channel group or inserted channel group
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  adc_channel_group: select the channel group
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
-    \param[in]  length: the length of the channel
-                        regular channel 1-16
-                        inserted channel 1-4
-    \param[out] none
-    \retval     none
+    \brief        configure the length of regular channel group or inserted channel group
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    adc_channel_group: select the channel group
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_REGULAR_CHANNEL: regular channel group
+    \arg          ADC_INSERTED_CHANNEL: inserted channel group
+    \param[in]    length: the length of the channel
+                  regular channel 1-16
+                  inserted channel 1-4
+    \param[out]   none
+    \retval       none
 */
-void adc_channel_length_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t length)
+void adc_channel_length_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t length)
 {
-    switch(adc_channel_group){
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
-        if((length >= 1U) && (length <= 16U)){
-        ADC_RSQ0(adc_periph) &= ~((uint32_t)ADC_RSQ0_RL);
-        ADC_RSQ0(adc_periph) |= RSQ0_RL((uint32_t)(length-ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
+        if((length >= 1U) && (length <= 16U)) {
+            ADC_RSQ0(adc_periph) &= ~((uint32_t)ADC_RSQ0_RL);
+            ADC_RSQ0(adc_periph) |= RSQ0_RL((uint32_t)(length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
         }
         break;
     case ADC_INSERTED_CHANNEL:
-        if((length >= 1U) && (length <= 4U)){
-        ADC_ISQ(adc_periph) &= ~((uint32_t)ADC_ISQ_IL);
-        ADC_ISQ(adc_periph) |= ISQ_IL((uint32_t)(length-ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
+        if((length >= 1U) && (length <= 4U)) {
+            ADC_ISQ(adc_periph) &= ~((uint32_t)ADC_ISQ_IL);
+            ADC_ISQ(adc_periph) |= ISQ_IL((uint32_t)(length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
         }
         break;
     default:
@@ -437,70 +438,70 @@ void adc_channel_length_config(uint32_t adc_periph , uint8_t adc_channel_group ,
 }
 
 /*!
-    \brief    configure ADC regular channel
-    \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  rank: the regular group sequencer rank,this parameter must be between 0 to 15
-    \param[in]  adc_channel: the selected ADC channel
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_CHANNEL_x(x=0..18): ADC Channelx
-    \param[in]  sample_time: the sample time value
-                only one parameter can be selected which is shown as below:
-      \arg        ADC_SAMPLETIME_3: 3 cycles
-      \arg        ADC_SAMPLETIME_15: 15 cycles
-      \arg        ADC_SAMPLETIME_28: 28 cycles
-      \arg        ADC_SAMPLETIME_56: 56 cycles
-      \arg        ADC_SAMPLETIME_84: 84 cycles
-      \arg        ADC_SAMPLETIME_112: 112 cycles
-      \arg        ADC_SAMPLETIME_144: 144 cycles
-      \arg        ADC_SAMPLETIME_480: 480 cycles
-    \param[out] none
-    \retval     none
+    \brief        configure ADC regular channel
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    rank: the regular group sequencer rank,this parameter must be between 0 to 15
+    \param[in]    adc_channel: the selected ADC channel
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_CHANNEL_x(x=0..18): ADC Channelx
+    \param[in]    sample_time: the sample time value
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_SAMPLETIME_3: 3 cycles
+    \arg          ADC_SAMPLETIME_15: 15 cycles
+    \arg          ADC_SAMPLETIME_28: 28 cycles
+    \arg          ADC_SAMPLETIME_56: 56 cycles
+    \arg          ADC_SAMPLETIME_84: 84 cycles
+    \arg          ADC_SAMPLETIME_112: 112 cycles
+    \arg          ADC_SAMPLETIME_144: 144 cycles
+    \arg          ADC_SAMPLETIME_480: 480 cycles
+    \param[out]   none
+    \retval       none
 */
-void adc_regular_channel_config(uint32_t adc_periph , uint8_t rank , uint8_t adc_channel , uint32_t sample_time)
+void adc_regular_channel_config(uint32_t adc_periph, uint8_t rank, uint8_t adc_channel, uint32_t sample_time)
 {
-    uint32_t rsq,sampt;
-    
+    uint32_t rsq, sampt;
+
     /* ADC regular sequence config */
-    if(rank < ADC_REGULAR_CHANNEL_RANK_SIX){
+    if(rank < ADC_REGULAR_CHANNEL_RANK_SIX) {
         /* the regular group sequence rank is smaller than six */
         rsq = ADC_RSQ2(adc_periph);
-        rsq &=  ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH*rank)));
+        rsq &=  ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * rank)));
         /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
-        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH*rank));
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * rank));
         ADC_RSQ2(adc_periph) = rsq;
-    }else if(rank < ADC_REGULAR_CHANNEL_RANK_TWELVE){
+    } else if(rank < ADC_REGULAR_CHANNEL_RANK_TWELVE) {
         /* the regular group sequence rank is smaller than twelve */
         rsq = ADC_RSQ1(adc_periph);
-        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH*(rank-ADC_REGULAR_CHANNEL_RANK_SIX))));
+        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_SIX))));
         /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
-        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH*(rank-ADC_REGULAR_CHANNEL_RANK_SIX)));
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_SIX)));
         ADC_RSQ1(adc_periph) = rsq;
-    }else if(rank < ADC_REGULAR_CHANNEL_RANK_SIXTEEN){
+    } else if(rank < ADC_REGULAR_CHANNEL_RANK_SIXTEEN) {
         /* the regular group sequence rank is smaller than sixteen */
         rsq = ADC_RSQ0(adc_periph);
-        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH*(rank-ADC_REGULAR_CHANNEL_RANK_TWELVE))));
+        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_TWELVE))));
         /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
-        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH*(rank-ADC_REGULAR_CHANNEL_RANK_TWELVE)));
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_TWELVE)));
         ADC_RSQ0(adc_periph) = rsq;
-    }else{
+    } else {
     }
-    
+
     /* ADC sampling time config */
-    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN){
+    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN) {
         /* the regular group sequence rank is smaller than ten */
         sampt = ADC_SAMPT1(adc_periph);
-        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH*adc_channel)));
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel)));
         /* channel sample time set*/
-        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH*adc_channel));
+        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel));
         ADC_SAMPT1(adc_periph) = sampt;
-    }else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN){
+    } else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN) {
         /* the regular group sequence rank is smaller than eighteen */
         sampt = ADC_SAMPT0(adc_periph);
-        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH*(adc_channel-ADC_CHANNEL_SAMPLE_TEN))));
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN))));
         /* channel sample time set*/
-        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH*(adc_channel-ADC_CHANNEL_SAMPLE_TEN)));
+        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN)));
         ADC_SAMPT0(adc_periph) = sampt;
-    }else{
+    } else {
     }
 }
 
@@ -510,76 +511,76 @@ void adc_regular_channel_config(uint32_t adc_periph , uint8_t rank , uint8_t adc
     \param[in]  rank: the inserted group sequencer rank,this parameter must be between 0 to 3
     \param[in]  adc_channel: the selected ADC channel
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_CHANNEL_x(x=0..18): ADC Channelx
+    \arg        ADC_CHANNEL_x(x=0..18): ADC Channelx
     \param[in]  sample_time: The sample time value
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_SAMPLETIME_3: 3 cycles
-      \arg        ADC_SAMPLETIME_15: 15 cycles
-      \arg        ADC_SAMPLETIME_28: 28 cycles
-      \arg        ADC_SAMPLETIME_56: 56 cycles
-      \arg        ADC_SAMPLETIME_84: 84 cycles
-      \arg        ADC_SAMPLETIME_112: 112 cycles
-      \arg        ADC_SAMPLETIME_144: 144 cycles
-      \arg        ADC_SAMPLETIME_480: 480 cycles
+    \arg        ADC_SAMPLETIME_3: 3 cycles
+    \arg        ADC_SAMPLETIME_15: 15 cycles
+    \arg        ADC_SAMPLETIME_28: 28 cycles
+    \arg        ADC_SAMPLETIME_56: 56 cycles
+    \arg        ADC_SAMPLETIME_84: 84 cycles
+    \arg        ADC_SAMPLETIME_112: 112 cycles
+    \arg        ADC_SAMPLETIME_144: 144 cycles
+    \arg        ADC_SAMPLETIME_480: 480 cycles
     \param[out] none
     \retval     none
 */
-void adc_inserted_channel_config(uint32_t adc_periph , uint8_t rank , uint8_t adc_channel , uint32_t sample_time)
+void adc_inserted_channel_config(uint32_t adc_periph, uint8_t rank, uint8_t adc_channel, uint32_t sample_time)
 {
     uint8_t inserted_length;
-    uint32_t isq,sampt;
+    uint32_t isq, sampt;
 
     /* get inserted channel group length */
-    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph) , 20U , 21U);
-     /* the channel number is written to these bits to select a channel as the nth conversion in the inserted channel group */
-    if(rank < 4U){
+    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph), 20U, 21U);
+    /* the channel number is written to these bits to select a channel as the nth conversion in the inserted channel group */
+    if(rank < 4U) {
         isq = ADC_ISQ(adc_periph);
-        isq &= ~((uint32_t)(ADC_ISQ_ISQN << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH-(inserted_length-rank)*ADC_INSERTED_CHANNEL_RANK_LENGTH)));
-        isq |= ((uint32_t)adc_channel << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH-(inserted_length-rank)*ADC_INSERTED_CHANNEL_RANK_LENGTH));
+        isq &= ~((uint32_t)(ADC_ISQ_ISQN << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH - (inserted_length - rank) * ADC_INSERTED_CHANNEL_RANK_LENGTH)));
+        isq |= ((uint32_t)adc_channel << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH - (inserted_length - rank) * ADC_INSERTED_CHANNEL_RANK_LENGTH));
         ADC_ISQ(adc_periph) = isq;
     }
 
     /* ADC sampling time config */
-    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN){
+    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN) {
         /* the inserted group sequence rank is smaller than ten */
         sampt = ADC_SAMPT1(adc_periph);
-        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH*adc_channel)));
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel)));
         /* channel sample time set*/
-        sampt |= (uint32_t) sample_time << (ADC_CHANNEL_SAMPLE_LENGTH*adc_channel);
+        sampt |= (uint32_t) sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel);
         ADC_SAMPT1(adc_periph) = sampt;
-    }else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN){
+    } else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN) {
         /* the inserted group sequence rank is smaller than eighteen */
         sampt = ADC_SAMPT0(adc_periph);
-        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH*(adc_channel - ADC_CHANNEL_SAMPLE_TEN))));
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN))));
         /* channel sample time set*/
-        sampt |= ((uint32_t)sample_time << (ADC_CHANNEL_SAMPLE_LENGTH*(adc_channel - ADC_CHANNEL_SAMPLE_TEN)));
+        sampt |= ((uint32_t)sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN)));
         ADC_SAMPT0(adc_periph) = sampt;
-    }else{
+    } else {
     }
 }
 
 /*!
-    \brief    configure ADC inserted channel offset
+    \brief      configure ADC inserted channel offset
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  inserted_channel : insert channel select
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INSERTED_CHANNEL_0: inserted channel0
-      \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
-      \arg        ADC_INSERTED_CHANNEL_2: inserted channel2
-      \arg        ADC_INSERTED_CHANNEL_3: inserted channel3
+    \arg        ADC_INSERTED_CHANNEL_0: inserted channel0
+    \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
+    \arg        ADC_INSERTED_CHANNEL_2: inserted channel2
+    \arg        ADC_INSERTED_CHANNEL_3: inserted channel3
     \param[in]  offset : the offset data
     \param[out] none
     \retval     none
 */
-void adc_inserted_channel_offset_config(uint32_t adc_periph , uint8_t inserted_channel , uint16_t offset)
+void adc_inserted_channel_offset_config(uint32_t adc_periph, uint8_t inserted_channel, uint16_t offset)
 {
     uint8_t inserted_length;
     uint32_t num = 0U;
 
-    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph) , 20U , 21U);
+    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph), 20U, 21U);
     num = ((uint32_t)ADC_OFFSET_LENGTH - ((uint32_t)inserted_length - (uint32_t)inserted_channel));
-    
-    if(num <= ADC_OFFSET_LENGTH){
+
+    if(num <= ADC_OFFSET_LENGTH) {
         /* calculate the offset of the register */
         num = num * ADC_OFFSET_SHIFT_LENGTH;
         /* config the offset of the selected channels */
@@ -588,55 +589,55 @@ void adc_inserted_channel_offset_config(uint32_t adc_periph , uint8_t inserted_c
 }
 
 /*!
-    \brief    configure ADC external trigger source
+    \brief      configure ADC external trigger source
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_channel_group: select the channel group
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
     \param[in]  external_trigger_source: regular or inserted group trigger source
                 for regular channel:
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_EXTTRIG_REGULAR_T0_CH0: external trigger timer 0 CC0 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T0_CH1: external trigger timer 0 CC1 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T0_CH2: external trigger timer 0 CC2 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T1_CH1: external trigger timer 1 CC1 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T1_CH2: external trigger timer 1 CC2 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T1_CH3: external trigger timer 1 CC3 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T1_TRGO: external trigger timer 1 TRGO event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T2_CH0 : external trigger timer 2 CC0 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T2_TRGO : external trigger timer 2 TRGO event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T3_CH3: external trigger timer 3 CC3 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T4_CH0: external trigger timer 4 CC0 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T4_CH1: external trigger timer 4 CC1 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T4_CH2: external trigger timer 4 CC2 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T7_CH0: external trigger timer 7 CC0 event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_T7_TRGO: external trigger timer 7 TRGO event select for regular channel 
-      \arg        ADC_EXTTRIG_REGULAR_EXTI_11: external trigger extiline 11 select for regular channel 
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH0: external trigger timer 0 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH1: external trigger timer 0 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH2: external trigger timer 0 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH1: external trigger timer 1 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH2: external trigger timer 1 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH3: external trigger timer 1 CC3 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_TRGO: external trigger timer 1 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T2_CH0 : external trigger timer 2 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T2_TRGO : external trigger timer 2 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T3_CH3: external trigger timer 3 CC3 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH0: external trigger timer 4 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH1: external trigger timer 4 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH2: external trigger timer 4 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T7_CH0: external trigger timer 7 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T7_TRGO: external trigger timer 7 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_EXTI_11: external trigger extiline 11 select for regular channel
                 for inserted channel:
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_EXTTRIG_INSERTED_T0_CH3: timer0 capture compare 3 
-      \arg        ADC_EXTTRIG_INSERTED_T0_TRGO: timer0 TRGO event 
-      \arg        ADC_EXTTRIG_INSERTED_T1_CH0: timer1 capture compare 0 
-      \arg        ADC_EXTTRIG_INSERTED_T1_TRGO: timer1 TRGO event 
-      \arg        ADC_EXTTRIG_INSERTED_T2_CH1: timer2 capture compare 1 
-      \arg        ADC_EXTTRIG_INSERTED_T2_CH3: timer2 capture compare 3 
-      \arg        ADC_EXTTRIG_INSERTED_T3_CH0: timer3 capture compare 0 
-      \arg        ADC_EXTTRIG_INSERTED_T3_CH1: timer3 capture compare 1 
-      \arg        ADC_EXTTRIG_INSERTED_T3_CH2: timer3 capture compare 2 
-      \arg        ADC_EXTTRIG_INSERTED_T3_TRGO: timer3 capture compare TRGO 
-      \arg        ADC_EXTTRIG_INSERTED_T4_CH3: timer4 capture compare 3 
-      \arg        ADC_EXTTRIG_INSERTED_T4_TRGO: timer4 capture compare TRGO 
-      \arg        ADC_EXTTRIG_INSERTED_T7_CH1: timer7 capture compare 1 
-      \arg        ADC_EXTTRIG_INSERTED_T7_CH2: timer7 capture compare 2 
-      \arg        ADC_EXTTRIG_INSERTED_T7_CH3: timer7 capture compare 3 
-      \arg        ADC_EXTTRIG_INSERTED_EXTI_15: external interrupt line 15 
+    \arg        ADC_EXTTRIG_INSERTED_T0_CH3: timer0 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T0_TRGO: timer0 TRGO event
+    \arg        ADC_EXTTRIG_INSERTED_T1_CH0: timer1 capture compare 0
+    \arg        ADC_EXTTRIG_INSERTED_T1_TRGO: timer1 TRGO event
+    \arg        ADC_EXTTRIG_INSERTED_T2_CH1: timer2 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T2_CH3: timer2 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH0: timer3 capture compare 0
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH1: timer3 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH2: timer3 capture compare 2
+    \arg        ADC_EXTTRIG_INSERTED_T3_TRGO: timer3 capture compare TRGO
+    \arg        ADC_EXTTRIG_INSERTED_T4_CH3: timer4 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T4_TRGO: timer4 capture compare TRGO
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH1: timer7 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH2: timer7 capture compare 2
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH3: timer7 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_EXTI_15: external interrupt line 15
     \param[out] none
     \retval     none
 */
-void adc_external_trigger_source_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t external_trigger_source)
-{   
-    switch(adc_channel_group){
+void adc_external_trigger_source_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t external_trigger_source)
+{
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
         /* configure ADC regular group external trigger source */
         ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETSRC);
@@ -653,52 +654,52 @@ void adc_external_trigger_source_config(uint32_t adc_periph , uint8_t adc_channe
 }
 
 /*!
-    \brief    enable ADC external trigger
+    \brief      enable ADC external trigger
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_channel_group: select the channel group
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
     \param[in]  trigger_mode: external trigger mode
                 only one parameter can be selected which is shown as below:
-      \arg        EXTERNAL_TRIGGER_DISABLE: external trigger disable
-      \arg        EXTERNAL_TRIGGER_RISING: rising edge of external trigger
-      \arg        EXTERNAL_TRIGGER_FALLING: falling edge of external trigger
-      \arg        EXTERNAL_TRIGGER_RISING_FALLING: rising and falling edge of external trigger
+    \arg        EXTERNAL_TRIGGER_DISABLE: external trigger disable
+    \arg        EXTERNAL_TRIGGER_RISING: rising edge of external trigger
+    \arg        EXTERNAL_TRIGGER_FALLING: falling edge of external trigger
+    \arg        EXTERNAL_TRIGGER_RISING_FALLING: rising and falling edge of external trigger
     \param[out] none
     \retval     none
 */
-void adc_external_trigger_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t trigger_mode)
+void adc_external_trigger_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t trigger_mode)
 {
-        switch(adc_channel_group){
-        case ADC_REGULAR_CHANNEL:
-            /* configure ADC regular channel group external trigger mode */
-            ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETMRC);
-            ADC_CTL1(adc_periph) |= (uint32_t) (trigger_mode << REGULAR_TRIGGER_MODE);
-            break;
-        case ADC_INSERTED_CHANNEL:
-            /* configure ADC inserted channel group external trigger mode */
-            ADC_CTL1(adc_periph) &=  ~((uint32_t)ADC_CTL1_ETMIC);
-            ADC_CTL1(adc_periph) |= (uint32_t) (trigger_mode << INSERTED_TRIGGER_MODE);
-            break;
-        default:
-            break;
-        }
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* configure ADC regular channel group external trigger mode */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETMRC);
+        ADC_CTL1(adc_periph) |= (uint32_t)(trigger_mode << REGULAR_TRIGGER_MODE);
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* configure ADC inserted channel group external trigger mode */
+        ADC_CTL1(adc_periph) &=  ~((uint32_t)ADC_CTL1_ETMIC);
+        ADC_CTL1(adc_periph) |= (uint32_t)(trigger_mode << INSERTED_TRIGGER_MODE);
+        break;
+    default:
+        break;
+    }
 }
 
 /*!
-    \brief    enable ADC software trigger
+    \brief      enable ADC software trigger
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_channel_group: select the channel group
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
     \param[out] none
     \retval     none
 */
-void adc_software_trigger_enable(uint32_t adc_periph , uint8_t adc_channel_group)
+void adc_software_trigger_enable(uint32_t adc_periph, uint8_t adc_channel_group)
 {
-    switch(adc_channel_group){
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
         /* enable ADC regular channel group software trigger */
         ADC_CTL1(adc_periph) |= (uint32_t)ADC_CTL1_SWRCST;
@@ -713,33 +714,33 @@ void adc_software_trigger_enable(uint32_t adc_periph , uint8_t adc_channel_group
 }
 
 /*!
-    \brief    configure end of conversion mode
+    \brief      configure end of conversion mode
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  end_selection: end of conversion mode
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_EOC_SET_SEQUENCE: only at the end of a sequence of regular conversions, the EOC bit is set.Overflow detection is disabled unless DMA=1.
-      \arg        ADC_EOC_SET_CONVERSION: at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically.
+    \arg        ADC_EOC_SET_SEQUENCE: only at the end of a sequence of regular conversions, the EOC bit is set.Overflow detection is disabled unless DMA=1.
+    \arg        ADC_EOC_SET_CONVERSION: at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically.
     \param[out] none
     \retval     none
 */
-void adc_end_of_conversion_config(uint32_t adc_periph , uint8_t end_selection)
+void adc_end_of_conversion_config(uint32_t adc_periph, uint8_t end_selection)
 {
-    switch(end_selection){
-        case ADC_EOC_SET_SEQUENCE:
-            /* only at the end of a sequence of regular conversions, the EOC bit is set */
-            ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_EOCM);
-            break;
-        case ADC_EOC_SET_CONVERSION:
-            /* at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically */
-            ADC_CTL1(adc_periph) |= (uint32_t)(ADC_CTL1_EOCM);
-            break;
-        default:
-            break;
+    switch(end_selection) {
+    case ADC_EOC_SET_SEQUENCE:
+        /* only at the end of a sequence of regular conversions, the EOC bit is set */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_EOCM);
+        break;
+    case ADC_EOC_SET_CONVERSION:
+        /* at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically */
+        ADC_CTL1(adc_periph) |= (uint32_t)(ADC_CTL1_EOCM);
+        break;
+    default:
+        break;
     }
 }
 
 /*!
-    \brief    read ADC regular group data register
+    \brief      read ADC regular group data register
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  none
     \param[out] none
@@ -751,22 +752,22 @@ uint16_t adc_regular_data_read(uint32_t adc_periph)
 }
 
 /*!
-    \brief    read ADC inserted group data register
+    \brief      read ADC inserted group data register
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  inserted_channel : insert channel select
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INSERTED_CHANNEL_0: inserted Channel0
-      \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
-      \arg        ADC_INSERTED_CHANNEL_2: inserted Channel2
-      \arg        ADC_INSERTED_CHANNEL_3: inserted Channel3
+    \arg        ADC_INSERTED_CHANNEL_0: inserted Channel0
+    \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
+    \arg        ADC_INSERTED_CHANNEL_2: inserted Channel2
+    \arg        ADC_INSERTED_CHANNEL_3: inserted Channel3
     \param[out] none
     \retval     the conversion value
 */
-uint16_t adc_inserted_data_read(uint32_t adc_periph , uint8_t inserted_channel)
+uint16_t adc_inserted_data_read(uint32_t adc_periph, uint8_t inserted_channel)
 {
     uint32_t idata;
     /* read the data of the selected channel */
-    switch(inserted_channel){
+    switch(inserted_channel) {
     case ADC_INSERTED_CHANNEL_0:
         /* read the data of channel 0 */
         idata = ADC_IDATA0(adc_periph);
@@ -791,26 +792,26 @@ uint16_t adc_inserted_data_read(uint32_t adc_periph , uint8_t inserted_channel)
 }
 
 /*!
-    \brief    disable ADC analog watchdog single channel
+    \brief      disable ADC analog watchdog single channel
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[out] none
     \retval     none
 */
-void adc_watchdog_single_channel_disable(uint32_t adc_periph )
+void adc_watchdog_single_channel_disable(uint32_t adc_periph)
 {
     ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDSC);
 }
 
 /*!
-    \brief    enable ADC analog watchdog single channel
+    \brief      enable ADC analog watchdog single channel
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_channel: the selected ADC channel
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_CHANNEL_x: ADC Channelx(x=0..18)
+    \arg        ADC_CHANNEL_x: ADC Channelx(x=0..18)
     \param[out] none
     \retval     none
 */
-void adc_watchdog_single_channel_enable(uint32_t adc_periph , uint8_t adc_channel)
+void adc_watchdog_single_channel_enable(uint32_t adc_periph, uint8_t adc_channel)
 {
     ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDCHSEL);
 
@@ -820,21 +821,21 @@ void adc_watchdog_single_channel_enable(uint32_t adc_periph , uint8_t adc_channe
 }
 
 /*!
-    \brief    configure ADC analog watchdog group channel
+    \brief      configure ADC analog watchdog group channel
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_channel_group: the channel group use analog watchdog
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
-      \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
     \param[out] none
     \retval     none
 */
-void adc_watchdog_group_channel_enable(uint32_t adc_periph , uint8_t adc_channel_group)
+void adc_watchdog_group_channel_enable(uint32_t adc_periph, uint8_t adc_channel_group)
 {
     ADC_CTL0(adc_periph) &= ~((uint32_t)(ADC_CTL0_RWDEN | ADC_CTL0_IWDEN | ADC_CTL0_WDSC));
     /* select the group */
-    switch(adc_channel_group){
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
         /* regular channel analog watchdog enable */
         ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_RWDEN;
@@ -853,20 +854,20 @@ void adc_watchdog_group_channel_enable(uint32_t adc_periph , uint8_t adc_channel
 }
 
 /*!
-    \brief    disable ADC analog watchdog
+    \brief      disable ADC analog watchdog
     \param[in]  adc_periph: ADCx,x=0,1,2
-    \param[in]  adc_channel_group: the channel group use analog watchdog 
+    \param[in]  adc_channel_group: the channel group use analog watchdog
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_REGULAR_CHANNEL: regular channel group
-      \arg        ADC_INSERTED_CHANNEL: inserted channel group
-      \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
     \param[out] none
     \retval     none
 */
-void adc_watchdog_disable(uint32_t adc_periph , uint8_t adc_channel_group)
+void adc_watchdog_disable(uint32_t adc_periph, uint8_t adc_channel_group)
 {
     /* select the group */
-    switch(adc_channel_group){
+    switch(adc_channel_group) {
     case ADC_REGULAR_CHANNEL:
         /* disable ADC analog watchdog regular channel group */
         ADC_CTL0(adc_periph) &=  ~((uint32_t)ADC_CTL0_RWDEN);
@@ -885,14 +886,14 @@ void adc_watchdog_disable(uint32_t adc_periph , uint8_t adc_channel_group)
 }
 
 /*!
-    \brief    configure ADC analog watchdog threshold
+    \brief      configure ADC analog watchdog threshold
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  low_threshold: analog watchdog low threshold,0..4095
     \param[in]  high_threshold: analog watchdog high threshold,0..4095
     \param[out] none
     \retval     none
 */
-void adc_watchdog_threshold_config(uint32_t adc_periph , uint16_t low_threshold , uint16_t high_threshold)
+void adc_watchdog_threshold_config(uint32_t adc_periph, uint16_t low_threshold, uint16_t high_threshold)
 {
     /* configure ADC analog watchdog low threshold */
     ADC_WDLT(adc_periph) = (uint32_t)WDLT_WDLT(low_threshold);
@@ -901,23 +902,23 @@ void adc_watchdog_threshold_config(uint32_t adc_periph , uint16_t low_threshold 
 }
 
 /*!
-    \brief    get the ADC flag bits
+    \brief      get the ADC flag bits
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_flag: the adc flag bits
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_FLAG_WDE: analog watchdog event flag
-      \arg        ADC_FLAG_EOC: end of group conversion flag
-      \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
-      \arg        ADC_FLAG_STIC: start flag of inserted channel group
-      \arg        ADC_FLAG_STRC: start flag of regular channel group
-      \arg        ADC_FLAG_ROVF: regular data register overflow flag
+    \arg        ADC_FLAG_WDE: analog watchdog event flag
+    \arg        ADC_FLAG_EOC: end of group conversion flag
+    \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
+    \arg        ADC_FLAG_STIC: start flag of inserted channel group
+    \arg        ADC_FLAG_STRC: start flag of regular channel group
+    \arg        ADC_FLAG_ROVF: regular data register overflow flag
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
-FlagStatus adc_flag_get(uint32_t adc_periph , uint32_t adc_flag)
+FlagStatus adc_flag_get(uint32_t adc_periph, uint32_t adc_flag)
 {
     FlagStatus reval = RESET;
-    if(ADC_STAT(adc_periph) & adc_flag){
+    if(ADC_STAT(adc_periph) & adc_flag) {
         reval = SET;
     }
     return reval;
@@ -925,26 +926,26 @@ FlagStatus adc_flag_get(uint32_t adc_periph , uint32_t adc_flag)
 }
 
 /*!
-    \brief    clear the ADC flag bits
+    \brief      clear the ADC flag bits
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_flag: the adc flag bits
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_FLAG_WDE: analog watchdog event flag
-      \arg        ADC_FLAG_EOC: end of group conversion flag
-      \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
-      \arg        ADC_FLAG_STIC: start flag of inserted channel group
-      \arg        ADC_FLAG_STRC: start flag of regular channel group
-      \arg        ADC_FLAG_ROVF: regular data register overflow flag
+    \arg        ADC_FLAG_WDE: analog watchdog event flag
+    \arg        ADC_FLAG_EOC: end of group conversion flag
+    \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
+    \arg        ADC_FLAG_STIC: start flag of inserted channel group
+    \arg        ADC_FLAG_STRC: start flag of regular channel group
+    \arg        ADC_FLAG_ROVF: regular data register overflow flag
     \param[out] none
     \retval     none
 */
-void adc_flag_clear(uint32_t adc_periph , uint32_t adc_flag)
+void adc_flag_clear(uint32_t adc_periph, uint32_t adc_flag)
 {
     ADC_STAT(adc_periph) &= ~((uint32_t)adc_flag);
 }
 
 /*!
-    \brief    get the bit state of ADCx software start conversion
+    \brief      get the bit state of ADCx software start conversion
     \param[in]  adc_periph: ADCx, x=0,1,2 only one among these parameters can be selected
     \param[in]  none
     \param[out] none
@@ -953,14 +954,14 @@ void adc_flag_clear(uint32_t adc_periph , uint32_t adc_flag)
 FlagStatus adc_regular_software_startconv_flag_get(uint32_t adc_periph)
 {
     FlagStatus reval = RESET;
-    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STRC)){
+    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STRC)) {
         reval = SET;
     }
     return reval;
 }
 
 /*!
-    \brief    get the bit state of ADCx software inserted channel start conversion
+    \brief      get the bit state of ADCx software inserted channel start conversion
     \param[in]  adc_periph: ADCx, x=0,1,2 only one among these parameters can be selected
     \param[in]  none
     \param[out] none
@@ -969,56 +970,56 @@ FlagStatus adc_regular_software_startconv_flag_get(uint32_t adc_periph)
 FlagStatus adc_inserted_software_startconv_flag_get(uint32_t adc_periph)
 {
     FlagStatus reval = RESET;
-    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STIC)){
+    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STIC)) {
         reval = SET;
     }
     return reval;
 }
 
 /*!
-    \brief    get the ADC interrupt bits
+    \brief      get the ADC interrupt bits
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_interrupt: the adc interrupt bits
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
-      \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
-      \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
-      \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
+    \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
+    \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
+    \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
+    \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
-FlagStatus adc_interrupt_flag_get(uint32_t adc_periph , uint32_t adc_interrupt)
+FlagStatus adc_interrupt_flag_get(uint32_t adc_periph, uint32_t adc_interrupt)
 {
     FlagStatus interrupt_flag = RESET;
     uint32_t state;
     /* check the interrupt bits */
-    switch(adc_interrupt){
+    switch(adc_interrupt) {
     case ADC_INT_FLAG_WDE:
         /* get the ADC analog watchdog interrupt bits */
         state = ADC_STAT(adc_periph) & ADC_STAT_WDE;
-        if((ADC_CTL0(adc_periph) & ADC_CTL0_WDEIE) && state){
-          interrupt_flag = SET;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_WDEIE) && state) {
+            interrupt_flag = SET;
         }
         break;
     case ADC_INT_FLAG_EOC:
-         /* get the ADC end of group conversion interrupt bits */
+        /* get the ADC end of group conversion interrupt bits */
         state = ADC_STAT(adc_periph) & ADC_STAT_EOC;
-          if((ADC_CTL0(adc_periph) & ADC_CTL0_EOCIE) && state){
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_EOCIE) && state) {
             interrupt_flag = SET;
-          }
+        }
         break;
     case ADC_INT_FLAG_EOIC:
         /* get the ADC end of inserted group conversion interrupt bits */
         state = ADC_STAT(adc_periph) & ADC_STAT_EOIC;
-        if((ADC_CTL0(adc_periph) & ADC_CTL0_EOICIE) && state){
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_EOICIE) && state) {
             interrupt_flag = SET;
         }
         break;
     case ADC_INT_FLAG_ROVF:
         /* get the ADC regular data register overflow interrupt bits */
         state = ADC_STAT(adc_periph) & ADC_STAT_ROVF;
-        if((ADC_CTL0(adc_periph) & ADC_CTL0_ROVFIE) && state){
-          interrupt_flag = SET;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_ROVFIE) && state) {
+            interrupt_flag = SET;
         }
         break;
     default:
@@ -1028,37 +1029,37 @@ FlagStatus adc_interrupt_flag_get(uint32_t adc_periph , uint32_t adc_interrupt)
 }
 
 /*!
-    \brief    clear the ADC flag
+    \brief      clear the ADC flag
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_interrupt: the adc status flag
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
-      \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
-      \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
-      \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
+    \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
+    \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
+    \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
+    \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
     \param[out] none
     \retval     none
 */
-void adc_interrupt_flag_clear(uint32_t adc_periph , uint32_t adc_interrupt)
+void adc_interrupt_flag_clear(uint32_t adc_periph, uint32_t adc_interrupt)
 {
     ADC_STAT(adc_periph) &= ~((uint32_t)adc_interrupt);
 }
 
 /*!
-    \brief    enable ADC interrupt
+    \brief      enable ADC interrupt
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_interrupt: the adc interrupt flag
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INT_WDE: analog watchdog interrupt flag
-      \arg        ADC_INT_EOC: end of group conversion interrupt flag
-      \arg        ADC_INT_EOIC: end of inserted group conversion interrupt flag
-      \arg        ADC_INT_ROVF: regular data register overflow interrupt flag
+    \arg        ADC_INT_WDE: analog watchdog interrupt flag
+    \arg        ADC_INT_EOC: end of group conversion interrupt flag
+    \arg        ADC_INT_EOIC: end of inserted group conversion interrupt flag
+    \arg        ADC_INT_ROVF: regular data register overflow interrupt flag
     \param[out] none
     \retval     none
 */
-void adc_interrupt_enable(uint32_t adc_periph , uint32_t adc_interrupt)
+void adc_interrupt_enable(uint32_t adc_periph, uint32_t adc_interrupt)
 {
-    switch(adc_interrupt){
+    switch(adc_interrupt) {
     case ADC_INT_WDE:
         /* enable analog watchdog interrupt */
         ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_WDEIE;
@@ -1080,20 +1081,20 @@ void adc_interrupt_enable(uint32_t adc_periph , uint32_t adc_interrupt)
 }
 
 /*!
-    \brief    disable ADC interrupt
+    \brief      disable ADC interrupt
     \param[in]  adc_periph: ADCx,x=0,1,2
     \param[in]  adc_flag: the adc interrupt flag
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_INT_WDE: analog watchdog interrupt flag
-      \arg        ADC_INT_EOC: end of group conversion interrupt flag
-      \arg        ADC_INT_EOIC: end of inserted group conversion interrupt flag
-      \arg        ADC_INT_ROVF: regular data register overflow interrupt flag
+      \arg      ADC_INT_WDE: analog watchdog interrupt flag
+      \arg      ADC_INT_EOC: end of group conversion interrupt flag
+      \arg      ADC_INT_EOIC: end of inserted group conversion interrupt flag
+      \arg      ADC_INT_ROVF: regular data register overflow interrupt flag
     \param[out] none
     \retval     none
 */
-void adc_interrupt_disable(uint32_t adc_periph , uint32_t adc_interrupt)
+void adc_interrupt_disable(uint32_t adc_periph, uint32_t adc_interrupt)
 {
-    switch(adc_interrupt){
+    switch(adc_interrupt) {
     /* select the interrupt source */
     case ADC_INT_WDE:
         ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDEIE);
@@ -1113,22 +1114,22 @@ void adc_interrupt_disable(uint32_t adc_periph , uint32_t adc_interrupt)
 }
 
 /*!
-    \brief    configure the ADC sync mode
-    \param[in]  sync_mode: ADC sync mode 
+    \brief      configure the ADC sync mode
+    \param[in]  sync_mode: ADC sync mode
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_SYNC_MODE_INDEPENDENT: all the ADCs work independently
-      \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL: ADC0 and ADC1 work in combined regular parallel & inserted parallel mode
-      \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION: ADC0 and ADC1 work in combined regular parallel & trigger rotation mode
-      \arg        ADC_DAUL_INSERTED_PARALLEL: ADC0 and ADC1 work in inserted parallel mode
-      \arg        ADC_DAUL_REGULAL_PARALLEL: ADC0 and ADC1 work in regular parallel mode
-      \arg        ADC_DAUL_REGULAL_FOLLOW_UP: ADC0 and ADC1 work in follow-up mode
-      \arg        ADC_DAUL_INSERTED_TRRIGGER_ROTATION: ADC0 and ADC1 work in trigger rotation mode
-      \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_PARALLEL: all ADCs work in combined regular parallel & inserted parallel mode
-      \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_ROTATION: all ADCs work in combined regular parallel & trigger rotation mode
-      \arg        ADC_ALL_INSERTED_PARALLEL: all ADCs work in inserted parallel mode
-      \arg        ADC_ALL_REGULAL_PARALLEL: all ADCs work in regular parallel mode
-      \arg        ADC_ALL_REGULAL_FOLLOW_UP: all ADCs work in follow-up mode
-      \arg        ADC_ALL_INSERTED_TRRIGGER_ROTATION: all ADCs work in trigger rotation mode
+    \arg        ADC_SYNC_MODE_INDEPENDENT: all the ADCs work independently
+    \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL: ADC0 and ADC1 work in combined regular parallel & inserted parallel mode
+    \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION: ADC0 and ADC1 work in combined regular parallel & trigger rotation mode
+    \arg        ADC_DAUL_INSERTED_PARALLEL: ADC0 and ADC1 work in inserted parallel mode
+    \arg        ADC_DAUL_REGULAL_PARALLEL: ADC0 and ADC1 work in regular parallel mode
+    \arg        ADC_DAUL_REGULAL_FOLLOW_UP: ADC0 and ADC1 work in follow-up mode
+    \arg        ADC_DAUL_INSERTED_TRRIGGER_ROTATION: ADC0 and ADC1 work in trigger rotation mode
+    \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_PARALLEL: all ADCs work in combined regular parallel & inserted parallel mode
+    \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_ROTATION: all ADCs work in combined regular parallel & trigger rotation mode
+    \arg        ADC_ALL_INSERTED_PARALLEL: all ADCs work in inserted parallel mode
+    \arg        ADC_ALL_REGULAL_PARALLEL: all ADCs work in regular parallel mode
+    \arg        ADC_ALL_REGULAL_FOLLOW_UP: all ADCs work in follow-up mode
+    \arg        ADC_ALL_INSERTED_TRRIGGER_ROTATION: all ADCs work in trigger rotation mode
     \param[out] none
     \retval     none
 */
@@ -1139,10 +1140,10 @@ void adc_sync_mode_config(uint32_t sync_mode)
 }
 
 /*!
-    \brief    configure the delay between 2 sampling phases in ADC sync modes
-    \param[in]  sample_delay:  the delay between 2 sampling phases in ADC sync modes 
+    \brief      configure the delay between 2 sampling phases in ADC sync modes
+    \param[in]  sample_delay:  the delay between 2 sampling phases in ADC sync modes
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_SYNC_DELAY_xCYCLE: x=5..20,the delay between 2 sampling phases in ADC sync modes is x ADC clock cycles
+      \arg      ADC_SYNC_DELAY_xCYCLE: x=5..20,the delay between 2 sampling phases in ADC sync modes is x ADC clock cycles
     \param[out] none
     \retval     none
 */
@@ -1153,23 +1154,23 @@ void adc_sync_delay_config(uint32_t sample_delay)
 }
 
 /*!
-    \brief    configure ADC sync DMA mode selection
+    \brief      configure ADC sync DMA mode selection
     \param[in]  dma_mode:  ADC sync DMA mode
                 only one parameter can be selected which is shown as below:
-      \arg        ADC_SYNC_DMA_DISABLE: ADC sync DMA disabled
-      \arg        ADC_SYNC_DMA_MODE0: ADC sync DMA mode 0
-      \arg        ADC_SYNC_DMA_MODE1: ADC sync DMA mode 1
+    \arg        ADC_SYNC_DMA_DISABLE: ADC sync DMA disabled
+    \arg        ADC_SYNC_DMA_MODE0: ADC sync DMA mode 0
+    \arg        ADC_SYNC_DMA_MODE1: ADC sync DMA mode 1
     \param[out] none
     \retval     none
 */
-void adc_sync_dma_config(uint32_t dma_mode )
+void adc_sync_dma_config(uint32_t dma_mode)
 {
     ADC_SYNCCTL &= ~(ADC_SYNCCTL_SYNCDMA);
     ADC_SYNCCTL |= dma_mode;
 }
 
 /*!
-    \brief    configure ADC sync DMA engine is disabled after the end of transfer signal from DMA controller is detected
+    \brief      configure ADC sync DMA engine is disabled after the end of transfer signal from DMA controller is detected
     \param[in]  none
     \param[out] none
     \retval     none
@@ -1180,7 +1181,7 @@ void adc_sync_dma_request_after_last_enable(void)
 }
 
 /*!
-    \brief    configure ADC sync DMA engine issues requests according to the SYNCDMA bits
+    \brief      configure ADC sync DMA engine issues requests according to the SYNCDMA bits
     \param[in]  none
     \param[out] none
     \retval     none
@@ -1191,7 +1192,7 @@ void adc_sync_dma_request_after_last_disable(void)
 }
 
 /*!
-    \brief    read ADC sync regular data register
+    \brief      read ADC sync regular data register
     \param[in]  none
     \param[out] none
     \retval     sync regular data

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
@@ -1,38 +1,40 @@
 /*!
     \file    gd32f4xx_can.c
     \brief   CAN driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2019-11-27, V2.0.1, firmware for GD32F4xx
     \version 2020-07-14, V2.0.2, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2021-12-28, V2.1.1, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -41,7 +43,7 @@ OF SUCH DAMAGE.
 #define CAN_ERROR_HANDLE(s)     do{}while(1)
 
 /*!
-    \brief    deinitialize CAN 
+    \brief      deinitialize CAN
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -49,130 +51,129 @@ OF SUCH DAMAGE.
 */
 void can_deinit(uint32_t can_periph)
 {
-    if(CAN0 == can_periph){
+    if(CAN0 == can_periph) {
         rcu_periph_reset_enable(RCU_CAN0RST);
         rcu_periph_reset_disable(RCU_CAN0RST);
-    }else{
+    } else {
         rcu_periph_reset_enable(RCU_CAN1RST);
         rcu_periph_reset_disable(RCU_CAN1RST);
     }
 }
 
 /*!
-    \brief    initialize CAN parameter struct with a default value
-    \param[in]  type: the type of CAN parameter struct  
+    \brief      initialize CAN parameter struct with a default value
+    \param[in]  type: the type of CAN parameter struct
                 only one parameter can be selected which is shown as below:
       \arg        CAN_INIT_STRUCT: the CAN initial struct
       \arg        CAN_FILTER_STRUCT: the CAN filter struct
       \arg        CAN_TX_MESSAGE_STRUCT: the CAN TX message struct
       \arg        CAN_RX_MESSAGE_STRUCT: the CAN RX message struct
-    \param[in]  p_struct: the pointer of the specific struct 
-    \param[out] none
+    \param[out] p_struct: the pointer of the specific struct
     \retval     none
 */
-void can_struct_para_init(can_struct_type_enum type, void* p_struct)
+void can_struct_para_init(can_struct_type_enum type, void *p_struct)
 {
     uint8_t i;
-    
+
     /* get type of the struct */
-    switch(type){
-        /* used for can_init() */
-        case CAN_INIT_STRUCT:
-            ((can_parameter_struct*)p_struct)->auto_bus_off_recovery = DISABLE;
-            ((can_parameter_struct*)p_struct)->no_auto_retrans = DISABLE;
-            ((can_parameter_struct*)p_struct)->auto_wake_up = DISABLE;
-            ((can_parameter_struct*)p_struct)->prescaler = 0x03FFU; 
-            ((can_parameter_struct*)p_struct)->rec_fifo_overwrite = DISABLE; 
-            ((can_parameter_struct*)p_struct)->resync_jump_width = CAN_BT_SJW_1TQ;
-            ((can_parameter_struct*)p_struct)->time_segment_1 = CAN_BT_BS1_3TQ;
-            ((can_parameter_struct*)p_struct)->time_segment_2 = CAN_BT_BS2_1TQ;
-            ((can_parameter_struct*)p_struct)->time_triggered = DISABLE;
-            ((can_parameter_struct*)p_struct)->trans_fifo_order = DISABLE;
-            ((can_parameter_struct*)p_struct)->working_mode = GD32_CAN_NORMAL_MODE;
-            
-            break;
-        /* used for can_filter_init() */
-        case CAN_FILTER_STRUCT:
-            ((can_filter_parameter_struct*)p_struct)->filter_bits = CAN_FILTERBITS_32BIT;
-            ((can_filter_parameter_struct*)p_struct)->filter_enable = DISABLE;
-            ((can_filter_parameter_struct*)p_struct)->filter_fifo_number = CAN_FIFO0;
-            ((can_filter_parameter_struct*)p_struct)->filter_list_high = 0x0000U;
-            ((can_filter_parameter_struct*)p_struct)->filter_list_low = 0x0000U;
-            ((can_filter_parameter_struct*)p_struct)->filter_mask_high = 0x0000U;
-            ((can_filter_parameter_struct*)p_struct)->filter_mask_low = 0x0000U;
-            ((can_filter_parameter_struct*)p_struct)->filter_mode = CAN_FILTERMODE_MASK;
-            ((can_filter_parameter_struct*)p_struct)->filter_number = 0U;
+    switch(type) {
+    /* used for can_init() */
+    case CAN_INIT_STRUCT:
+        ((can_parameter_struct *)p_struct)->auto_bus_off_recovery = DISABLE;
+        ((can_parameter_struct *)p_struct)->auto_retrans = ENABLE;
+        ((can_parameter_struct *)p_struct)->auto_wake_up = DISABLE;
+        ((can_parameter_struct *)p_struct)->prescaler = 0x03FFU;
+        ((can_parameter_struct *)p_struct)->rec_fifo_overwrite = ENABLE;
+        ((can_parameter_struct *)p_struct)->resync_jump_width = CAN_BT_SJW_1TQ;
+        ((can_parameter_struct *)p_struct)->time_segment_1 = CAN_BT_BS1_3TQ;
+        ((can_parameter_struct *)p_struct)->time_segment_2 = CAN_BT_BS2_1TQ;
+        ((can_parameter_struct *)p_struct)->time_triggered = DISABLE;
+        ((can_parameter_struct *)p_struct)->trans_fifo_order = DISABLE;
+        ((can_parameter_struct *)p_struct)->working_mode = CAN_NORMAL_MODE;
 
-            break;
-        /* used for can_message_transmit() */
-        case CAN_TX_MESSAGE_STRUCT:
-            for(i = 0U; i < 8U; i++){
-                ((can_trasnmit_message_struct*)p_struct)->tx_data[i] = 0U;
-            }
-            
-            ((can_trasnmit_message_struct*)p_struct)->tx_dlen = 0u;
-            ((can_trasnmit_message_struct*)p_struct)->tx_efid = 0U;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_trasnmit_message_struct*)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_trasnmit_message_struct*)p_struct)->tx_sfid = 0U;
-            
-            break;
-        /* used for can_message_receive() */
-        case CAN_RX_MESSAGE_STRUCT:
-            for(i = 0U; i < 8U; i++){
-                ((can_receive_message_struct*)p_struct)->rx_data[i] = 0U;
-            }
-            
-            ((can_receive_message_struct*)p_struct)->rx_dlen = 0U;
-            ((can_receive_message_struct*)p_struct)->rx_efid = 0U;
-            ((can_receive_message_struct*)p_struct)->rx_ff = (uint8_t)CAN_FF_STANDARD;
-            ((can_receive_message_struct*)p_struct)->rx_fi = 0U;
-            ((can_receive_message_struct*)p_struct)->rx_ft = (uint8_t)CAN_FT_DATA;
-            ((can_receive_message_struct*)p_struct)->rx_sfid = 0U;
-            
-            break;
+        break;
+    /* used for can_filter_init() */
+    case CAN_FILTER_STRUCT:
+        ((can_filter_parameter_struct *)p_struct)->filter_bits = CAN_FILTERBITS_32BIT;
+        ((can_filter_parameter_struct *)p_struct)->filter_enable = DISABLE;
+        ((can_filter_parameter_struct *)p_struct)->filter_fifo_number = CAN_FIFO0;
+        ((can_filter_parameter_struct *)p_struct)->filter_list_high = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_list_low = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mask_high = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mask_low = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mode = CAN_FILTERMODE_MASK;
+        ((can_filter_parameter_struct *)p_struct)->filter_number = 0U;
 
-        default:
-            CAN_ERROR_HANDLE("parameter is invalid \r\n");
+        break;
+    /* used for can_message_transmit() */
+    case CAN_TX_MESSAGE_STRUCT:
+        for(i = 0U; i < 8U; i++) {
+            ((can_trasnmit_message_struct *)p_struct)->tx_data[i] = 0U;
+        }
+
+        ((can_trasnmit_message_struct *)p_struct)->tx_dlen = 0u;
+        ((can_trasnmit_message_struct *)p_struct)->tx_efid = 0U;
+        ((can_trasnmit_message_struct *)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+        ((can_trasnmit_message_struct *)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+        ((can_trasnmit_message_struct *)p_struct)->tx_sfid = 0U;
+
+        break;
+    /* used for can_message_receive() */
+    case CAN_RX_MESSAGE_STRUCT:
+        for(i = 0U; i < 8U; i++) {
+            ((can_receive_message_struct *)p_struct)->rx_data[i] = 0U;
+        }
+
+        ((can_receive_message_struct *)p_struct)->rx_dlen = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_efid = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_ff = (uint8_t)CAN_FF_STANDARD;
+        ((can_receive_message_struct *)p_struct)->rx_fi = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_ft = (uint8_t)CAN_FT_DATA;
+        ((can_receive_message_struct *)p_struct)->rx_sfid = 0U;
+
+        break;
+
+    default:
+        CAN_ERROR_HANDLE("parameter is invalid \r\n");
     }
 }
 
 /*!
-    \brief    initialize CAN
+    \brief      initialize CAN
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  can_parameter_init: parameters for CAN initializtion
-      \arg        working_mode: GD32_CAN_NORMAL_MODE, GD32_CAN_LOOPBACK_MODE, GD32_CAN_SILENT_MODE, GD32_CAN_SILENT_LOOPBACK_MODE
+      \arg        working_mode: CAN_NORMAL_MODE, CAN_LOOPBACK_MODE, CAN_SILENT_MODE, CAN_SILENT_LOOPBACK_MODE
       \arg        resync_jump_width: CAN_BT_SJW_xTQ(x=1, 2, 3, 4)
       \arg        time_segment_1: CAN_BT_BS1_xTQ(1..16)
       \arg        time_segment_2: CAN_BT_BS2_xTQ(1..8)
       \arg        time_triggered: ENABLE or DISABLE
       \arg        auto_bus_off_recovery: ENABLE or DISABLE
       \arg        auto_wake_up: ENABLE or DISABLE
-      \arg        no_auto_retrans: ENABLE or DISABLE
+      \arg        auto_retrans: ENABLE or DISABLE
       \arg        rec_fifo_overwrite: ENABLE or DISABLE
       \arg        trans_fifo_order: ENABLE or DISABLE
       \arg        prescaler: 0x0001 - 0x0400
     \param[out] none
     \retval     ErrStatus: SUCCESS or ERROR
 */
-ErrStatus can_init(uint32_t can_periph, can_parameter_struct* can_parameter_init)
+ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init)
 {
-    uint32_t timeout = GD32_CAN_TIMEOUT;
+    uint32_t timeout = CAN_TIMEOUT;
     ErrStatus flag = ERROR;
-    
+
     /* disable sleep mode */
     CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;
     /* enable initialize mode */
     CAN_CTL(can_periph) |= CAN_CTL_IWMOD;
     /* wait ACK */
-    while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
+    while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
         timeout--;
     }
     /* check initialize working success */
-    if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)){
+    if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) {
         flag = ERROR;
-    }else{
+    } else {
         /* set the bit timing register */
         CAN_BT(can_periph) = (BT_MODE((uint32_t)can_parameter_init->working_mode) | \
                               BT_SJW((uint32_t)can_parameter_init->resync_jump_width) | \
@@ -181,138 +182,138 @@ ErrStatus can_init(uint32_t can_periph, can_parameter_struct* can_parameter_init
                               BT_BAUDPSC(((uint32_t)(can_parameter_init->prescaler) - 1U)));
 
         /* time trigger communication mode */
-        if(ENABLE == can_parameter_init->time_triggered){
+        if(ENABLE == can_parameter_init->time_triggered) {
             CAN_CTL(can_periph) |= CAN_CTL_TTC;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_TTC;
         }
-        /* automatic bus-off managment */
-        if(ENABLE == can_parameter_init->auto_bus_off_recovery){
+        /* automatic bus-off management */
+        if(ENABLE == can_parameter_init->auto_bus_off_recovery) {
             CAN_CTL(can_periph) |= CAN_CTL_ABOR;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_ABOR;
         }
         /* automatic wakeup mode */
-        if(ENABLE == can_parameter_init->auto_wake_up){
+        if(ENABLE == can_parameter_init->auto_wake_up) {
             CAN_CTL(can_periph) |= CAN_CTL_AWU;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_AWU;
         }
-        /* automatic retransmission mode disable*/
-        if(ENABLE == can_parameter_init->no_auto_retrans){
+        /* automatic retransmission mode disable */
+        if(DISABLE == can_parameter_init->auto_retrans) {
             CAN_CTL(can_periph) |= CAN_CTL_ARD;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_ARD;
         }
-        /* receive fifo overwrite mode */        
-        if(ENABLE == can_parameter_init->rec_fifo_overwrite){
+        /* receive FIFO overwrite mode disable */
+        if(DISABLE == can_parameter_init->rec_fifo_overwrite) {
             CAN_CTL(can_periph) |= CAN_CTL_RFOD;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_RFOD;
-        } 
-        /* transmit fifo order */
-        if(ENABLE == can_parameter_init->trans_fifo_order){
+        }
+        /* transmit FIFO order */
+        if(ENABLE == can_parameter_init->trans_fifo_order) {
             CAN_CTL(can_periph) |= CAN_CTL_TFO;
-        }else{
+        } else {
             CAN_CTL(can_periph) &= ~CAN_CTL_TFO;
-        }  
+        }
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = GD32_CAN_TIMEOUT;
+        timeout = CAN_TIMEOUT;
         /* wait the ACK */
-        while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
+        while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
         }
         /* check exit initialize mode */
-        if(0U != timeout){
+        if(0U != timeout) {
             flag = SUCCESS;
         }
-    }  
+    }
     return flag;
 }
 
 /*!
-    \brief    initialize CAN filter 
+    \brief      initialize CAN filter
     \param[in]  can_filter_parameter_init: struct for CAN filter initialization
       \arg        filter_list_high: 0x0000 - 0xFFFF
       \arg        filter_list_low: 0x0000 - 0xFFFF
       \arg        filter_mask_high: 0x0000 - 0xFFFF
       \arg        filter_mask_low: 0x0000 - 0xFFFF
-      \arg        filter_fifo_number: CAN_FIFO0, CAN_FIFO1 
+      \arg        filter_fifo_number: CAN_FIFO0, CAN_FIFO1
       \arg        filter_number: 0 - 27
       \arg        filter_mode: CAN_FILTERMODE_MASK, CAN_FILTERMODE_LIST
-      \arg        filter_bits: CAN_FILTERBITS_32BIT, CAN_FILTERBITS_16BIT 
+      \arg        filter_bits: CAN_FILTERBITS_32BIT, CAN_FILTERBITS_16BIT
       \arg        filter_enable: ENABLE or DISABLE
     \param[out] none
     \retval     none
 */
-void can_filter_init(can_filter_parameter_struct* can_filter_parameter_init)
+void can_filter_init(can_filter_parameter_struct *can_filter_parameter_init)
 {
     uint32_t val = 0U;
-    
+
     val = ((uint32_t)1) << (can_filter_parameter_init->filter_number);
     /* filter lock disable */
     CAN_FCTL(CAN0) |= CAN_FCTL_FLD;
     /* disable filter */
     CAN_FW(CAN0) &= ~(uint32_t)val;
-    
+
     /* filter 16 bits */
-    if(CAN_FILTERBITS_16BIT == can_filter_parameter_init->filter_bits){
+    if(CAN_FILTERBITS_16BIT == can_filter_parameter_init->filter_bits) {
         /* set filter 16 bits */
         CAN_FSCFG(CAN0) &= ~(uint32_t)val;
         /* first 16 bits list and first 16 bits mask or first 16 bits list and second 16 bits list */
         CAN_FDATA0(CAN0, can_filter_parameter_init->filter_number) = \
-                                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS) | \
-                                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS) | \
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
         /* second 16 bits list and second 16 bits mask or third 16 bits list and fourth 16 bits list */
         CAN_FDATA1(CAN0, can_filter_parameter_init->filter_number) = \
-                                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) | \
-                                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS);
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) | \
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS);
     }
     /* filter 32 bits */
-    if(CAN_FILTERBITS_32BIT == can_filter_parameter_init->filter_bits){
+    if(CAN_FILTERBITS_32BIT == can_filter_parameter_init->filter_bits) {
         /* set filter 32 bits */
         CAN_FSCFG(CAN0) |= (uint32_t)val;
         /* 32 bits list or first 32 bits list */
         CAN_FDATA0(CAN0, can_filter_parameter_init->filter_number) = \
-                                FDATA_MASK_HIGH((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS) |
-                                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS) |
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
         /* 32 bits mask or second 32 bits list */
         CAN_FDATA1(CAN0, can_filter_parameter_init->filter_number) = \
-                                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) |
-                                FDATA_MASK_LOW((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS);
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) |
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS);
     }
-    
+
     /* filter mode */
-    if(CAN_FILTERMODE_MASK == can_filter_parameter_init->filter_mode){
+    if(CAN_FILTERMODE_MASK == can_filter_parameter_init->filter_mode) {
         /* mask mode */
         CAN_FMCFG(CAN0) &= ~(uint32_t)val;
-    }else{
+    } else {
         /* list mode */
         CAN_FMCFG(CAN0) |= (uint32_t)val;
     }
-    
+
     /* filter FIFO */
-    if(CAN_FIFO0 == (can_filter_parameter_init->filter_fifo_number)){
+    if(CAN_FIFO0 == (can_filter_parameter_init->filter_fifo_number)) {
         /* FIFO0 */
         CAN_FAFIFO(CAN0) &= ~(uint32_t)val;
-    }else{
+    } else {
         /* FIFO1 */
         CAN_FAFIFO(CAN0) |= (uint32_t)val;
     }
-    
+
     /* filter working */
-    if(ENABLE == can_filter_parameter_init->filter_enable){
-        
+    if(ENABLE == can_filter_parameter_init->filter_enable) {
+
         CAN_FW(CAN0) |= (uint32_t)val;
     }
-    
+
     /* filter lock enable */
     CAN_FCTL(CAN0) &= ~CAN_FCTL_FLD;
 }
 
 /*!
-    \brief    set CAN1 fliter start bank number
+    \brief      set CAN1 filter start bank number
     \param[in]  start_bank: CAN1 start bank number
                 only one parameter can be selected which is shown as below:
       \arg        (1..27)
@@ -326,12 +327,12 @@ void can1_filter_start_bank(uint8_t start_bank)
     /* set CAN1 filter start number */
     CAN_FCTL(CAN0) &= ~(uint32_t)CAN_FCTL_HBC1F;
     CAN_FCTL(CAN0) |= FCTL_HBC1F(start_bank);
-    /* filter lock enaable */
+    /* filter lock enable */
     CAN_FCTL(CAN0) &= ~CAN_FCTL_FLD;
 }
 
 /*!
-    \brief    enable CAN debug freeze
+    \brief      enable CAN debug freeze
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -341,15 +342,16 @@ void can_debug_freeze_enable(uint32_t can_periph)
 {
     /* set DFZ bit */
     CAN_CTL(can_periph) |= CAN_CTL_DFZ;
-    if(CAN0 == can_periph){
+
+    if(CAN0 == can_periph) {
         dbg_periph_enable(DBG_CAN0_HOLD);
-    }else{
+    } else {
         dbg_periph_enable(DBG_CAN1_HOLD);
     }
 }
 
 /*!
-    \brief    disable CAN debug freeze
+    \brief      disable CAN debug freeze
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -359,15 +361,16 @@ void can_debug_freeze_disable(uint32_t can_periph)
 {
     /* set DFZ bit */
     CAN_CTL(can_periph) &= ~CAN_CTL_DFZ;
-    if(CAN0 == can_periph){
+
+    if(CAN0 == can_periph) {
         dbg_periph_disable(DBG_CAN0_HOLD);
-    }else{
+    } else {
         dbg_periph_disable(DBG_CAN1_HOLD);
     }
 }
 
 /*!
-    \brief    enable CAN time trigger mode
+    \brief      enable CAN time trigger mode
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -376,17 +379,17 @@ void can_debug_freeze_disable(uint32_t can_periph)
 void can_time_trigger_mode_enable(uint32_t can_periph)
 {
     uint8_t mailbox_number;
-    
-    /* enable the tcc mode */
+
+    /* enable the TTC mode */
     CAN_CTL(can_periph) |= CAN_CTL_TTC;
     /* enable time stamp */
-    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++){
+    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++) {
         CAN_TMP(can_periph, mailbox_number) |= CAN_TMP_TSEN;
     }
 }
 
 /*!
-    \brief    disable CAN time trigger mode
+    \brief      disable CAN time trigger mode
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -394,18 +397,18 @@ void can_time_trigger_mode_enable(uint32_t can_periph)
 */
 void can_time_trigger_mode_disable(uint32_t can_periph)
 {
-    uint8_t mailbox_number; 
-    
-    /* disable the TCC mode */
+    uint8_t mailbox_number;
+
+    /* disable the TTC mode */
     CAN_CTL(can_periph) &= ~CAN_CTL_TTC;
     /* reset TSEN bits */
-    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++){
+    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++) {
         CAN_TMP(can_periph, mailbox_number) &= ~CAN_TMP_TSEN;
     }
 }
 
 /*!
-    \brief     transmit CAN message
+    \brief      transmit CAN message
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  transmit_message: struct for CAN transmit message
@@ -418,48 +421,48 @@ void can_time_trigger_mode_disable(uint32_t can_periph)
     \param[out] none
     \retval     mailbox_number
 */
-uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* transmit_message)
+uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct *transmit_message)
 {
     uint8_t mailbox_number = CAN_MAILBOX0;
 
     /* select one empty mailbox */
-    if(CAN_TSTAT_TME0 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME0)){
+    if(CAN_TSTAT_TME0 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME0)) {
         mailbox_number = CAN_MAILBOX0;
-    }else if(CAN_TSTAT_TME1 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME1)){
+    } else if(CAN_TSTAT_TME1 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME1)) {
         mailbox_number = CAN_MAILBOX1;
-    }else if(CAN_TSTAT_TME2 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME2)){
+    } else if(CAN_TSTAT_TME2 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME2)) {
         mailbox_number = CAN_MAILBOX2;
-    }else{
+    } else {
         mailbox_number = CAN_NOMAILBOX;
     }
     /* return no mailbox empty */
-    if(CAN_NOMAILBOX == mailbox_number){
+    if(CAN_NOMAILBOX == mailbox_number) {
         return CAN_NOMAILBOX;
     }
-    
+
     CAN_TMI(can_periph, mailbox_number) &= CAN_TMI_TEN;
-    if(CAN_FF_STANDARD == transmit_message->tx_ff){
+    if(CAN_FF_STANDARD == transmit_message->tx_ff) {
         /* set transmit mailbox standard identifier */
         CAN_TMI(can_periph, mailbox_number) |= (uint32_t)(TMI_SFID(transmit_message->tx_sfid) | \
-                                                transmit_message->tx_ft);
-    }else{
+                                               transmit_message->tx_ft);
+    } else {
         /* set transmit mailbox extended identifier */
         CAN_TMI(can_periph, mailbox_number) |= (uint32_t)(TMI_EFID(transmit_message->tx_efid) | \
-                                                transmit_message->tx_ff | \
-                                                transmit_message->tx_ft);
+                                               transmit_message->tx_ff | \
+                                               transmit_message->tx_ft);
     }
     /* set the data length */
     CAN_TMP(can_periph, mailbox_number) &= ~CAN_TMP_DLENC;
     CAN_TMP(can_periph, mailbox_number) |= transmit_message->tx_dlen;
     /* set the data */
     CAN_TMDATA0(can_periph, mailbox_number) = TMDATA0_DB3(transmit_message->tx_data[3]) | \
-                                              TMDATA0_DB2(transmit_message->tx_data[2]) | \
-                                              TMDATA0_DB1(transmit_message->tx_data[1]) | \
-                                              TMDATA0_DB0(transmit_message->tx_data[0]);
+            TMDATA0_DB2(transmit_message->tx_data[2]) | \
+            TMDATA0_DB1(transmit_message->tx_data[1]) | \
+            TMDATA0_DB0(transmit_message->tx_data[0]);
     CAN_TMDATA1(can_periph, mailbox_number) = TMDATA1_DB7(transmit_message->tx_data[7]) | \
-                                              TMDATA1_DB6(transmit_message->tx_data[6]) | \
-                                              TMDATA1_DB5(transmit_message->tx_data[5]) | \
-                                              TMDATA1_DB4(transmit_message->tx_data[4]);
+            TMDATA1_DB6(transmit_message->tx_data[6]) | \
+            TMDATA1_DB5(transmit_message->tx_data[5]) | \
+            TMDATA1_DB4(transmit_message->tx_data[4]);
     /* enable transmission */
     CAN_TMI(can_periph, mailbox_number) |= CAN_TMI_TEN;
 
@@ -467,7 +470,7 @@ uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct* t
 }
 
 /*!
-    \brief    get CAN transmit state 
+    \brief      get CAN transmit state
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  mailbox_number
@@ -480,9 +483,9 @@ can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox
 {
     can_transmit_state_enum state = CAN_TRANSMIT_FAILED;
     uint32_t val = 0U;
-    
-    /* check selected mailbox state */    
-    switch(mailbox_number){
+
+    /* check selected mailbox state */
+    switch(mailbox_number) {
     /* mailbox0 */
     case CAN_MAILBOX0:
         val = CAN_TSTAT(can_periph) & (CAN_TSTAT_MTF0 | CAN_TSTAT_MTFNERR0 | CAN_TSTAT_TME0);
@@ -499,26 +502,26 @@ can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox
         val = CAN_TRANSMIT_FAILED;
         break;
     }
-    
-    switch(val){
-        /* transmit pending */
-    case (CAN_STATE_PENDING): 
+
+    switch(val) {
+    /* transmit pending */
+    case(CAN_STATE_PENDING):
         state = CAN_TRANSMIT_PENDING;
         break;
-        /* mailbox0 transmit succeeded */
-    case (CAN_TSTAT_MTF0 | CAN_TSTAT_MTFNERR0 | CAN_TSTAT_TME0):
+    /* mailbox0 transmit succeeded */
+    case(CAN_TSTAT_MTF0 | CAN_TSTAT_MTFNERR0 | CAN_TSTAT_TME0):
         state = CAN_TRANSMIT_OK;
         break;
-        /* mailbox1 transmit succeeded */
-    case (CAN_TSTAT_MTF1 | CAN_TSTAT_MTFNERR1 | CAN_TSTAT_TME1):
+    /* mailbox1 transmit succeeded */
+    case(CAN_TSTAT_MTF1 | CAN_TSTAT_MTFNERR1 | CAN_TSTAT_TME1):
         state = CAN_TRANSMIT_OK;
         break;
-        /* mailbox2 transmit succeeded */
-    case (CAN_TSTAT_MTF2 | CAN_TSTAT_MTFNERR2 | CAN_TSTAT_TME2):
+    /* mailbox2 transmit succeeded */
+    case(CAN_TSTAT_MTF2 | CAN_TSTAT_MTFNERR2 | CAN_TSTAT_TME2):
         state = CAN_TRANSMIT_OK;
         break;
-        /* transmit failed */
-    default: 
+    /* transmit failed */
+    default:
         state = CAN_TRANSMIT_FAILED;
         break;
     }
@@ -526,7 +529,7 @@ can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox
 }
 
 /*!
-    \brief    stop CAN transmission
+    \brief      stop CAN transmission
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  mailbox_number
@@ -537,25 +540,25 @@ can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox
 */
 void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number)
 {
-    if(CAN_MAILBOX0 == mailbox_number){
+    if(CAN_MAILBOX0 == mailbox_number) {
         CAN_TSTAT(can_periph) |= CAN_TSTAT_MST0;
-        while(CAN_TSTAT_MST0 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST0)){
+        while(CAN_TSTAT_MST0 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST0)) {
         }
-    }else if(CAN_MAILBOX1 == mailbox_number){
+    } else if(CAN_MAILBOX1 == mailbox_number) {
         CAN_TSTAT(can_periph) |= CAN_TSTAT_MST1;
-        while(CAN_TSTAT_MST1 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST1)){
+        while(CAN_TSTAT_MST1 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST1)) {
         }
-    }else if(CAN_MAILBOX2 == mailbox_number){
+    } else if(CAN_MAILBOX2 == mailbox_number) {
         CAN_TSTAT(can_periph) |= CAN_TSTAT_MST2;
-        while(CAN_TSTAT_MST2 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST2)){
+        while(CAN_TSTAT_MST2 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST2)) {
         }
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    CAN receive message
+    \brief      CAN receive message
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  fifo_number
@@ -570,25 +573,25 @@ void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number)
       \arg        rx_fi: 0 - 27
     \retval     none
 */
-void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct* receive_message)
+void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct *receive_message)
 {
     /* get the frame format */
     receive_message->rx_ff = (uint8_t)(CAN_RFIFOMI_FF & CAN_RFIFOMI(can_periph, fifo_number));
-    if(CAN_FF_STANDARD == receive_message->rx_ff){
+    if(CAN_FF_STANDARD == receive_message->rx_ff) {
         /* get standard identifier */
         receive_message->rx_sfid = (uint32_t)(GET_RFIFOMI_SFID(CAN_RFIFOMI(can_periph, fifo_number)));
-    }else{
+    } else {
         /* get extended identifier */
         receive_message->rx_efid = (uint32_t)(GET_RFIFOMI_EFID(CAN_RFIFOMI(can_periph, fifo_number)));
     }
-    
+
     /* get frame type */
-    receive_message->rx_ft = (uint8_t)(CAN_RFIFOMI_FT & CAN_RFIFOMI(can_periph, fifo_number));        
+    receive_message->rx_ft = (uint8_t)(CAN_RFIFOMI_FT & CAN_RFIFOMI(can_periph, fifo_number));
     /* filtering index */
     receive_message->rx_fi = (uint8_t)(GET_RFIFOMP_FI(CAN_RFIFOMP(can_periph, fifo_number)));
-    /* get recevie data length */
+    /* get receive data length */
     receive_message->rx_dlen = (uint8_t)(GET_RFIFOMP_DLENC(CAN_RFIFOMP(can_periph, fifo_number)));
-    
+
     /* receive data */
     receive_message -> rx_data[0] = (uint8_t)(GET_RFIFOMDATA0_DB0(CAN_RFIFOMDATA0(can_periph, fifo_number)));
     receive_message -> rx_data[1] = (uint8_t)(GET_RFIFOMDATA0_DB1(CAN_RFIFOMDATA0(can_periph, fifo_number)));
@@ -598,17 +601,17 @@ void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_m
     receive_message -> rx_data[5] = (uint8_t)(GET_RFIFOMDATA1_DB5(CAN_RFIFOMDATA1(can_periph, fifo_number)));
     receive_message -> rx_data[6] = (uint8_t)(GET_RFIFOMDATA1_DB6(CAN_RFIFOMDATA1(can_periph, fifo_number)));
     receive_message -> rx_data[7] = (uint8_t)(GET_RFIFOMDATA1_DB7(CAN_RFIFOMDATA1(can_periph, fifo_number)));
-    
+
     /* release FIFO */
-    if(CAN_FIFO0 == fifo_number){
+    if(CAN_FIFO0 == fifo_number) {
         CAN_RFIFO0(can_periph) |= CAN_RFIFO0_RFD0;
-    }else{
+    } else {
         CAN_RFIFO1(can_periph) |= CAN_RFIFO1_RFD1;
     }
 }
 
 /*!
-    \brief    release FIFO0
+    \brief      release FIFO
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  fifo_number
@@ -619,44 +622,44 @@ void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_m
 */
 void can_fifo_release(uint32_t can_periph, uint8_t fifo_number)
 {
-    if(CAN_FIFO0 == fifo_number){
+    if(CAN_FIFO0 == fifo_number) {
         CAN_RFIFO0(can_periph) |= CAN_RFIFO0_RFD0;
-    }else if(CAN_FIFO1 == fifo_number){
+    } else if(CAN_FIFO1 == fifo_number) {
         CAN_RFIFO1(can_periph) |= CAN_RFIFO1_RFD1;
-    }else{
+    } else {
         /* illegal parameters */
         CAN_ERROR_HANDLE("CAN FIFO NUM is invalid \r\n");
     }
 }
 
 /*!
-    \brief    CAN receive message length
+    \brief      CAN receive message length
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  fifo_number
                 only one parameter can be selected which is shown as below:
-      \arg        CAN_FIFOx(x=0,1) 
+      \arg        CAN_FIFOx(x=0,1)
     \param[out] none
     \retval     message length
 */
 uint8_t can_receive_message_length_get(uint32_t can_periph, uint8_t fifo_number)
 {
     uint8_t val = 0U;
-    
-    if(CAN_FIFO0 == fifo_number){
+
+    if(CAN_FIFO0 == fifo_number) {
         /* FIFO0 */
         val = (uint8_t)(CAN_RFIFO0(can_periph) & CAN_RFIF_RFL_MASK);
-    }else if(CAN_FIFO1 == fifo_number){
+    } else if(CAN_FIFO1 == fifo_number) {
         /* FIFO1 */
         val = (uint8_t)(CAN_RFIFO1(can_periph) & CAN_RFIF_RFL_MASK);
-    }else{
+    } else {
         /* illegal parameters */
     }
     return val;
 }
 
 /*!
-    \brief    set CAN working mode
+    \brief      set CAN working mode
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  can_working_mode
@@ -671,56 +674,56 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 {
     ErrStatus flag = ERROR;
     /* timeout for IWS or also for SLPWS bits */
-    uint32_t timeout = GD32_CAN_TIMEOUT;
-    
-    if(CAN_MODE_INITIALIZE == working_mode){
+    uint32_t timeout = CAN_TIMEOUT;
+
+    if(CAN_MODE_INITIALIZE == working_mode) {
         /* disable sleep mode */
         CAN_CTL(can_periph) &= (~(uint32_t)CAN_CTL_SLPWMOD);
         /* set initialize mode */
         CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_IWMOD;
         /* wait the acknowledge */
-        while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
+        while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
         }
-        if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)){
+        if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) {
             flag = ERROR;
-        }else{
+        } else {
             flag = SUCCESS;
         }
-    }else if(CAN_MODE_NORMAL == working_mode){
+    } else if(CAN_MODE_NORMAL == working_mode) {
         /* enter normal mode */
         CAN_CTL(can_periph) &= ~(uint32_t)(CAN_CTL_SLPWMOD | CAN_CTL_IWMOD);
         /* wait the acknowledge */
-        while((0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))) && (0U != timeout)){
+        while((0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))) && (0U != timeout)) {
             timeout--;
         }
-        if(0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))){
+        if(0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))) {
             flag = ERROR;
-        }else{
+        } else {
             flag = SUCCESS;
         }
-    }else if(CAN_MODE_SLEEP == working_mode){
+    } else if(CAN_MODE_SLEEP == working_mode) {
         /* disable initialize mode */
         CAN_CTL(can_periph) &= (~(uint32_t)CAN_CTL_IWMOD);
         /* set sleep mode */
         CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_SLPWMOD;
         /* wait the acknowledge */
-        while((CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0U != timeout)){
+        while((CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0U != timeout)) {
             timeout--;
         }
-        if(CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)){
+        if(CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) {
             flag = ERROR;
-        }else{
+        } else {
             flag = SUCCESS;
         }
-    }else{
+    } else {
         flag = ERROR;
     }
     return flag;
 }
 
 /*!
-    \brief    wake up CAN
+    \brief      wake up CAN
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -729,25 +732,25 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 ErrStatus can_wakeup(uint32_t can_periph)
 {
     ErrStatus flag = ERROR;
-    uint32_t timeout = GD32_CAN_TIMEOUT;
-    
+    uint32_t timeout = CAN_TIMEOUT;
+
     /* wakeup */
     CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;
-    
-    while((0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0x00U != timeout)){
+
+    while((0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0x00U != timeout)) {
         timeout--;
     }
     /* check state */
-    if(0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)){
+    if(0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) {
         flag = ERROR;
-    }else{
+    } else {
         flag = SUCCESS;
     }
     return flag;
 }
 
 /*!
-    \brief    get CAN error type
+    \brief      get CAN error type
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -765,14 +768,14 @@ can_error_enum can_error_get(uint32_t can_periph)
 {
     can_error_enum error;
     error = CAN_ERROR_NONE;
-    
+
     /* get error type */
     error = (can_error_enum)(GET_ERR_ERRN(CAN_ERR(can_periph)));
     return error;
 }
 
 /*!
-    \brief    get CAN receive error number
+    \brief      get CAN receive error number
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -781,14 +784,14 @@ can_error_enum can_error_get(uint32_t can_periph)
 uint8_t can_receive_error_number_get(uint32_t can_periph)
 {
     uint8_t val;
-    
+
     /* get error count */
     val = (uint8_t)(GET_ERR_RECNT(CAN_ERR(can_periph)));
     return val;
 }
 
 /*!
-    \brief    get CAN transmit error number
+    \brief      get CAN transmit error number
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[out] none
@@ -797,69 +800,13 @@ uint8_t can_receive_error_number_get(uint32_t can_periph)
 uint8_t can_transmit_error_number_get(uint32_t can_periph)
 {
     uint8_t val;
-    
+
     val = (uint8_t)(GET_ERR_TECNT(CAN_ERR(can_periph)));
     return val;
 }
 
 /*!
-    \brief    enable CAN interrupt 
-    \param[in]  can_periph
-      \arg        CANx(x=0,1)
-    \param[in]  interrupt 
-                one or more parameters can be selected which are shown as below:
-      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
-      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
-      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
-      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
-      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
-      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
-      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
-      \arg        CAN_INT_WERR: warning error interrupt enable
-      \arg        CAN_INT_PERR: passive error interrupt enable
-      \arg        CAN_INT_BO: bus-off interrupt enable
-      \arg        CAN_INT_ERRN: error number interrupt enable
-      \arg        CAN_INT_ERR: error interrupt enable
-      \arg        CAN_INT_WU: wakeup interrupt enable
-      \arg        CAN_INT_SLPW: sleep working interrupt enable
-    \param[out] none
-    \retval     none
-*/
-void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt)
-{
-    CAN_INTEN(can_periph) |= interrupt;
-}
-
-/*!
-    \brief    disable CAN interrupt 
-    \param[in]  can_periph
-      \arg        CANx(x=0,1)
-    \param[in]  interrupt
-                one or more parameters can be selected which are shown as below:
-      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
-      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
-      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
-      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
-      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
-      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
-      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
-      \arg        CAN_INT_WERR: warning error interrupt enable
-      \arg        CAN_INT_PERR: passive error interrupt enable
-      \arg        CAN_INT_BO: bus-off interrupt enable
-      \arg        CAN_INT_ERRN: error number interrupt enable
-      \arg        CAN_INT_ERR: error interrupt enable
-      \arg        CAN_INT_WU: wakeup interrupt enable
-      \arg        CAN_INT_SLPW: sleep working interrupt enable
-    \param[out] none
-    \retval     none
-*/
-void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt)
-{
-    CAN_INTEN(can_periph) &= ~interrupt;
-}
-
-/*!
-    \brief    get CAN flag state
+    \brief      get CAN flag state
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  flag: CAN flags, refer to can_flag_enum
@@ -873,9 +820,9 @@ void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt)
       \arg        CAN_FLAG_ERRIF: error flag
       \arg        CAN_FLAG_SLPWS: sleep working state
       \arg        CAN_FLAG_IWS: initial working state
-      \arg        CAN_FLAG_TMLS2: transmit mailbox 2 last sending in Tx FIFO
-      \arg        CAN_FLAG_TMLS1: transmit mailbox 1 last sending in Tx FIFO
-      \arg        CAN_FLAG_TMLS0: transmit mailbox 0 last sending in Tx FIFO
+      \arg        CAN_FLAG_TMLS2: transmit mailbox 2 last sending in TX FIFO
+      \arg        CAN_FLAG_TMLS1: transmit mailbox 1 last sending in TX FIFO
+      \arg        CAN_FLAG_TMLS0: transmit mailbox 0 last sending in TX FIFO
       \arg        CAN_FLAG_TME2: transmit mailbox 2 empty
       \arg        CAN_FLAG_TME1: transmit mailbox 1 empty
       \arg        CAN_FLAG_TME0: transmit mailbox 0 empty
@@ -902,17 +849,17 @@ void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt)
     \retval     FlagStatus: SET or RESET
 */
 FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag)
-{  
+{
     /* get flag and interrupt enable state */
-    if(RESET != (CAN_REG_VAL(can_periph, flag) & BIT(CAN_BIT_POS(flag)))){
+    if(RESET != (CAN_REG_VAL(can_periph, flag) & BIT(CAN_BIT_POS(flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear CAN flag state
+    \brief      clear CAN flag state
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  flag: CAN flags, refer to can_flag_enum
@@ -945,7 +892,63 @@ void can_flag_clear(uint32_t can_periph, can_flag_enum flag)
 }
 
 /*!
-    \brief    get CAN interrupt flag state
+    \brief      enable CAN interrupt
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  interrupt
+                one or more parameters can be selected which are shown as below:
+      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
+      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
+      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
+      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
+      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
+      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
+      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
+      \arg        CAN_INT_WERR: warning error interrupt enable
+      \arg        CAN_INT_PERR: passive error interrupt enable
+      \arg        CAN_INT_BO: bus-off interrupt enable
+      \arg        CAN_INT_ERRN: error number interrupt enable
+      \arg        CAN_INT_ERR: error interrupt enable
+      \arg        CAN_INT_WAKEUP: wakeup interrupt enable
+      \arg        CAN_INT_SLPW: sleep working interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt)
+{
+    CAN_INTEN(can_periph) |= interrupt;
+}
+
+/*!
+    \brief      disable CAN interrupt
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  interrupt
+                one or more parameters can be selected which are shown as below:
+      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
+      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
+      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
+      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
+      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
+      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
+      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
+      \arg        CAN_INT_WERR: warning error interrupt enable
+      \arg        CAN_INT_PERR: passive error interrupt enable
+      \arg        CAN_INT_BO: bus-off interrupt enable
+      \arg        CAN_INT_ERRN: error number interrupt enable
+      \arg        CAN_INT_ERR: error interrupt enable
+      \arg        CAN_INT_WAKEUP: wakeup interrupt enable
+      \arg        CAN_INT_SLPW: sleep working interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt)
+{
+    CAN_INTEN(can_periph) &= ~interrupt;
+}
+
+/*!
+    \brief      get CAN interrupt flag state
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  flag: CAN interrupt flags, refer to can_interrupt_flag_enum
@@ -973,29 +976,29 @@ FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum f
 {
     uint32_t ret1 = RESET;
     uint32_t ret2 = RESET;
-    
-    /* get the staus of interrupt flag */
-    if (flag == CAN_INT_FLAG_RFF0) {
+
+    /* get the status of interrupt flag */
+    if(flag == CAN_INT_FLAG_RFL0) {
         ret1 = can_receive_message_length_get(can_periph, CAN_FIFO0);
-    } else if (flag == CAN_INT_FLAG_RFF1) {
+    } else if(flag == CAN_INT_FLAG_RFL1) {
         ret1 = can_receive_message_length_get(can_periph, CAN_FIFO1);
-    } else if (flag == CAN_INT_FLAG_ERRN) {
+    } else if(flag == CAN_INT_FLAG_ERRN) {
         ret1 = can_error_get(can_periph);
     } else {
         ret1 = CAN_REG_VALS(can_periph, flag) & BIT(CAN_BIT_POS0(flag));
     }
-    /* get the staus of interrupt enale bit */
+    /* get the status of interrupt enable bit */
     ret2 = CAN_INTEN(can_periph) & BIT(CAN_BIT_POS1(flag));
-    if(ret1 && ret2){
+    if(ret1 && ret2) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear CAN interrupt flag state
-     \param[in]  can_periph
+    \brief      clear CAN interrupt flag state
+    \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  flag: CAN interrupt flags, refer to can_interrupt_flag_enum
                 only one parameter can be selected which is shown as below:

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
@@ -89,7 +89,7 @@ void can_struct_para_init(can_struct_type_enum type, void *p_struct)
         ((can_parameter_struct *)p_struct)->time_segment_2 = CAN_BT_BS2_1TQ;
         ((can_parameter_struct *)p_struct)->time_triggered = DISABLE;
         ((can_parameter_struct *)p_struct)->trans_fifo_order = DISABLE;
-        ((can_parameter_struct *)p_struct)->working_mode = CAN_NORMAL_MODE;
+        ((can_parameter_struct *)p_struct)->working_mode = GD32_CAN_NORMAL_MODE;
 
         break;
     /* used for can_filter_init() */
@@ -143,7 +143,7 @@ void can_struct_para_init(can_struct_type_enum type, void *p_struct)
     \param[in]  can_periph
       \arg        CANx(x=0,1)
     \param[in]  can_parameter_init: parameters for CAN initializtion
-      \arg        working_mode: CAN_NORMAL_MODE, CAN_LOOPBACK_MODE, CAN_SILENT_MODE, CAN_SILENT_LOOPBACK_MODE
+      \arg        working_mode: GD32_CAN_NORMAL_MODE, GD32_CAN_LOOPBACK_MODE, GD32_CAN_SILENT_MODE, GD32_CAN_SILENT_LOOPBACK_MODE
       \arg        resync_jump_width: CAN_BT_SJW_xTQ(x=1, 2, 3, 4)
       \arg        time_segment_1: CAN_BT_BS1_xTQ(1..16)
       \arg        time_segment_2: CAN_BT_BS2_xTQ(1..8)

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_crc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_crc.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -38,8 +39,9 @@ OF SUCH DAMAGE.
 
 #define CRC_DATA_RESET_VALUE      ((uint32_t)0xFFFFFFFFU)
 #define CRC_FDATA_RESET_VALUE     ((uint32_t)0x00000000U)
+
 /*!
-    \brief    deinit CRC calculation unit
+    \brief      deinit CRC calculation unit
     \param[in]  none
     \param[out] none
     \retval     none
@@ -52,7 +54,7 @@ void crc_deinit(void)
 }
 
 /*!
-    \brief    reset data register(CRC_DATA) to the value of 0xFFFFFFFF
+    \brief      reset data register(CRC_DATA) to the value of 0xFFFFFFFF
     \param[in]  none
     \param[out] none
     \retval     none
@@ -63,7 +65,7 @@ void crc_data_register_reset(void)
 }
 
 /*!
-    \brief    read the value of the data register 
+    \brief      read the value of the data register
     \param[in]  none
     \param[out] none
     \retval     32-bit value of the data register
@@ -76,7 +78,7 @@ uint32_t crc_data_register_read(void)
 }
 
 /*!
-    \brief    read the value of the free data register
+    \brief      read the value of the free data register
     \param[in]  none
     \param[out] none
     \retval     8-bit value of the free data register
@@ -89,7 +91,7 @@ uint8_t crc_free_data_register_read(void)
 }
 
 /*!
-    \brief    write data to the free data register
+    \brief      write data to the free data register
     \param[in]  free_data: specified 8-bit data
     \param[out] none
     \retval     none
@@ -100,7 +102,7 @@ void crc_free_data_register_write(uint8_t free_data)
 }
 
 /*!
-    \brief    calculate the CRC value of a 32-bit data
+    \brief      calculate the CRC value of a 32-bit data
     \param[in]  sdata: specified 32-bit data
     \param[out] none
     \retval     32-bit value calculated by CRC
@@ -112,7 +114,7 @@ uint32_t crc_single_data_calculate(uint32_t sdata)
 }
 
 /*!
-    \brief    calculate the CRC value of an array of 32-bit values
+    \brief      calculate the CRC value of an array of 32-bit values
     \param[in]  array: pointer to an array of 32-bit values
     \param[in]  size: size of the array
     \param[out] none
@@ -121,7 +123,7 @@ uint32_t crc_single_data_calculate(uint32_t sdata)
 uint32_t crc_block_data_calculate(uint32_t array[], uint32_t size)
 {
     uint32_t index;
-    for(index = 0U; index < size; index++){
+    for(index = 0U; index < size; index++) {
         CRC_DATA = array[index];
     }
     return (CRC_DATA);

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_ctc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_ctc.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -221,7 +222,7 @@ void ctc_counter_reload_value_config(uint16_t reload_value)
 uint16_t ctc_counter_capture_value_read(void)
 {
     uint16_t capture_value = 0U;
-    capture_value = (uint16_t)((CTC_STAT & CTC_STAT_REFCAP)>> CTC_REFCAP_OFFSET);
+    capture_value = (uint16_t)((CTC_STAT & CTC_STAT_REFCAP) >> CTC_REFCAP_OFFSET);
     return (capture_value);
 }
 
@@ -235,9 +236,9 @@ uint16_t ctc_counter_capture_value_read(void)
 */
 FlagStatus ctc_counter_direction_read(void)
 {
-    if(RESET != (CTC_STAT & CTC_STAT_REFDIR)){
+    if(RESET != (CTC_STAT & CTC_STAT_REFDIR)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -281,7 +282,7 @@ uint8_t ctc_irc48m_trim_value_read(void)
 */
 void ctc_interrupt_enable(uint32_t interrupt)
 {
-    CTC_CTL0 |= (uint32_t)interrupt; 
+    CTC_CTL0 |= (uint32_t)interrupt;
 }
 
 /*!
@@ -297,7 +298,7 @@ void ctc_interrupt_enable(uint32_t interrupt)
 */
 void ctc_interrupt_disable(uint32_t interrupt)
 {
-    CTC_CTL0 &= (uint32_t)(~interrupt); 
+    CTC_CTL0 &= (uint32_t)(~interrupt);
 }
 
 /*!
@@ -305,11 +306,11 @@ void ctc_interrupt_disable(uint32_t interrupt)
     \param[in]  int_flag: the CTC interrupt flag
                 only one parameter can be selected which is shown as below:
       \arg        CTC_INT_FLAG_CKOK: clock trim OK interrupt
-      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt 
-      \arg        CTC_INT_FLAG_ERR: error interrupt 
+      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt
+      \arg        CTC_INT_FLAG_ERR: error interrupt
       \arg        CTC_INT_FLAG_EREF: expect reference interrupt
       \arg        CTC_INT_FLAG_CKERR: clock trim error bit interrupt
-      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt 
+      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt
       \arg        CTC_INT_FLAG_TRIMERR: trim value error interrupt
     \param[out] none
     \retval     FlagStatus: SET or RESET
@@ -317,20 +318,20 @@ void ctc_interrupt_disable(uint32_t interrupt)
 FlagStatus ctc_interrupt_flag_get(uint32_t int_flag)
 {
     uint32_t interrupt_flag = 0U, intenable = 0U;
-    
+
     /* check whether the interrupt is enabled */
-    if(RESET != (int_flag & CTC_FLAG_MASK)){
+    if(RESET != (int_flag & CTC_FLAG_MASK)) {
         intenable = CTC_CTL0 & CTC_CTL0_ERRIE;
-    }else{
+    } else {
         intenable = CTC_CTL0 & int_flag;
     }
-    
+
     /* get interrupt flag status */
     interrupt_flag = CTC_STAT & int_flag;
 
-    if(interrupt_flag && intenable){
+    if(interrupt_flag && intenable) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -340,20 +341,20 @@ FlagStatus ctc_interrupt_flag_get(uint32_t int_flag)
     \param[in]  int_flag: the CTC interrupt flag
                 only one parameter can be selected which is shown as below:
       \arg        CTC_INT_FLAG_CKOK: clock trim OK interrupt
-      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt 
-      \arg        CTC_INT_FLAG_ERR: error interrupt 
-      \arg        CTC_INT_FLAG_EREF: expect reference interrupt 
+      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt
+      \arg        CTC_INT_FLAG_ERR: error interrupt
+      \arg        CTC_INT_FLAG_EREF: expect reference interrupt
       \arg        CTC_INT_FLAG_CKERR: clock trim error bit interrupt
-      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt 
+      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt
       \arg        CTC_INT_FLAG_TRIMERR: trim value error interrupt
     \param[out] none
     \retval     none
-*/ 
+*/
 void ctc_interrupt_flag_clear(uint32_t int_flag)
 {
-    if(RESET != (int_flag & CTC_FLAG_MASK)){
+    if(RESET != (int_flag & CTC_FLAG_MASK)) {
         CTC_INTC |= CTC_INTC_ERRIC;
-    }else{
+    } else {
         CTC_INTC |= int_flag;
     }
 }
@@ -361,10 +362,10 @@ void ctc_interrupt_flag_clear(uint32_t int_flag)
 /*!
     \brief    get CTC flag
     \param[in]  flag: the CTC flag
-                only one parameter can be selected which is shown as below: 
+                only one parameter can be selected which is shown as below:
       \arg        CTC_FLAG_CKOK: clock trim OK flag
-      \arg        CTC_FLAG_CKWARN: clock trim warning flag 
-      \arg        CTC_FLAG_ERR: error flag 
+      \arg        CTC_FLAG_CKWARN: clock trim warning flag
+      \arg        CTC_FLAG_ERR: error flag
       \arg        CTC_FLAG_EREF: expect reference flag
       \arg        CTC_FLAG_CKERR: clock trim error bit
       \arg        CTC_FLAG_REFMISS: reference sync pulse miss
@@ -374,9 +375,9 @@ void ctc_interrupt_flag_clear(uint32_t int_flag)
 */
 FlagStatus ctc_flag_get(uint32_t flag)
 {
-    if(RESET != (CTC_STAT & flag)){
+    if(RESET != (CTC_STAT & flag)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -386,8 +387,8 @@ FlagStatus ctc_flag_get(uint32_t flag)
     \param[in]  flag: the CTC flag
                 only one parameter can be selected which is shown as below:
       \arg        CTC_FLAG_CKOK: clock trim OK flag
-      \arg        CTC_FLAG_CKWARN: clock trim warning flag 
-      \arg        CTC_FLAG_ERR: error flag 
+      \arg        CTC_FLAG_CKWARN: clock trim warning flag
+      \arg        CTC_FLAG_ERR: error flag
       \arg        CTC_FLAG_EREF: expect reference flag
       \arg        CTC_FLAG_CKERR: clock trim error bit
       \arg        CTC_FLAG_REFMISS: reference sync pulse miss
@@ -397,9 +398,9 @@ FlagStatus ctc_flag_get(uint32_t flag)
 */
 void ctc_flag_clear(uint32_t flag)
 {
-    if(RESET != (flag & CTC_FLAG_MASK)){
+    if(RESET != (flag & CTC_FLAG_MASK)) {
         CTC_INTC |= CTC_INTC_ERRIC;
-    }else{
+    } else {
         CTC_INTC |= flag;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_dac.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_dac.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_dac.c
     \brief   DAC driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -42,7 +43,7 @@ OF SUCH DAMAGE.
 #define DH_8BIT_OFFSET            ((uint32_t)8U)
 
 /*!
-    \brief    deinitialize DAC
+    \brief      deinitialize DAC
     \param[in]  none
     \param[out] none
     \retval     none
@@ -54,97 +55,97 @@ void dac_deinit(void)
 }
 
 /*!
-    \brief    enable DAC
+    \brief      enable DAC
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_enable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL |= DAC_CTL_DEN0;
-    }else{
+    } else {
         DAC_CTL |= DAC_CTL_DEN1;
     }
-} 
+}
 
 /*!
-    \brief    disable DAC
+    \brief      disable DAC
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_disable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL &= ~DAC_CTL_DEN0;
-    }else{
+    } else {
         DAC_CTL &= ~DAC_CTL_DEN1;
     }
 }
 
 /*!
-    \brief    enable DAC DMA function
+    \brief      enable DAC DMA function
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_dma_enable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL |= DAC_CTL_DDMAEN0;
-    }else{
+    } else {
         DAC_CTL |= DAC_CTL_DDMAEN1;
     }
 }
 
 /*!
-    \brief    disable DAC DMA function
+    \brief      disable DAC DMA function
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_dma_disable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL &= ~DAC_CTL_DDMAEN0;
-    }else{
+    } else {
         DAC_CTL &= ~DAC_CTL_DDMAEN1;
     }
 }
 
 /*!
-    \brief    enable DAC output buffer
+    \brief      enable DAC output buffer
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_output_buffer_enable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL &= ~DAC_CTL_DBOFF0;
-    }else{
+    } else {
         DAC_CTL &= ~DAC_CTL_DBOFF1;
     }
 }
 
 /*!
-    \brief    disable DAC output buffer
+    \brief      disable DAC output buffer
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_output_buffer_disable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL |= DAC_CTL_DBOFF0;
-    }else{
+    } else {
         DAC_CTL |= DAC_CTL_DBOFF1;
     }
 }
 
 /*!
-    \brief    get DAC output value
+    \brief      get DAC output value
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     DAC output data
@@ -152,10 +153,10 @@ void dac_output_buffer_disable(uint32_t dac_periph)
 uint16_t dac_output_value_get(uint32_t dac_periph)
 {
     uint16_t data = 0U;
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* store the DAC0 output value */
         data = (uint16_t)DAC0_DO;
-    }else{
+    } else {
         /* store the DAC1 output value */
         data = (uint16_t)DAC1_DO;
     }
@@ -163,7 +164,7 @@ uint16_t dac_output_value_get(uint32_t dac_periph)
 }
 
 /*!
-    \brief    set the DAC specified data holding register value
+    \brief      set the DAC specified data holding register value
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  dac_align: data alignment
                 only one parameter can be selected which is shown as below:
@@ -176,8 +177,8 @@ uint16_t dac_output_value_get(uint32_t dac_periph)
 */
 void dac_data_set(uint32_t dac_periph, uint32_t dac_align, uint16_t data)
 {
-    if(DAC0 == dac_periph){
-        switch(dac_align){
+    if(DAC0 == dac_periph) {
+        switch(dac_align) {
         /* data right 12 bit alignment */
         case DAC_ALIGN_12B_R:
             DAC0_R12DH = data;
@@ -193,8 +194,8 @@ void dac_data_set(uint32_t dac_periph, uint32_t dac_align, uint16_t data)
         default:
             break;
         }
-    }else{
-        switch(dac_align){
+    } else {
+        switch(dac_align) {
         /* data right 12 bit alignment */
         case DAC_ALIGN_12B_R:
             DAC1_R12DH = data;
@@ -214,37 +215,37 @@ void dac_data_set(uint32_t dac_periph, uint32_t dac_align, uint16_t data)
 }
 
 /*!
-    \brief    enable DAC trigger
+    \brief      enable DAC trigger
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_trigger_enable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL |= DAC_CTL_DTEN0;
-    }else{
+    } else {
         DAC_CTL |= DAC_CTL_DTEN1;
     }
 }
 
 /*!
-    \brief    disable DAC trigger
+    \brief      disable DAC trigger
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_trigger_disable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_CTL &= ~DAC_CTL_DTEN0;
-    }else{
+    } else {
         DAC_CTL &= ~DAC_CTL_DTEN1;
     }
 }
 
 /*!
-    \brief    set DAC trigger source
+    \brief      set DAC trigger source
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  triggersource: external triggers of DAC
                 only one parameter can be selected which is shown as below:
@@ -259,13 +260,13 @@ void dac_trigger_disable(uint32_t dac_periph)
     \param[out] none
     \retval     none
 */
-void dac_trigger_source_config(uint32_t dac_periph,uint32_t triggersource)
+void dac_trigger_source_config(uint32_t dac_periph, uint32_t triggersource)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* configure DAC0 trigger source */
         DAC_CTL &= ~DAC_CTL_DTSEL0;
         DAC_CTL |= triggersource;
-    }else{
+    } else {
         /* configure DAC1 trigger source */
         DAC_CTL &= ~DAC_CTL_DTSEL1;
         DAC_CTL |= (triggersource << DAC1_REG_OFFSET);
@@ -273,36 +274,36 @@ void dac_trigger_source_config(uint32_t dac_periph,uint32_t triggersource)
 }
 
 /*!
-    \brief    enable DAC software trigger
+    \brief      enable DAC software trigger
     \param[in]  dac_periph: DACx(x = 0,1)
     \retval     none
 */
 void dac_software_trigger_enable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_SWT |= DAC_SWT_SWTR0;
-    }else{
+    } else {
         DAC_SWT |= DAC_SWT_SWTR1;
     }
 }
 
 /*!
-    \brief    disable DAC software trigger
+    \brief      disable DAC software trigger
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_software_trigger_disable(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_SWT &= ~DAC_SWT_SWTR0;
-    }else{
+    } else {
         DAC_SWT &= ~DAC_SWT_SWTR1;
     }
 }
 
 /*!
-    \brief    configure DAC wave mode
+    \brief      configure DAC wave mode
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  wave_mode: noise wave mode
                 only one parameter can be selected which is shown as below:
@@ -314,11 +315,11 @@ void dac_software_trigger_disable(uint32_t dac_periph)
 */
 void dac_wave_mode_config(uint32_t dac_periph, uint32_t wave_mode)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* configure DAC0 wave mode */
         DAC_CTL &= ~DAC_CTL_DWM0;
         DAC_CTL |= wave_mode;
-    }else{
+    } else {
         /* configure DAC1 wave mode */
         DAC_CTL &= ~DAC_CTL_DWM1;
         DAC_CTL |= (wave_mode << DAC1_REG_OFFSET);
@@ -326,7 +327,7 @@ void dac_wave_mode_config(uint32_t dac_periph, uint32_t wave_mode)
 }
 
 /*!
-    \brief    configure DAC wave bit width
+    \brief      configure DAC wave bit width
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  bit_width: noise wave bit width
                 only one parameter can be selected which is shown as below:
@@ -347,11 +348,11 @@ void dac_wave_mode_config(uint32_t dac_periph, uint32_t wave_mode)
 */
 void dac_wave_bit_width_config(uint32_t dac_periph, uint32_t bit_width)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* configure DAC0 wave bit width */
         DAC_CTL &= ~DAC_CTL_DWBW0;
         DAC_CTL |= bit_width;
-    }else{
+    } else {
         /* configure DAC1 wave bit width */
         DAC_CTL &= ~DAC_CTL_DWBW1;
         DAC_CTL |= (bit_width << DAC1_REG_OFFSET);
@@ -359,7 +360,7 @@ void dac_wave_bit_width_config(uint32_t dac_periph, uint32_t bit_width)
 }
 
 /*!
-    \brief    configure DAC LFSR noise mode
+    \brief      configure DAC LFSR noise mode
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  unmask_bits: unmask LFSR bits in DAC LFSR noise mode
                 only one parameter can be selected which is shown as below:
@@ -380,11 +381,11 @@ void dac_wave_bit_width_config(uint32_t dac_periph, uint32_t bit_width)
 */
 void dac_lfsr_noise_config(uint32_t dac_periph, uint32_t unmask_bits)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* configure DAC0 LFSR noise mode */
         DAC_CTL &= ~DAC_CTL_DWBW0;
         DAC_CTL |= unmask_bits;
-    }else{
+    } else {
         /* configure DAC1 LFSR noise mode */
         DAC_CTL &= ~DAC_CTL_DWBW1;
         DAC_CTL |= (unmask_bits << DAC1_REG_OFFSET);
@@ -392,7 +393,7 @@ void dac_lfsr_noise_config(uint32_t dac_periph, uint32_t unmask_bits)
 }
 
 /*!
-    \brief    configure DAC triangle noise mode
+    \brief      configure DAC triangle noise mode
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[in]  amplitude: triangle amplitude in DAC triangle noise mode
                 only one parameter can be selected which is shown as below:
@@ -413,11 +414,11 @@ void dac_lfsr_noise_config(uint32_t dac_periph, uint32_t unmask_bits)
 */
 void dac_triangle_noise_config(uint32_t dac_periph, uint32_t amplitude)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* configure DAC0 triangle noise mode */
         DAC_CTL &= ~DAC_CTL_DWBW0;
         DAC_CTL |= amplitude;
-    }else{
+    } else {
         /* configure DAC1 triangle noise mode */
         DAC_CTL &= ~DAC_CTL_DWBW1;
         DAC_CTL |= (amplitude << DAC1_REG_OFFSET);
@@ -425,7 +426,7 @@ void dac_triangle_noise_config(uint32_t dac_periph, uint32_t amplitude)
 }
 
 /*!
-    \brief    enable DAC concurrent mode
+    \brief      enable DAC concurrent mode
     \param[in]  none
     \param[out] none
     \retval     none
@@ -438,7 +439,7 @@ void dac_concurrent_enable(void)
 }
 
 /*!
-    \brief    disable DAC concurrent mode
+    \brief      disable DAC concurrent mode
     \param[in]  none
     \param[out] none
     \retval     none
@@ -451,7 +452,7 @@ void dac_concurrent_disable(void)
 }
 
 /*!
-    \brief    enable DAC concurrent software trigger function
+    \brief      enable DAC concurrent software trigger function
     \param[in]  none
     \param[out] none
     \retval     none
@@ -460,11 +461,11 @@ void dac_concurrent_software_trigger_enable(void)
 {
     uint32_t swt = 0U;
     swt = DAC_SWT_SWTR0 | DAC_SWT_SWTR1;
-    DAC_SWT |= (swt); 
+    DAC_SWT |= (swt);
 }
 
 /*!
-    \brief    disable DAC concurrent software trigger function
+    \brief      disable DAC concurrent software trigger function
     \param[in]  none
     \param[out] none
     \retval     none
@@ -477,7 +478,7 @@ void dac_concurrent_software_trigger_disable(void)
 }
 
 /*!
-    \brief    enable DAC concurrent buffer function
+    \brief      enable DAC concurrent buffer function
     \param[in]  none
     \param[out] none
     \retval     none
@@ -490,7 +491,7 @@ void dac_concurrent_output_buffer_enable(void)
 }
 
 /*!
-    \brief    disable DAC concurrent buffer function
+    \brief      disable DAC concurrent buffer function
     \param[in]  none
     \param[out] none
     \retval     none
@@ -503,7 +504,7 @@ void dac_concurrent_output_buffer_disable(void)
 }
 
 /*!
-    \brief    set DAC concurrent mode data holding register value
+    \brief      set DAC concurrent mode data holding register value
     \param[in]  dac_align: data alignment
                 only one parameter can be selected which is shown as below:
       \arg        DAC_ALIGN_8B_R: data right 8b alignment
@@ -517,7 +518,7 @@ void dac_concurrent_output_buffer_disable(void)
 void dac_concurrent_data_set(uint32_t dac_align, uint16_t data0, uint16_t data1)
 {
     uint32_t data = 0U;
-    switch(dac_align){
+    switch(dac_align) {
     /* data right 12b alignment */
     case DAC_ALIGN_12B_R:
         data = ((uint32_t)data1 << DH_12BIT_OFFSET) | data0;
@@ -539,7 +540,7 @@ void dac_concurrent_data_set(uint32_t dac_align, uint16_t data0, uint16_t data1)
 }
 
 /*!
-    \brief    enable DAC concurrent interrupt funcution
+    \brief      enable DAC concurrent interrupt funcution
     \param[in]  none
     \param[out] none
     \retval     none
@@ -552,7 +553,7 @@ void dac_concurrent_interrupt_enable(void)
 }
 
 /*!
-    \brief    disable DAC concurrent interrupt funcution
+    \brief      disable DAC concurrent interrupt funcution
     \param[in]  none
     \param[out] none
     \retval     none
@@ -565,37 +566,7 @@ void dac_concurrent_interrupt_disable(void)
 }
 
 /*!
-    \brief    enable DAC interrupt(DAC DMA underrun interrupt)
-    \param[in]  dac_periph: DACx(x = 0,1)
-    \param[out] none
-    \retval     none
-*/
-void dac_interrupt_enable(uint32_t dac_periph)
-{
-    if(DAC0 == dac_periph){
-        DAC_CTL |= DAC_CTL_DDUDRIE0;
-    }else{
-        DAC_CTL |= DAC_CTL_DDUDRIE1;
-    }
-}
-
-/*!
-    \brief    disable DAC interrupt(DAC DMA underrun interrupt)
-    \param[in]  dac_periph: DACx(x = 0,1)
-    \param[out] none
-    \retval     none
-*/
-void dac_interrupt_disable(uint32_t dac_periph)
-{
-    if(DAC0 == dac_periph){
-        DAC_CTL &= ~DAC_CTL_DDUDRIE0;
-    }else{
-        DAC_CTL &= ~DAC_CTL_DDUDRIE1;
-    }
-}
-
-/*!
-    \brief    get the specified DAC flag (DAC DMA underrun flag)
+    \brief      get the specified DAC flag (DAC DMA underrun flag)
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     FlagStatus: SET or RESET
@@ -603,14 +574,14 @@ void dac_interrupt_disable(uint32_t dac_periph)
 FlagStatus dac_flag_get(uint32_t dac_periph)
 {
     FlagStatus temp_flag = RESET;
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* check the DMA underrun flag */
-        if(RESET != (DAC_STAT & DAC_STAT_DDUDR0)){
+        if(RESET != (DAC_STAT & DAC_STAT_DDUDR0)) {
             temp_flag = SET;
         }
-    }else{
+    } else {
         /* check the DMA underrun flag */
-        if(RESET != (DAC_STAT & DAC_STAT_DDUDR1)){
+        if(RESET != (DAC_STAT & DAC_STAT_DDUDR1)) {
             temp_flag = SET;
         }
     }
@@ -618,22 +589,52 @@ FlagStatus dac_flag_get(uint32_t dac_periph)
 }
 
 /*!
-    \brief    clear the specified DAC flag (DAC DMA underrun flag)
+    \brief      clear the specified DAC flag (DAC DMA underrun flag)
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_flag_clear(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_STAT |= DAC_STAT_DDUDR0;
-    }else{
+    } else {
         DAC_STAT |= DAC_STAT_DDUDR1;
     }
 }
 
 /*!
-    \brief    get the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
+    \brief      enable DAC interrupt(DAC DMA underrun interrupt)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_interrupt_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DDUDRIE0;
+    } else {
+        DAC_CTL |= DAC_CTL_DDUDRIE1;
+    }
+}
+
+/*!
+    \brief      disable DAC interrupt(DAC DMA underrun interrupt)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_interrupt_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DDUDRIE0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DDUDRIE1;
+    }
+}
+
+/*!
+    \brief      get the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     FlagStatus: SET or RESET
@@ -643,18 +644,18 @@ FlagStatus dac_interrupt_flag_get(uint32_t dac_periph)
     FlagStatus temp_flag = RESET;
     uint32_t ddudr_flag = 0U, ddudrie_flag = 0U;
 
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         /* check the DMA underrun flag and DAC DMA underrun interrupt enable flag */
         ddudr_flag = DAC_STAT & DAC_STAT_DDUDR0;
         ddudrie_flag = DAC_CTL & DAC_CTL_DDUDRIE0;
-        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)){
+        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)) {
             temp_flag = SET;
         }
-    }else{
+    } else {
         /* check the DMA underrun flag and DAC DMA underrun interrupt enable flag */
         ddudr_flag = DAC_STAT & DAC_STAT_DDUDR1;
         ddudrie_flag = DAC_CTL & DAC_CTL_DDUDRIE1;
-        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)){
+        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)) {
             temp_flag = SET;
         }
     }
@@ -662,16 +663,16 @@ FlagStatus dac_interrupt_flag_get(uint32_t dac_periph)
 }
 
 /*!
-    \brief    clear the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
+    \brief      clear the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
     \param[in]  dac_periph: DACx(x = 0,1)
     \param[out] none
     \retval     none
 */
 void dac_interrupt_flag_clear(uint32_t dac_periph)
 {
-    if(DAC0 == dac_periph){
+    if(DAC0 == dac_periph) {
         DAC_STAT |= DAC_STAT_DDUDR0;
-    }else{
+    } else {
         DAC_STAT |= DAC_STAT_DDUDR1;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_dbg.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_dbg.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_dbg.c
     \brief   DBG driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -95,29 +96,28 @@ void dbg_low_power_disable(uint32_t dbg_low_power)
     \brief    enable peripheral behavior when the mcu is in debug mode
     \param[in]  dbg_periph: dbg_periph_enum
                 only one parameter can be selected which is shown as below:
-      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted  
-      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted  
-      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted  
-      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted  
-      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted  
-      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted  
-      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted  
-      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted  
-      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted  
-      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted  
-      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted  
-      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted  
-      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted  
-      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted  
-      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted  
-      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted  
-      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted  
-      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted  
-      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted  
-      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted  
-      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted  
-      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted  
-      \arg        \param[out] none
+      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted
+      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted
+      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted
+      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted
+      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted
+      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted
+      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted
+      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted
+      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted
+      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted
+      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted
+      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted
+      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted
+      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted
+      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted
+      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted
+      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted
+      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted
+      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted
+      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted
+      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted
+      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted
     \retval     none
 */
 void dbg_periph_enable(dbg_periph_enum dbg_periph)
@@ -129,28 +129,28 @@ void dbg_periph_enable(dbg_periph_enum dbg_periph)
     \brief    disable peripheral behavior when the mcu is in debug mode
     \param[in]  dbg_periph: dbg_periph_enum
                 only one parameter can be selected which is shown as below:
-      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted  
-      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted  
-      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted  
-      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted  
-      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted  
-      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted  
-      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted  
-      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted  
-      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted  
-      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted  
-      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted  
-      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted  
-      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted  
-      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted  
-      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted  
-      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted  
-      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted  
-      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted  
-      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted  
-      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted  
-      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted  
-      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted  
+      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted
+      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted
+      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted
+      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted
+      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted
+      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted
+      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted
+      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted
+      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted
+      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted
+      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted
+      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted
+      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted
+      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted
+      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted
+      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted
+      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted
+      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted
+      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted
+      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted
+      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted
+      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted
     \param[out] none
     \retval     none
 */
@@ -181,18 +181,3 @@ void dbg_trace_pin_disable(void)
     DBG_CTL0 &= ~DBG_CTL0_TRACE_IOEN;
 }
 
-/*!
-    \brief    trace pin mode selection 
-    \param[in]  trace_mode:
-      \arg        TRACE_MODE_ASYNC: trace pin used for async mode 
-      \arg        TRACE_MODE_SYNC_DATASIZE_1: trace pin used for sync mode and data size is 1
-      \arg        TRACE_MODE_SYNC_DATASIZE_2: trace pin used for sync mode and data size is 2
-      \arg        TRACE_MODE_SYNC_DATASIZE_4: trace pin used for sync mode and data size is 4
-    \param[out] none
-    \retval     none
-*/
-void dbg_trace_pin_mode_set(uint32_t trace_mode)
-{
-    DBG_CTL0 &= ~DBG_CTL0_TRACE_MODE;
-    DBG_CTL0 |= trace_mode;
-}

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_dci.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_dci.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_dci.c
     \brief   DCI driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -62,7 +63,7 @@ void dci_deinit(void)
     \param[out] none
     \retval     none
 */
-void dci_init(dci_parameter_struct* dci_struct)
+void dci_init(dci_parameter_struct *dci_struct)
 {
     uint32_t reg = 0U;
     /* disable capture function and DCI */
@@ -79,18 +80,18 @@ void dci_init(dci_parameter_struct* dci_struct)
 }
 
 /*!
-    \brief    enable DCI function 
+    \brief    enable DCI function
     \param[in]  none
     \param[out] none
     \retval     none
 */
 void dci_enable(void)
 {
-    DCI_CTL |= DCI_CTL_DCIEN;    
+    DCI_CTL |= DCI_CTL_DCIEN;
 }
 
 /*!
-    \brief    disable DCI function 
+    \brief    disable DCI function
     \param[in]  none
     \param[out] none
     \retval     none
@@ -101,7 +102,7 @@ void dci_disable(void)
 }
 
 /*!
-    \brief    enable DCI capture 
+    \brief    enable DCI capture
     \param[in]  none
     \param[out] none
     \retval     none
@@ -112,7 +113,7 @@ void dci_capture_enable(void)
 }
 
 /*!
-    \brief    disable DCI capture 
+    \brief    disable DCI capture
     \param[in]  none
     \param[out] none
     \retval     none
@@ -123,7 +124,7 @@ void dci_capture_disable(void)
 }
 
 /*!
-    \brief    enable DCI jpeg mode 
+    \brief    enable DCI jpeg mode
     \param[in]  none
     \param[out] none
     \retval     none
@@ -134,7 +135,7 @@ void dci_jpeg_enable(void)
 }
 
 /*!
-    \brief    disable DCI jpeg mode 
+    \brief    disable DCI jpeg mode
     \param[in]  none
     \param[out] none
     \retval     none
@@ -167,7 +168,7 @@ void dci_crop_window_disable(void)
 }
 
 /*!
-    \brief    configure DCI cropping window 
+    \brief    configure DCI cropping window
     \param[in]  start_x: window horizontal start position
     \param[in]  start_y: window vertical start position
     \param[in]  size_width: window horizontal size
@@ -177,8 +178,8 @@ void dci_crop_window_disable(void)
 */
 void dci_crop_window_config(uint16_t start_x, uint16_t start_y, uint16_t size_width, uint16_t size_height)
 {
-    DCI_CWSPOS = ((uint32_t)start_x | ((uint32_t)start_y<<16));
-    DCI_CWSZ = ((uint32_t)size_width | ((uint32_t)size_height<<16));
+    DCI_CWSPOS = ((uint32_t)start_x | ((uint32_t)start_y << 16));
+    DCI_CWSZ = ((uint32_t)size_width | ((uint32_t)size_height << 16));
 }
 
 /*!
@@ -213,7 +214,7 @@ void dci_embedded_sync_disable(void)
 */
 void dci_sync_codes_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end)
 {
-    DCI_SC = ((uint32_t)frame_start | ((uint32_t)line_start<<8) | ((uint32_t)line_end<<16) | ((uint32_t)frame_end<<24));
+    DCI_SC = ((uint32_t)frame_start | ((uint32_t)line_start << 8) | ((uint32_t)line_end << 16) | ((uint32_t)frame_end << 24));
 }
 
 /*!
@@ -227,7 +228,7 @@ void dci_sync_codes_config(uint8_t frame_start, uint8_t line_start, uint8_t line
 */
 void dci_sync_codes_unmask_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end)
 {
-    DCI_SCUMSK = ((uint32_t)frame_start | ((uint32_t)line_start<<8) | ((uint32_t)line_end<<16) | ((uint32_t)frame_end<<24));	
+    DCI_SCUMSK = ((uint32_t)frame_start | ((uint32_t)line_start << 8) | ((uint32_t)line_end << 16) | ((uint32_t)frame_end << 24));
 }
 
 /*!
@@ -258,18 +259,18 @@ uint32_t dci_data_read(void)
 FlagStatus dci_flag_get(uint32_t flag)
 {
     uint32_t stat = 0U;
-    
-    if(flag >> 31){
+
+    if(flag >> 31) {
         /* get flag status from DCI_STAT1 register */
         stat = DCI_STAT1;
-    }else{
+    } else {
         /* get flag status from DCI_STAT0 register */
         stat = DCI_STAT0;
     }
-    
-    if(flag & stat){
+
+    if(flag & stat) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -279,7 +280,7 @@ FlagStatus dci_flag_get(uint32_t flag)
     \param[in]  interrupt:
       \arg         DCI_INT_EF: end of frame interrupt
       \arg         DCI_INT_OVR: FIFO overrun interrupt
-      \arg         DCI_INT_ESE: embedded synchronous error interrupt 
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
       \arg         DCI_INT_VSYNC: vsync interrupt
       \arg         DCI_INT_EL: end of line interrupt
     \param[out] none
@@ -295,7 +296,7 @@ void dci_interrupt_enable(uint32_t interrupt)
     \param[in]  interrupt:
       \arg         DCI_INT_EF: end of frame interrupt
       \arg         DCI_INT_OVR: FIFO overrun interrupt
-      \arg         DCI_INT_ESE: embedded synchronous error interrupt 
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
       \arg         DCI_INT_VSYNC: vsync interrupt
       \arg         DCI_INT_EL: end of line interrupt
     \param[out] none
@@ -311,7 +312,7 @@ void dci_interrupt_disable(uint32_t interrupt)
     \param[in]  int_flag:
       \arg         DCI_INT_EF: end of frame interrupt
       \arg         DCI_INT_OVR: FIFO overrun interrupt
-      \arg         DCI_INT_ESE: embedded synchronous error interrupt 
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
       \arg         DCI_INT_VSYNC: vsync interrupt
       \arg         DCI_INT_EL: end of line interrupt
     \param[out] none
@@ -327,7 +328,7 @@ void dci_interrupt_flag_clear(uint32_t int_flag)
     \param[in]  int_flag:
       \arg         DCI_INT_FLAG_EF: end of frame interrupt flag
       \arg         DCI_INT_FLAG_OVR: FIFO overrun interrupt flag
-      \arg         DCI_INT_FLAG_ESE: embedded synchronous error interrupt flag 
+      \arg         DCI_INT_FLAG_ESE: embedded synchronous error interrupt flag
       \arg         DCI_INT_FLAG_VSYNC: vsync interrupt flag
       \arg         DCI_INT_FLAG_EL: end of line interrupt flag
     \param[out] none
@@ -335,9 +336,9 @@ void dci_interrupt_flag_clear(uint32_t int_flag)
 */
 FlagStatus dci_interrupt_flag_get(uint32_t int_flag)
 {
-    if(RESET == (DCI_INTF & int_flag)){
+    if(RESET == (DCI_INTF & int_flag)) {
         return RESET;
-    }else{
+    } else {
         return SET;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_dma.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_dma.c
@@ -1,39 +1,38 @@
 /*!
     \file    gd32f4xx_dma.c
     \brief   DMA driver
-
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
-
 
 #include "gd32f4xx_dma.h"
 
@@ -52,19 +51,19 @@ OF SUCH DAMAGE.
 void dma_deinit(uint32_t dma_periph, dma_channel_enum channelx)
 {
     /* disable DMA a channel */
-    DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_CHEN;
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
     /* reset DMA channel registers */
-    DMA_CHCTL(dma_periph,channelx) = DMA_CHCTL_RESET_VALUE;
-    DMA_CHCNT(dma_periph,channelx) = DMA_CHCNT_RESET_VALUE;
-    DMA_CHPADDR(dma_periph,channelx) = DMA_CHPADDR_RESET_VALUE;
-    DMA_CHM0ADDR(dma_periph,channelx) = DMA_CHMADDR_RESET_VALUE;
-    DMA_CHM1ADDR(dma_periph,channelx) = DMA_CHMADDR_RESET_VALUE;
-    DMA_CHFCTL(dma_periph,channelx) = DMA_CHFCTL_RESET_VALUE;
-    if(channelx < DMA_CH4){
-        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE,channelx);
-    }else{
+    DMA_CHCTL(dma_periph, channelx) = DMA_CHCTL_RESET_VALUE;
+    DMA_CHCNT(dma_periph, channelx) = DMA_CHCNT_RESET_VALUE;
+    DMA_CHPADDR(dma_periph, channelx) = DMA_CHPADDR_RESET_VALUE;
+    DMA_CHM0ADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
+    DMA_CHM1ADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
+    DMA_CHFCTL(dma_periph, channelx) = DMA_CHFCTL_RESET_VALUE;
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
+    } else {
         channelx -= (dma_channel_enum)4;
-        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE,channelx);
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
     }
 }
 
@@ -74,7 +73,7 @@ void dma_deinit(uint32_t dma_periph, dma_channel_enum channelx)
     \param[out] none
     \retval     none
 */
-void dma_single_data_para_struct_init(dma_single_data_parameter_struct* init_struct)
+void dma_single_data_para_struct_init(dma_single_data_parameter_struct *init_struct)
 {
     /* set the DMA struct with the default values */
     init_struct->periph_addr         = 0U;
@@ -94,7 +93,7 @@ void dma_single_data_para_struct_init(dma_single_data_parameter_struct* init_str
     \param[out] none
     \retval     none
 */
-void dma_multi_data_para_struct_init(dma_multi_data_parameter_struct* init_struct)
+void dma_multi_data_para_struct_init(dma_multi_data_parameter_struct *init_struct)
 {
     /* set the DMA struct with the default values */
     init_struct->periph_addr         = 0U;
@@ -123,56 +122,56 @@ void dma_multi_data_para_struct_init(dma_multi_data_parameter_struct* init_struc
                   memory0_addr: memory base address
                   memory_inc: DMA_MEMORY_INCREASE_ENABLE,DMA_MEMORY_INCREASE_DISABLE
                   periph_memory_width: DMA_PERIPH_WIDTH_8BIT,DMA_PERIPH_WIDTH_16BIT,DMA_PERIPH_WIDTH_32BIT
-                  circular_mode: DMA_CIRCULAR_MODE_ENABLE,DMA_CIRCULAR_MODE_DISABLE                 
+                  circular_mode: DMA_CIRCULAR_MODE_ENABLE,DMA_CIRCULAR_MODE_DISABLE
                   direction: DMA_PERIPH_TO_MEMORY,DMA_MEMORY_TO_PERIPH,DMA_MEMORY_TO_MEMORY
                   number: the number of remaining data to be transferred by the DMA
-                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH                
+                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH
     \param[out] none
     \retval     none
 */
-void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_single_data_parameter_struct* init_struct)
+void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_single_data_parameter_struct *init_struct)
 {
     uint32_t ctl;
-    
+
     /* select single data mode */
-    DMA_CHFCTL(dma_periph,channelx) &= ~DMA_CHXFCTL_MDMEN;
-    
+    DMA_CHFCTL(dma_periph, channelx) &= ~DMA_CHXFCTL_MDMEN;
+
     /* configure peripheral base address */
-    DMA_CHPADDR(dma_periph,channelx) = init_struct->periph_addr;
-    
+    DMA_CHPADDR(dma_periph, channelx) = init_struct->periph_addr;
+
     /* configure memory base address */
-    DMA_CHM0ADDR(dma_periph,channelx) = init_struct->memory0_addr;
-    
+    DMA_CHM0ADDR(dma_periph, channelx) = init_struct->memory0_addr;
+
     /* configure the number of remaining data to be transferred */
-    DMA_CHCNT(dma_periph,channelx) = init_struct->number;
-    
+    DMA_CHCNT(dma_periph, channelx) = init_struct->number;
+
     /* configure peripheral and memory transfer width,channel priotity,transfer mode */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     ctl &= ~(DMA_CHXCTL_PWIDTH | DMA_CHXCTL_MWIDTH | DMA_CHXCTL_PRIO | DMA_CHXCTL_TM);
     ctl |= (init_struct->periph_memory_width | (init_struct->periph_memory_width << 2) | init_struct->priority | init_struct->direction);
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 
     /* configure peripheral increasing mode */
-    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PNAGA;
-    }else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc){
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_PNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PAIF;
+    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
     }
 
     /* configure memory increasing mode */
-    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_MNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_MNAGA;
+    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
     }
 
     /* configure DMA circular mode */
-    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_CMEN;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_CMEN;
+    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
     }
 }
 
@@ -185,7 +184,7 @@ void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, d
     \param[in]  dma_multi_data_parameter_struct: the data needed to initialize DMA multi data mode
                   periph_addr: peripheral base address
                   periph_width: DMA_PERIPH_WIDTH_8BIT,DMA_PERIPH_WIDTH_16BIT,DMA_PERIPH_WIDTH_32BIT
-                  periph_inc: DMA_PERIPH_INCREASE_ENABLE,DMA_PERIPH_INCREASE_DISABLE,DMA_PERIPH_INCREASE_FIX 
+                  periph_inc: DMA_PERIPH_INCREASE_ENABLE,DMA_PERIPH_INCREASE_DISABLE,DMA_PERIPH_INCREASE_FIX
                   memory0_addr: memory0 base address
                   memory_width: DMA_MEMORY_WIDTH_8BIT,DMA_MEMORY_WIDTH_16BIT,DMA_MEMORY_WIDTH_32BIT
                   memory_inc: DMA_MEMORY_INCREASE_ENABLE,DMA_MEMORY_INCREASE_DISABLE
@@ -195,53 +194,54 @@ void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, d
                   circular_mode: DMA_CIRCULAR_MODE_ENABLE,DMA_CIRCULAR_MODE_DISABLE
                   direction: DMA_PERIPH_TO_MEMORY,DMA_MEMORY_TO_PERIPH,DMA_MEMORY_TO_MEMORY
                   number: the number of remaining data to be transferred by the DMA
-                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH            
+                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH
     \param[out] none
     \retval     none
 */
-void dma_multi_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_multi_data_parameter_struct* init_struct)
+void dma_multi_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_multi_data_parameter_struct *init_struct)
 {
     uint32_t ctl;
-    
+
     /* select multi data mode and configure FIFO critical value */
-    DMA_CHFCTL(dma_periph,channelx) |= (DMA_CHXFCTL_MDMEN | init_struct->critical_value);
-    
+    DMA_CHFCTL(dma_periph, channelx) |= (DMA_CHXFCTL_MDMEN | init_struct->critical_value);
+
     /* configure peripheral base address */
-    DMA_CHPADDR(dma_periph,channelx) = init_struct->periph_addr;
-    
+    DMA_CHPADDR(dma_periph, channelx) = init_struct->periph_addr;
+
     /* configure memory base address */
-    DMA_CHM0ADDR(dma_periph,channelx) = init_struct->memory0_addr;
-    
+    DMA_CHM0ADDR(dma_periph, channelx) = init_struct->memory0_addr;
+
     /* configure the number of remaining data to be transferred */
-    DMA_CHCNT(dma_periph,channelx) = init_struct->number;
-    
+    DMA_CHCNT(dma_periph, channelx) = init_struct->number;
+
     /* configure peripheral and memory transfer width,channel priotity,transfer mode,peripheral and memory burst transfer width */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     ctl &= ~(DMA_CHXCTL_PWIDTH | DMA_CHXCTL_MWIDTH | DMA_CHXCTL_PRIO | DMA_CHXCTL_TM | DMA_CHXCTL_PBURST | DMA_CHXCTL_MBURST);
-    ctl |= (init_struct->periph_width | (init_struct->memory_width ) | init_struct->priority | init_struct->direction | init_struct->memory_burst_width | init_struct->periph_burst_width);
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    ctl |= (init_struct->periph_width | (init_struct->memory_width) | init_struct->priority | init_struct->direction | init_struct->memory_burst_width |
+            init_struct->periph_burst_width);
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 
     /* configure peripheral increasing mode */
-    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PNAGA;
-    }else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc){
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_PNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PAIF;
+    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
     }
 
     /* configure memory increasing mode */
-    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_MNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_MNAGA;
+    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
     }
 
     /* configure DMA circular mode */
-    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_CMEN;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_CMEN;
+    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
     }
 }
 
@@ -257,14 +257,14 @@ void dma_multi_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dm
 */
 void dma_periph_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t address)
 {
-    DMA_CHPADDR(dma_periph,channelx) = address;
+    DMA_CHPADDR(dma_periph, channelx) = address;
 }
 
 /*!
     \brief    set DMA Memory0 base address
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel to set Memory base address 
+    \param[in]  channelx: specify which DMA channel to set Memory base address
       \arg        DMA_CHx(x=0..7)
     \param[in]  memory_flag: DMA_MEMORY_x(x=0,1)
     \param[in]  address: Memory base address
@@ -273,10 +273,10 @@ void dma_periph_address_config(uint32_t dma_periph, dma_channel_enum channelx, u
 */
 void dma_memory_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t memory_flag, uint32_t address)
 {
-    if(memory_flag){
-        DMA_CHM1ADDR(dma_periph,channelx) = address;
-    }else{
-        DMA_CHM0ADDR(dma_periph,channelx) = address;
+    if(memory_flag) {
+        DMA_CHM1ADDR(dma_periph, channelx) = address;
+    } else {
+        DMA_CHM0ADDR(dma_periph, channelx) = address;
     }
 }
 
@@ -292,21 +292,21 @@ void dma_memory_address_config(uint32_t dma_periph, dma_channel_enum channelx, u
 */
 void dma_transfer_number_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t number)
 {
-    DMA_CHCNT(dma_periph,channelx) = number;
+    DMA_CHCNT(dma_periph, channelx) = number;
 }
 
 /*!
     \brief    get the number of remaining data to be transferred by the DMA
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel to set number 
+    \param[in]  channelx: specify which DMA channel to set number
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     uint32_t: the number of remaining data to be transferred by the DMA 
+    \retval     uint32_t: the number of remaining data to be transferred by the DMA
 */
 uint32_t dma_transfer_number_get(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    return (uint32_t)DMA_CHCNT(dma_periph,channelx);
+    return (uint32_t)DMA_CHCNT(dma_periph, channelx);
 }
 
 /*!
@@ -322,17 +322,17 @@ uint32_t dma_transfer_number_get(uint32_t dma_periph, dma_channel_enum channelx)
       \arg        DMA_PRIORITY_HIGH: high priority
       \arg        DMA_PRIORITY_ULTRA_HIGH: ultra high priority
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_priority_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t priority)
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_PRIO;
     ctl |= priority;
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
@@ -349,15 +349,15 @@ void dma_priority_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_
     \param[out] none
     \retval     none
 */
-void dma_memory_burst_beats_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t mbeat)
+void dma_memory_burst_beats_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t mbeat)
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_MBURST;
     ctl |= mbeat;
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
@@ -375,15 +375,15 @@ void dma_memory_burst_beats_config (uint32_t dma_periph, dma_channel_enum channe
     \param[out] none
     \retval     none
 */
-void dma_periph_burst_beats_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t pbeat)
+void dma_periph_burst_beats_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t pbeat)
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_PBURST;
     ctl |= pbeat;
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
@@ -404,18 +404,18 @@ void dma_memory_width_config(uint32_t dma_periph, dma_channel_enum channelx, uin
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_MWIDTH;
     ctl |= msize;
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
-    \brief    configure transfer data size of peripheral 
+    \brief    configure transfer data size of peripheral
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  msize: transfer data size of peripheral
                 only one parameter can be selected which is shown as below:
@@ -425,22 +425,22 @@ void dma_memory_width_config(uint32_t dma_periph, dma_channel_enum channelx, uin
     \param[out] none
     \retval     none
 */
-void dma_periph_width_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t psize)
+void dma_periph_width_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t psize)
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_PWIDTH;
     ctl |= psize;
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
     \brief    configure memory address generation generation_algorithm
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  generation_algorithm: the address generation algorithm
                 only one parameter can be selected which is shown as below:
@@ -451,10 +451,10 @@ void dma_periph_width_config (uint32_t dma_periph, dma_channel_enum channelx, ui
 */
 void dma_memory_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm)
 {
-    if(DMA_MEMORY_INCREASE_ENABLE == generation_algorithm){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_MNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_MNAGA;
+    if(DMA_MEMORY_INCREASE_ENABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
     }
 }
 
@@ -462,7 +462,7 @@ void dma_memory_address_generation_config(uint32_t dma_periph, dma_channel_enum 
     \brief    configure peripheral address generation_algorithm
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  generation_algorithm: the address generation algorithm
                 only one parameter can be selected which is shown as below:
@@ -474,13 +474,13 @@ void dma_memory_address_generation_config(uint32_t dma_periph, dma_channel_enum 
 */
 void dma_peripheral_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm)
 {
-    if(DMA_PERIPH_INCREASE_ENABLE == generation_algorithm){
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PNAGA;
-    }else if(DMA_PERIPH_INCREASE_DISABLE == generation_algorithm){
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_PNAGA;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PNAGA;
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_PAIF;
+    if(DMA_PERIPH_INCREASE_ENABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
     }
 }
 
@@ -488,63 +488,63 @@ void dma_peripheral_address_generation_config(uint32_t dma_periph, dma_channel_e
     \brief    enable DMA circulation mode
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_circulation_enable(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_CMEN;
+    DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
 }
 
 /*!
     \brief    disable DMA circulation mode
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_circulation_disable(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_CMEN;
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
 }
 
 /*!
     \brief    enable DMA channel
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_channel_enable(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_CHEN;
+    DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CHEN;
 }
 
 /*!
     \brief    disable DMA channel
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_channel_disable(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_CHEN;
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
 }
 
 /*!
     \brief    configure the direction of  data transfer on the channel
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  direction: specify the direction of  data transfer
                 only one parameter can be selected which is shown as below:
@@ -558,34 +558,34 @@ void dma_transfer_direction_config(uint32_t dma_periph, dma_channel_enum channel
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_TM;
     ctl |= direction;
-    
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
     \brief    DMA switch buffer mode config
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  memory1_addr: memory1 base address
     \param[in]  memory_select: DMA_MEMORY_0 or DMA_MEMORY_1
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_switch_buffer_mode_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t memory1_addr, uint32_t memory_select)
 {
     /* configure memory1 base address */
-    DMA_CHM1ADDR(dma_periph,channelx) = memory1_addr;
+    DMA_CHM1ADDR(dma_periph, channelx) = memory1_addr;
 
-    if(DMA_MEMORY_0 == memory_select){
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_MBS;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_MBS;
+    if(DMA_MEMORY_0 == memory_select) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MBS;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MBS;
     }
 }
 
@@ -593,16 +593,16 @@ void dma_switch_buffer_mode_config(uint32_t dma_periph, dma_channel_enum channel
     \brief    DMA using memory get
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     the using memory 
+    \retval     the using memory
 */
 uint32_t dma_using_memory_get(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    if((DMA_CHCTL(dma_periph,channelx)) & DMA_CHXCTL_MBS){
+    if((DMA_CHCTL(dma_periph, channelx)) & DMA_CHXCTL_MBS) {
         return DMA_MEMORY_1;
-    }else{
+    } else {
         return DMA_MEMORY_0;
     }
 }
@@ -611,32 +611,32 @@ uint32_t dma_using_memory_get(uint32_t dma_periph, dma_channel_enum channelx)
     \brief    DMA channel peripheral select
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  sub_periph: specify DMA channel peripheral
       \arg        DMA_SUBPERIx(x=0..7)
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_channel_subperipheral_select(uint32_t dma_periph, dma_channel_enum channelx, dma_subperipheral_enum sub_periph)
 {
     uint32_t ctl;
     /* acquire DMA_CHxCTL register */
-    ctl = DMA_CHCTL(dma_periph,channelx);
+    ctl = DMA_CHCTL(dma_periph, channelx);
     /* assign regiser */
     ctl &= ~DMA_CHXCTL_PERIEN;
     ctl |= ((uint32_t)sub_periph << CHXCTL_PERIEN_OFFSET);
-    
-    DMA_CHCTL(dma_periph,channelx) = ctl;
+
+    DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
     \brief    DMA flow controller configure
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
-    \param[in]  controller: specify DMA flow controler 
+    \param[in]  controller: specify DMA flow controler
                 only one parameter can be selected which is shown as below:
       \arg        DMA_FLOW_CONTROLLER_DMA: DMA is the flow controller
       \arg        DMA_FLOW_CONTROLLER_PERI: peripheral is the flow controller
@@ -645,10 +645,10 @@ void dma_channel_subperipheral_select(uint32_t dma_periph, dma_channel_enum chan
 */
 void dma_flow_controller_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t controller)
 {
-    if(DMA_FLOW_CONTROLLER_DMA == controller){
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_TFCS;
-    }else{
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_TFCS;
+    if(DMA_FLOW_CONTROLLER_DMA == controller) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_TFCS;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_TFCS;
     }
 }
 
@@ -656,20 +656,20 @@ void dma_flow_controller_config(uint32_t dma_periph, dma_channel_enum channelx, 
     \brief    DMA switch buffer mode enable
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[in]  newvalue: ENABLE or DISABLE
     \param[out] none
-    \retval     none 
+    \retval     none
 */
 void dma_switch_buffer_mode_enable(uint32_t dma_periph, dma_channel_enum channelx, ControlStatus newvalue)
 {
-    if(ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         /* switch buffer mode enable */
-        DMA_CHCTL(dma_periph,channelx) |= DMA_CHXCTL_SBMEN;
-    }else{
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_SBMEN;
+    } else {
         /* switch buffer mode disable */
-        DMA_CHCTL(dma_periph,channelx) &= ~DMA_CHXCTL_SBMEN;
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_SBMEN;
     }
 }
 
@@ -677,18 +677,18 @@ void dma_switch_buffer_mode_enable(uint32_t dma_periph, dma_channel_enum channel
     \brief    DMA FIFO status get
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
+    \param[in]  channelx: specify which DMA channel
       \arg        DMA_CHx(x=0..7)
     \param[out] none
-    \retval     the using memory 
+    \retval     the using memory
 */
 uint32_t dma_fifo_status_get(uint32_t dma_periph, dma_channel_enum channelx)
 {
-    return (DMA_CHFCTL(dma_periph,channelx) & DMA_CHXFCTL_FCNT);
+    return (DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FCNT);
 }
 
 /*!
-    \brief    get DMA flag is set or not 
+    \brief    get DMA flag is set or not
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specify which DMA channel to get flag
@@ -705,17 +705,17 @@ uint32_t dma_fifo_status_get(uint32_t dma_periph, dma_channel_enum channelx)
 */
 FlagStatus dma_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag)
 {
-    if(channelx < DMA_CH4){
-        if(DMA_INTF0(dma_periph) & DMA_FLAG_ADD(flag,channelx)){
+    if(channelx < DMA_CH4) {
+        if(DMA_INTF0(dma_periph) & DMA_FLAG_ADD(flag, channelx)) {
             return SET;
-        }else{
+        } else {
             return RESET;
         }
-    }else{
+    } else {
         channelx -= (dma_channel_enum)4;
-        if(DMA_INTF1(dma_periph) & DMA_FLAG_ADD(flag,channelx)){
+        if(DMA_INTF1(dma_periph) & DMA_FLAG_ADD(flag, channelx)) {
             return SET;
-        }else{
+        } else {
             return RESET;
         }
     }
@@ -739,16 +739,66 @@ FlagStatus dma_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t
 */
 void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag)
 {
-    if(channelx < DMA_CH4){
-        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(flag,channelx);
-    }else{
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(flag, channelx);
+    } else {
         channelx -= (dma_channel_enum)4;
-        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(flag,channelx);
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(flag, channelx);
     }
 }
 
 /*!
-    \brief    get DMA interrupt flag is set or not 
+    \brief    enable DMA interrupt
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  source: specify which interrupt to enbale
+                only one parameters can be selected which are shown as below:
+      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
+      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
+      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
+      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
+      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
+{
+    if(DMA_CHXFCTL_FEEIE != source) {
+        DMA_CHCTL(dma_periph, channelx) |= source;
+    } else {
+        DMA_CHFCTL(dma_periph, channelx) |= source;
+    }
+}
+
+/*!
+    \brief    disable DMA interrupt
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  source: specify which interrupt to disbale
+                only one parameters can be selected which are shown as below:
+      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
+      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
+      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
+      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
+      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
+{
+    if(DMA_CHXFCTL_FEEIE != source) {
+        DMA_CHCTL(dma_periph, channelx) &= ~source;
+    } else {
+        DMA_CHFCTL(dma_periph, channelx) &= ~source;
+    }
+}
+
+/*!
+    \brief    get DMA interrupt flag is set or not
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specify which DMA channel to get interrupt flag
@@ -765,64 +815,64 @@ void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t fla
 */
 FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt)
 {
-    uint32_t interrupt_enable = 0U,interrupt_flag = 0U;
+    uint32_t interrupt_enable = 0U, interrupt_flag = 0U;
     dma_channel_enum channel_flag_offset = channelx;
-    if(channelx < DMA_CH4){
-        switch(interrupt){
+    if(channelx < DMA_CH4) {
+        switch(interrupt) {
         case DMA_INTF_FEEIF:
-            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt,channelx);
-            interrupt_enable = DMA_CHFCTL(dma_periph,channelx) & DMA_CHXFCTL_FEEIE;
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FEEIE;
             break;
         case DMA_INTF_SDEIF:
-            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt,channelx);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_SDEIE;
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_SDEIE;
             break;
         case DMA_INTF_TAEIF:
-            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt,channelx);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_TAEIE;
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_TAEIE;
             break;
         case DMA_INTF_HTFIF:
-            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt,channelx);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_HTFIE;
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
             break;
         case DMA_INTF_FTFIF:
-            interrupt_flag = (DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt,channelx));
-            interrupt_enable = (DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_FTFIE);
+            interrupt_flag = (DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx));
+            interrupt_enable = (DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE);
             break;
         default:
             break;
         }
-    }else{
+    } else {
         channel_flag_offset -= (dma_channel_enum)4;
-        switch(interrupt){
+        switch(interrupt) {
         case DMA_INTF_FEEIF:
-            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt,channel_flag_offset);
-            interrupt_enable = DMA_CHFCTL(dma_periph,channelx) & DMA_CHXFCTL_FEEIE;
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FEEIE;
             break;
         case DMA_INTF_SDEIF:
-            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt,channel_flag_offset);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_SDEIE;
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_SDEIE;
             break;
         case DMA_INTF_TAEIF:
-            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt,channel_flag_offset);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_TAEIE;
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_TAEIE;
             break;
         case DMA_INTF_HTFIF:
-            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt,channel_flag_offset);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_HTFIE;
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
             break;
         case DMA_INTF_FTFIF:
-            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt,channel_flag_offset);
-            interrupt_enable = DMA_CHCTL(dma_periph,channelx) & DMA_CHXCTL_FTFIE;
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE;
             break;
         default:
             break;
         }
     }
-    
-    if(interrupt_flag && interrupt_enable){
+
+    if(interrupt_flag && interrupt_enable) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -845,61 +895,10 @@ FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx
 */
 void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt)
 {
-    if(channelx < DMA_CH4){
-        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(interrupt,channelx);
-    }else{
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(interrupt, channelx);
+    } else {
         channelx -= (dma_channel_enum)4;
-        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(interrupt,channelx);
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(interrupt, channelx);
     }
 }
-
-/*!
-    \brief    enable DMA interrupt
-    \param[in]  dma_periph: DMAx(x=0,1)
-      \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
-      \arg        DMA_CHx(x=0..7)
-    \param[in]  source: specify which interrupt to enbale
-                one or more parameters can be selected which are shown as below:
-      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
-      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
-      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
-      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
-      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
-    \param[out] none
-    \retval     none
-*/
-void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
-{
-    if(DMA_CHXFCTL_FEEIE != source){
-        DMA_CHCTL(dma_periph,channelx) |= source;
-    }else{
-        DMA_CHFCTL(dma_periph,channelx) |= source;
-    }
-}
-
-/*!
-    \brief    disable DMA interrupt
-    \param[in]  dma_periph: DMAx(x=0,1)
-      \arg        DMAx(x=0,1)
-    \param[in]  channelx: specify which DMA channel 
-      \arg        DMA_CHx(x=0..7)
-    \param[in]  source: specify which interrupt to disbale
-                one or more parameters can be selected which are shown as below:
-      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
-      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
-      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
-      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
-      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
-    \param[out] none
-    \retval     none
-*/
-void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
-{
-    if(DMA_CHXFCTL_FEEIE != source){
-        DMA_CHCTL(dma_periph,channelx) &= ~source;
-    }else{
-        DMA_CHFCTL(dma_periph,channelx) &= ~source;
-    }
-}
-

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_enet.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_enet.c
@@ -5,45 +5,45 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
-
-    Redistribution and use in source and binary forms, with or without modification, 
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_enet.h"
 
 #if defined   (__CC_ARM)                                    /*!< ARM compiler */
-__align(4) 
+__align(4)
 enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM];        /*!< ENET RxDMA descriptor */
-__align(4) 
+__align(4)
 enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM];        /*!< ENET TxDMA descriptor */
-__align(4) 
+__align(4)
 uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE];           /*!< ENET receive buffer */
-__align(4) 
+__align(4)
 uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE];           /*!< ENET transmit buffer */
 
 #elif defined ( __ICCARM__ )                                /*!< IAR compiler */
@@ -57,10 +57,10 @@ uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE];           /*!< ENET receive bu
 uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE];           /*!< ENET transmit buffer */
 
 #elif defined (__GNUC__)        /* GNU Compiler */
-enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM] __attribute__ ((aligned (4)));        /*!< ENET RxDMA descriptor */ 
-enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM] __attribute__ ((aligned (4)));        /*!< ENET TxDMA descriptor */
-uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE] __attribute__ ((aligned (4)));           /*!< ENET receive buffer */
-uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE] __attribute__ ((aligned (4)));           /*!< ENET transmit buffer */
+enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM] __attribute__((aligned(4)));          /*!< ENET RxDMA descriptor */
+enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM] __attribute__((aligned(4)));          /*!< ENET TxDMA descriptor */
+uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE] __attribute__((aligned(4)));             /*!< ENET receive buffer */
+uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE] __attribute__((aligned(4)));             /*!< ENET transmit buffer */
 
 #endif /* __CC_ARM */
 
@@ -73,25 +73,26 @@ enet_descriptors_struct  *dma_current_ptp_txdesc = NULL;
 enet_descriptors_struct  *dma_current_ptp_rxdesc = NULL;
 
 /* init structure parameters for ENET initialization */
-static enet_initpara_struct enet_initpara ={0,0,0,0,0,0,0,0,0,0,0,0,0,0,0};
+static enet_initpara_struct enet_initpara = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
 static uint32_t enet_unknow_err = 0U;
 /* array of register offset for debug information get */
 static const uint16_t enet_reg_tab[] = {
-0x0000, 0x0004, 0x0008, 0x000C, 0x0010, 0x0014, 0x0018, 0x001C, 0x0028, 0x002C, 0x0034,
-0x0038, 0x003C, 0x0040, 0x0044, 0x0048, 0x004C, 0x0050, 0x0054, 0x0058, 0x005C, 0x1080,
-  
-0x0100, 0x0104, 0x0108, 0x010C, 0x0110, 0x014C, 0x0150, 0x0168, 0x0194, 0x0198, 0x01C4, 
- 
-0x0700, 0x0704,0x0708, 0x070C, 0x0710, 0x0714, 0x0718, 0x071C, 0x0720, 0x0728, 0x072C, 
-  
-0x1000, 0x1004, 0x1008, 0x100C, 0x1010, 0x1014, 0x1018, 0x101C, 0x1020, 0x1024, 0x1048,
-0x104C, 0x1050, 0x1054};
+    0x0000, 0x0004, 0x0008, 0x000C, 0x0010, 0x0014, 0x0018, 0x001C, 0x0028, 0x002C, 0x0034,
+    0x0038, 0x003C, 0x0040, 0x0044, 0x0048, 0x004C, 0x0050, 0x0054, 0x0058, 0x005C, 0x1080,
+
+    0x0100, 0x0104, 0x0108, 0x010C, 0x0110, 0x014C, 0x0150, 0x0168, 0x0194, 0x0198, 0x01C4,
+
+    0x0700, 0x0704, 0x0708, 0x070C, 0x0710, 0x0714, 0x0718, 0x071C, 0x0720, 0x0728, 0x072C,
+
+    0x1000, 0x1004, 0x1008, 0x100C, 0x1010, 0x1014, 0x1018, 0x101C, 0x1020, 0x1024, 0x1048,
+    0x104C, 0x1050, 0x1054
+};
 
 /* initialize ENET peripheral with generally concerned parameters, call it by enet_init() */
 static void enet_default_init(void);
 #ifdef USE_DELAY
 /* user can provide more timing precise _ENET_DELAY_ function */
-#define _ENET_DELAY_                              delay_ms 
+#define _ENET_DELAY_                              delay_ms
 #else
 /* insert a delay time */
 static void enet_delay(uint32_t ncount);
@@ -115,7 +116,7 @@ void enet_deinit(void)
 
 /*!
     \brief    configure the parameters which are usually less cared for initialization
-                note -- this function must be called before enet_init(), otherwise 
+                note -- this function must be called before enet_init(), otherwise
                 configuration will be no effect
     \param[in]  option: different function option, which is related to several parameters, refer to enet_option_enum
                 only one parameter can be selected which is shown as below
@@ -124,7 +125,7 @@ void enet_deinit(void)
       \arg        DMA_MAXBURST_OPTION: choose to configure the DMA max burst related parameters
       \arg        DMA_ARBITRATION_OPTION: choose to configure the DMA arbitration related parameters
       \arg        STORE_OPTION: choose to configure the store forward mode related parameters
-      \arg        DMA_OPTION: choose to configure the DMA descriptor related parameters 
+      \arg        DMA_OPTION: choose to configure the DMA descriptor related parameters
       \arg        VLAN_OPTION: choose to configure vlan related parameters
       \arg        FLOWCTL_OPTION: choose to configure flow control related parameters
       \arg        HASHH_OPTION: choose to configure hash high
@@ -133,7 +134,7 @@ void enet_deinit(void)
       \arg        HALFDUPLEX_OPTION: choose to configure halfduplex mode related parameters
       \arg        TIMER_OPTION: choose to configure time counter related parameters
       \arg        INTERFRAMEGAP_OPTION: choose to configure the inter frame gap related parameters
-    \param[in]  para: the related parameters according to the option 
+    \param[in]  para: the related parameters according to the option
                 all the related parameters should be configured which are shown as below
                       FORWARD_OPTION related parameters:
                       -  ENET_AUTO_PADCRC_DROP_ENABLE/ ENET_AUTO_PADCRC_DROP_DISABLE ;
@@ -179,7 +180,7 @@ void enet_deinit(void)
                       FLOWCTL_OPTION related parameters:
                       -  MAC_FCTL_PTM(regval) ;
                       -  ENET_ZERO_QUANTA_PAUSE_ENABLE/ ENET_ZERO_QUANTA_PAUSE_DISABLE ;
-                      -  ENET_PAUSETIME_MINUS4/ ENET_PAUSETIME_MINUS28/ 
+                      -  ENET_PAUSETIME_MINUS4/ ENET_PAUSETIME_MINUS28/
                          ENET_PAUSETIME_MINUS144/ENET_PAUSETIME_MINUS256 ;
                       -  ENET_MAC0_AND_UNIQUE_ADDRESS_PAUSEDETECT/ ENET_UNIQUE_PAUSEDETECT ;
                       -  ENET_RX_FLOWCONTROL_ENABLE/ ENET_RX_FLOWCONTROL_DISABLE ;
@@ -226,7 +227,7 @@ void enet_deinit(void)
 */
 void enet_initpara_config(enet_option_enum option, uint32_t para)
 {
-    switch(option){
+    switch(option) {
     case FORWARD_OPTION:
         /* choose to configure forward_frame, and save the configuration parameters */
         enet_initpara.option_enable |= (uint32_t)FORWARD_OPTION;
@@ -255,11 +256,11 @@ void enet_initpara_config(enet_option_enum option, uint32_t para)
     case DMA_OPTION:
         /* choose to configure dma_function, and save the configuration parameters */
         enet_initpara.option_enable |= (uint32_t)DMA_OPTION;
-    
+
 #ifndef SELECT_DESCRIPTORS_ENHANCED_MODE
         para &= ~ENET_ENHANCED_DESCRIPTOR;
-#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */  
-    
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
         enet_initpara.dma_function = para;
         break;
     case VLAN_OPTION:
@@ -295,7 +296,7 @@ void enet_initpara_config(enet_option_enum option, uint32_t para)
     case TIMER_OPTION:
         /* choose to configure timer_config, and save the configuration parameters */
         enet_initpara.option_enable |= (uint32_t)TIMER_OPTION;
-        enet_initpara.timer_config = para; 
+        enet_initpara.timer_config = para;
         break;
     case INTERFRAMEGAP_OPTION:
         /* choose to configure interframegap, and save the configuration parameters */
@@ -303,14 +304,14 @@ void enet_initpara_config(enet_option_enum option, uint32_t para)
         enet_initpara.interframegap = para;
         break;
     default:
-        break;    
-    }      
-} 
+        break;
+    }
+}
 
 /*!
-    \brief    initialize ENET peripheral with generally concerned parameters and the less cared 
+    \brief    initialize ENET peripheral with generally concerned parameters and the less cared
                 parameters
-    \param[in]  mediamode: PHY mode and mac loopback configurations, refer to enet_mediamode_enum 
+    \param[in]  mediamode: PHY mode and mac loopback configurations, refer to enet_mediamode_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_AUTO_NEGOTIATION: PHY auto negotiation
       \arg        ENET_100M_FULLDUPLEX: 100Mbit/s, full-duplex
@@ -318,13 +319,13 @@ void enet_initpara_config(enet_option_enum option, uint32_t para)
       \arg        ENET_10M_FULLDUPLEX: 10Mbit/s, full-duplex
       \arg        ENET_10M_HALFDUPLEX: 10Mbit/s, half-duplex
       \arg        ENET_LOOPBACKMODE: MAC in loopback mode at the MII
-    \param[in]  checksum: IP frame checksum offload function, refer to enet_mediamode_enum 
+    \param[in]  checksum: IP frame checksum offload function, refer to enet_mediamode_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_NO_AUTOCHECKSUM: disable IP frame checksum function
       \arg        ENET_AUTOCHECKSUM_DROP_FAILFRAMES: enable IP frame checksum function
       \arg        ENET_AUTOCHECKSUM_ACCEPT_FAILFRAMES: enable IP frame checksum function, and the received frame
                                                        with only payload error but no other errors will not be dropped
-    \param[in]  recept: frame filter function, refer to enet_frmrecept_enum 
+    \param[in]  recept: frame filter function, refer to enet_frmrecept_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_PROMISCUOUS_MODE: promiscuous mode enabled
       \arg        ENET_RECEIVEALL: all received frame are forwarded to application
@@ -335,16 +336,16 @@ void enet_initpara_config(enet_option_enum option, uint32_t para)
 */
 ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum, enet_frmrecept_enum recept)
 {
-    uint32_t reg_value=0U, reg_temp = 0U, temp = 0U;
+    uint32_t reg_value = 0U, reg_temp = 0U, temp = 0U;
     uint32_t media_temp = 0U;
     uint32_t timeout = 0U;
     uint16_t phy_value = 0U;
-    ErrStatus phy_state= ERROR, enet_state = ERROR;
+    ErrStatus phy_state = ERROR, enet_state = ERROR;
 
     /* PHY interface configuration, configure SMI clock and reset PHY chip */
-    if(ERROR == enet_phy_config()){
+    if(ERROR == enet_phy_config()) {
         _ENET_DELAY_(PHY_RESETDELAY);
-        if(ERROR == enet_phy_config()){
+        if(ERROR == enet_phy_config()) {
             return enet_state;
         }
     }
@@ -354,15 +355,15 @@ ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum
     /* 1st, configure mediamode */
     media_temp = (uint32_t)mediamode;
     /* if is PHY auto negotiation */
-    if((uint32_t)ENET_AUTO_NEGOTIATION == media_temp){
+    if((uint32_t)ENET_AUTO_NEGOTIATION == media_temp) {
         /* wait for PHY_LINKED_STATUS bit be set */
-        do{
+        do {
             enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BSR, &phy_value);
-            phy_value &= PHY_LINKED_STATUS;  
+            phy_value &= PHY_LINKED_STATUS;
             timeout++;
-        }while((RESET == phy_value) && (timeout < PHY_READ_TO));
+        } while((RESET == phy_value) && (timeout < PHY_READ_TO));
         /* return ERROR due to timeout */
-        if(PHY_READ_TO == timeout){
+        if(PHY_READ_TO == timeout) {
             return enet_state;
         }
         /* reset timeout counter */
@@ -371,150 +372,150 @@ ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum
         /* enable auto-negotiation */
         phy_value = PHY_AUTONEGOTIATION;
         phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value);
-        if(!phy_state){
+        if(!phy_state) {
             /* return ERROR due to write timeout */
             return enet_state;
         }
 
         /* wait for the PHY_AUTONEGO_COMPLETE bit be set */
-        do{
+        do {
             enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BSR, &phy_value);
             phy_value &= PHY_AUTONEGO_COMPLETE;
             timeout++;
-        }while((RESET == phy_value) && (timeout < (uint32_t)PHY_READ_TO));  
+        } while((RESET == phy_value) && (timeout < (uint32_t)PHY_READ_TO));
         /* return ERROR due to timeout */
-        if(PHY_READ_TO == timeout){
+        if(PHY_READ_TO == timeout) {
             return enet_state;
         }
         /* reset timeout counter */
         timeout = 0U;
 
         /* read the result of the auto-negotiation */
-        enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_SR, &phy_value);  
+        enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_SR, &phy_value);
         /* configure the duplex mode of MAC following the auto-negotiation result */
-        if((uint16_t)RESET != (phy_value & PHY_DUPLEX_STATUS)){
+        if((uint16_t)RESET != (phy_value & PHY_DUPLEX_STATUS)) {
             media_temp = ENET_MODE_FULLDUPLEX;
-        }else{
+        } else {
             media_temp = ENET_MODE_HALFDUPLEX;
         }
         /* configure the communication speed of MAC following the auto-negotiation result */
-        if((uint16_t)RESET !=(phy_value & PHY_SPEED_STATUS)){
+        if((uint16_t)RESET != (phy_value & PHY_SPEED_STATUS)) {
             media_temp |= ENET_SPEEDMODE_10M;
-        }else{
+        } else {
             media_temp |= ENET_SPEEDMODE_100M;
-        }    
-    }else{
+        }
+    } else {
         phy_value = (uint16_t)((media_temp & ENET_MAC_CFG_DPM) >> 3);
         phy_value |= (uint16_t)((media_temp & ENET_MAC_CFG_SPD) >> 1);
         phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value);
-        if(!phy_state){
+        if(!phy_state) {
             /* return ERROR due to write timeout */
             return enet_state;
         }
         /* PHY configuration need some time */
-        _ENET_DELAY_(PHY_CONFIGDELAY);      
+        _ENET_DELAY_(PHY_CONFIGDELAY);
     }
     /* after configuring the PHY, use mediamode to configure registers */
     reg_value = ENET_MAC_CFG;
     /* configure ENET_MAC_CFG register */
-    reg_value &= (~(ENET_MAC_CFG_SPD |ENET_MAC_CFG_DPM |ENET_MAC_CFG_LBM));
+    reg_value &= (~(ENET_MAC_CFG_SPD | ENET_MAC_CFG_DPM | ENET_MAC_CFG_LBM));
     reg_value |= media_temp;
     ENET_MAC_CFG = reg_value;
-    
-    
+
+
     /* 2st, configure checksum */
-    if(RESET != ((uint32_t)checksum & ENET_CHECKSUMOFFLOAD_ENABLE)){
+    if(RESET != ((uint32_t)checksum & ENET_CHECKSUMOFFLOAD_ENABLE)) {
         ENET_MAC_CFG |= ENET_CHECKSUMOFFLOAD_ENABLE;
-      
+
         reg_value = ENET_DMA_CTL;
         /* configure ENET_DMA_CTL register */
         reg_value &= ~ENET_DMA_CTL_DTCERFD;
         reg_value |= ((uint32_t)checksum & ENET_DMA_CTL_DTCERFD);
         ENET_DMA_CTL = reg_value;
     }
-    
+
     /* 3rd, configure recept */
     ENET_MAC_FRMF |= (uint32_t)recept;
 
     /* 4th, configure different function options */
     /* configure forward_frame related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)FORWARD_OPTION)){
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FORWARD_OPTION)) {
         reg_temp = enet_initpara.forward_frame;
 
         reg_value = ENET_MAC_CFG;
         temp = reg_temp;
         /* configure ENET_MAC_CFG register */
-        reg_value &= (~(ENET_MAC_CFG_TFCD |ENET_MAC_CFG_APCD));
+        reg_value &= (~(ENET_MAC_CFG_TFCD | ENET_MAC_CFG_APCD));
         temp &= (ENET_MAC_CFG_TFCD | ENET_MAC_CFG_APCD);
         reg_value |= temp;
         ENET_MAC_CFG = reg_value;
-      
+
         reg_value = ENET_DMA_CTL;
         temp = reg_temp;
         /* configure ENET_DMA_CTL register */
-        reg_value &= (~(ENET_DMA_CTL_FERF |ENET_DMA_CTL_FUF));
+        reg_value &= (~(ENET_DMA_CTL_FERF | ENET_DMA_CTL_FUF));
         temp &= ((ENET_DMA_CTL_FERF | ENET_DMA_CTL_FUF) << 2);
         reg_value |= (temp >> 2);
         ENET_DMA_CTL = reg_value;
     }
 
     /* configure dmabus_mode related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)DMABUS_OPTION)){
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMABUS_OPTION)) {
         temp = enet_initpara.dmabus_mode;
-      
+
         reg_value = ENET_DMA_BCTL;
         /* configure ENET_DMA_BCTL register */
         reg_value &= ~(ENET_DMA_BCTL_AA | ENET_DMA_BCTL_FB \
-                      |ENET_DMA_BCTL_FPBL | ENET_DMA_BCTL_MB);
+                       | ENET_DMA_BCTL_FPBL | ENET_DMA_BCTL_MB);
         reg_value |= temp;
         ENET_DMA_BCTL = reg_value;
     }
 
     /* configure dma_maxburst related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_MAXBURST_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_MAXBURST_OPTION)) {
         temp = enet_initpara.dma_maxburst;
-      
+
         reg_value = ENET_DMA_BCTL;
         /* configure ENET_DMA_BCTL register */
-        reg_value &= ~(ENET_DMA_BCTL_RXDP| ENET_DMA_BCTL_PGBL | ENET_DMA_BCTL_UIP);    
+        reg_value &= ~(ENET_DMA_BCTL_RXDP | ENET_DMA_BCTL_PGBL | ENET_DMA_BCTL_UIP);
         reg_value |= temp;
         ENET_DMA_BCTL = reg_value;
     }
 
     /* configure dma_arbitration related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_ARBITRATION_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_ARBITRATION_OPTION)) {
         temp = enet_initpara.dma_arbitration;
-      
+
         reg_value = ENET_DMA_BCTL;
         /* configure ENET_DMA_BCTL register */
         reg_value &= ~(ENET_DMA_BCTL_RTPR | ENET_DMA_BCTL_DAB);
         reg_value |= temp;
         ENET_DMA_BCTL = reg_value;
     }
-    
+
     /* configure store_forward_mode related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)STORE_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)STORE_OPTION)) {
         temp = enet_initpara.store_forward_mode;
-      
+
         reg_value = ENET_DMA_CTL;
         /* configure ENET_DMA_CTL register */
-        reg_value &= ~(ENET_DMA_CTL_RSFD | ENET_DMA_CTL_TSFD| ENET_DMA_CTL_RTHC| ENET_DMA_CTL_TTHC);
+        reg_value &= ~(ENET_DMA_CTL_RSFD | ENET_DMA_CTL_TSFD | ENET_DMA_CTL_RTHC | ENET_DMA_CTL_TTHC);
         reg_value |= temp;
         ENET_DMA_CTL = reg_value;
     }
 
     /* configure dma_function related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_OPTION)) {
         reg_temp = enet_initpara.dma_function;
-              
+
         reg_value = ENET_DMA_CTL;
         temp = reg_temp;
         /* configure ENET_DMA_CTL register */
-        reg_value &= (~(ENET_DMA_CTL_DAFRF |ENET_DMA_CTL_OSF));
+        reg_value &= (~(ENET_DMA_CTL_DAFRF | ENET_DMA_CTL_OSF));
         temp &= (ENET_DMA_CTL_DAFRF | ENET_DMA_CTL_OSF);
         reg_value |= temp;
         ENET_DMA_CTL = reg_value;
-      
+
         reg_value = ENET_DMA_BCTL;
         temp = reg_temp;
         /* configure ENET_DMA_BCTL register */
@@ -525,9 +526,9 @@ ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum
     }
 
     /* configure vlan_config related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)VLAN_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)VLAN_OPTION)) {
         reg_temp = enet_initpara.vlan_config;
-              
+
         reg_value = ENET_MAC_VLT;
         /* configure ENET_MAC_VLT register */
         reg_value &= ~(ENET_MAC_VLT_VLTI | ENET_MAC_VLT_VLTC);
@@ -536,84 +537,84 @@ ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum
     }
 
     /* configure flow_control related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)FLOWCTL_OPTION)){
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FLOWCTL_OPTION)) {
         reg_temp = enet_initpara.flow_control;
 
         reg_value = ENET_MAC_FCTL;
         temp = reg_temp;
         /* configure ENET_MAC_FCTL register */
-        reg_value &= ~(ENET_MAC_FCTL_PTM |ENET_MAC_FCTL_DZQP |ENET_MAC_FCTL_PLTS \
-                      | ENET_MAC_FCTL_UPFDT |ENET_MAC_FCTL_RFCEN |ENET_MAC_FCTL_TFCEN);
-        temp &= (ENET_MAC_FCTL_PTM |ENET_MAC_FCTL_DZQP |ENET_MAC_FCTL_PLTS \
-                 | ENET_MAC_FCTL_UPFDT |ENET_MAC_FCTL_RFCEN |ENET_MAC_FCTL_TFCEN);
+        reg_value &= ~(ENET_MAC_FCTL_PTM | ENET_MAC_FCTL_DZQP | ENET_MAC_FCTL_PLTS \
+                       | ENET_MAC_FCTL_UPFDT | ENET_MAC_FCTL_RFCEN | ENET_MAC_FCTL_TFCEN);
+        temp &= (ENET_MAC_FCTL_PTM | ENET_MAC_FCTL_DZQP | ENET_MAC_FCTL_PLTS \
+                 | ENET_MAC_FCTL_UPFDT | ENET_MAC_FCTL_RFCEN | ENET_MAC_FCTL_TFCEN);
         reg_value |= temp;
         ENET_MAC_FCTL = reg_value;
 
         reg_value = ENET_MAC_FCTH;
         temp = reg_temp;
         /* configure ENET_MAC_FCTH register */
-        reg_value &= ~(ENET_MAC_FCTH_RFA |ENET_MAC_FCTH_RFD);
-        temp &= ((ENET_MAC_FCTH_RFA | ENET_MAC_FCTH_RFD ) << 8);
+        reg_value &= ~(ENET_MAC_FCTH_RFA | ENET_MAC_FCTH_RFD);
+        temp &= ((ENET_MAC_FCTH_RFA | ENET_MAC_FCTH_RFD) << 8);
         reg_value |= (temp >> 8);
         ENET_MAC_FCTH = reg_value;
     }
 
     /* configure hashtable_high related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHH_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHH_OPTION)) {
         ENET_MAC_HLH = enet_initpara.hashtable_high;
-    } 
+    }
 
     /* configure hashtable_low related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHL_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHL_OPTION)) {
         ENET_MAC_HLL = enet_initpara.hashtable_low;
-    }    
+    }
 
     /* configure framesfilter_mode related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)FILTER_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FILTER_OPTION)) {
         reg_temp = enet_initpara.framesfilter_mode;
-              
+
         reg_value = ENET_MAC_FRMF;
         /* configure ENET_MAC_FRMF register */
         reg_value &= ~(ENET_MAC_FRMF_SAFLT | ENET_MAC_FRMF_SAIFLT | ENET_MAC_FRMF_DAIFLT \
-                      | ENET_MAC_FRMF_HMF | ENET_MAC_FRMF_HPFLT | ENET_MAC_FRMF_MFD \
-                      | ENET_MAC_FRMF_HUF | ENET_MAC_FRMF_PCFRM);
+                       | ENET_MAC_FRMF_HMF | ENET_MAC_FRMF_HPFLT | ENET_MAC_FRMF_MFD \
+                       | ENET_MAC_FRMF_HUF | ENET_MAC_FRMF_PCFRM);
         reg_value |= reg_temp;
         ENET_MAC_FRMF = reg_value;
-    }  
+    }
 
     /* configure halfduplex_param related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)HALFDUPLEX_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HALFDUPLEX_OPTION)) {
         reg_temp = enet_initpara.halfduplex_param;
-              
+
         reg_value = ENET_MAC_CFG;
         /* configure ENET_MAC_CFG register */
         reg_value &= ~(ENET_MAC_CFG_CSD | ENET_MAC_CFG_ROD | ENET_MAC_CFG_RTD \
-                      | ENET_MAC_CFG_BOL | ENET_MAC_CFG_DFC);
+                       | ENET_MAC_CFG_BOL | ENET_MAC_CFG_DFC);
         reg_value |= reg_temp;
         ENET_MAC_CFG = reg_value;
-    } 
+    }
 
     /* configure timer_config related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)TIMER_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)TIMER_OPTION)) {
         reg_temp = enet_initpara.timer_config;
-              
+
         reg_value = ENET_MAC_CFG;
         /* configure ENET_MAC_CFG register */
         reg_value &= ~(ENET_MAC_CFG_WDD | ENET_MAC_CFG_JBD);
         reg_value |= reg_temp;
         ENET_MAC_CFG = reg_value;
-    } 
-    
+    }
+
     /* configure interframegap related registers */
-    if(RESET != (enet_initpara.option_enable & (uint32_t)INTERFRAMEGAP_OPTION)){   
+    if(RESET != (enet_initpara.option_enable & (uint32_t)INTERFRAMEGAP_OPTION)) {
         reg_temp = enet_initpara.interframegap;
-              
+
         reg_value = ENET_MAC_CFG;
         /* configure ENET_MAC_CFG register */
         reg_value &= ~ENET_MAC_CFG_IGBS;
         reg_value |= reg_temp;
         ENET_MAC_CFG = reg_value;
-    }    
+    }
 
     enet_state = SUCCESS;
     return enet_state;
@@ -630,21 +631,21 @@ ErrStatus enet_software_reset(void)
     uint32_t timeout = 0U;
     ErrStatus enet_state = ERROR;
     uint32_t dma_flag;
-    
+
     /* reset all core internal registers located in CLK_TX and CLK_RX */
     ENET_DMA_BCTL |= ENET_DMA_BCTL_SWR;
-    
+
     /* wait for reset operation complete */
-    do{
+    do {
         dma_flag = (ENET_DMA_BCTL & ENET_DMA_BCTL_SWR);
         timeout++;
-    }while((RESET != dma_flag) && (ENET_DELAY_TO != timeout));
+    } while((RESET != dma_flag) && (ENET_DELAY_TO != timeout));
 
-    /* reset operation complete */    
-    if(RESET == (ENET_DMA_BCTL & ENET_DMA_BCTL_SWR)){
+    /* reset operation complete */
+    if(RESET == (ENET_DMA_BCTL & ENET_DMA_BCTL_SWR)) {
         enet_state = SUCCESS;
     }
-    
+
     return enet_state;
 }
 
@@ -658,19 +659,19 @@ uint32_t enet_rxframe_size_get(void)
 {
     uint32_t size = 0U;
     uint32_t status;
-    
+
     /* get rdes0 information of current RxDMA descriptor */
     status = dma_current_rxdesc->status;
-    
+
     /* if the desciptor is owned by DMA */
-    if((uint32_t)RESET != (status & ENET_RDES0_DAV)){
+    if((uint32_t)RESET != (status & ENET_RDES0_DAV)) {
         return 0U;
     }
-    
+
     /* if has any error, or the frame uses two or more descriptors */
     if((((uint32_t)RESET) != (status & ENET_RDES0_ERRS)) ||
-       (((uint32_t)RESET) == (status & ENET_RDES0_LDES)) ||
-       (((uint32_t)RESET) == (status & ENET_RDES0_FDES))){
+            (((uint32_t)RESET) == (status & ENET_RDES0_LDES)) ||
+            (((uint32_t)RESET) == (status & ENET_RDES0_FDES))) {
         /* drop current receive frame */
         enet_rxframe_drop();
 
@@ -679,44 +680,44 @@ uint32_t enet_rxframe_size_get(void)
 #ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
     /* if is an ethernet-type frame, and IP frame payload error occurred */
     if(((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_FRMT) &&
-       ((uint32_t)RESET) != (dma_current_rxdesc->extended_status & ENET_RDES4_IPPLDERR)){
-         /* drop current receive frame */
-         enet_rxframe_drop();
+            ((uint32_t)RESET) != (dma_current_rxdesc->extended_status & ENET_RDES4_IPPLDERR)) {
+        /* drop current receive frame */
+        enet_rxframe_drop();
 
         return 1U;
     }
-#else 
+#else
     /* if is an ethernet-type frame, and IP frame payload error occurred */
     if((((uint32_t)RESET) != (status & ENET_RDES0_FRMT)) &&
-       (((uint32_t)RESET) != (status & ENET_RDES0_PCERR))){
-         /* drop current receive frame */
-         enet_rxframe_drop();
+            (((uint32_t)RESET) != (status & ENET_RDES0_PCERR))) {
+        /* drop current receive frame */
+        enet_rxframe_drop();
 
         return 1U;
-    }  
-#endif 
+    }
+#endif
     /* if CPU owns current descriptor, no error occured, the frame uses only one descriptor */
     if((((uint32_t)RESET) == (status & ENET_RDES0_DAV)) &&
-       (((uint32_t)RESET) == (status & ENET_RDES0_ERRS)) &&
-       (((uint32_t)RESET) != (status & ENET_RDES0_LDES)) &&
-       (((uint32_t)RESET) != (status & ENET_RDES0_FDES))){
+            (((uint32_t)RESET) == (status & ENET_RDES0_ERRS)) &&
+            (((uint32_t)RESET) != (status & ENET_RDES0_LDES)) &&
+            (((uint32_t)RESET) != (status & ENET_RDES0_FDES))) {
         /* get the size of the received data including CRC */
         size = GET_RDES0_FRML(status);
-        /* substract the CRC size */ 
+        /* substract the CRC size */
         size = size - 4U;
-        
-        /* if is a type frame, and CRC is not included in forwarding frame */ 
-        if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (status & ENET_RDES0_FRMT))){
+
+        /* if is a type frame, and CRC is not included in forwarding frame */
+        if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (status & ENET_RDES0_FRMT))) {
             size = size + 4U;
         }
-    }else{
+    } else {
         enet_unknow_err++;
         enet_rxframe_drop();
 
         return 1U;
     }
- 
-    /* return packet size */ 
+
+    /* return packet size */
     return size;
 }
 
@@ -734,62 +735,62 @@ void enet_descriptors_chain_init(enet_dmadirection_enum direction)
     uint32_t num = 0U, count = 0U, maxsize = 0U;
     uint32_t desc_status = 0U, desc_bufsize = 0U;
     enet_descriptors_struct *desc, *desc_tab;
-    uint8_t *buf;  
+    uint8_t *buf;
 
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
         maxsize = ENET_TXBUF_SIZE;
-      
+
         /* select chain mode */
         desc_status = ENET_TDES0_TCHM;
-      
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
-    }else{ 
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
         maxsize = ENET_RXBUF_SIZE;
-      
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* select receive chained mode and set buffer1 size */
         desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
-      
+
         /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
-        dma_current_rxdesc = desc_tab; 
+        dma_current_rxdesc = desc_tab;
     }
     dma_current_ptp_rxdesc = NULL;
     dma_current_ptp_txdesc = NULL;
-    
-    /* configure each descriptor */   
-    for(num=0U; num < count; num++){
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status;         
+        desc->status = desc_status;
         desc->control_buffer_size = desc_bufsize;
         desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
-    
+
         /* if is not the last descriptor */
-        if(num < (count - 1U)){
+        if(num < (count - 1U)) {
             /* configure the next descriptor address */
             desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
-        }else{
-            /* when it is the last descriptor, the next descriptor address 
-            equals to first descriptor address in descriptor table */ 
-            desc->buffer2_next_desc_addr = (uint32_t) desc_tab;  
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t) desc_tab;
         }
-    }  
+    }
 }
 
 /*!
@@ -807,64 +808,64 @@ void enet_descriptors_ring_init(enet_dmadirection_enum direction)
     uint32_t desc_status = 0U, desc_bufsize = 0U;
     enet_descriptors_struct *desc;
     enet_descriptors_struct *desc_tab;
-    uint8_t *buf; 
-  
+    uint8_t *buf;
+
     /* configure descriptor skip length */
     ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
     ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
-  
+
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
-        maxsize = ENET_TXBUF_SIZE;      
-      
+        maxsize = ENET_TXBUF_SIZE;
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
-    }else{
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
-        maxsize = ENET_RXBUF_SIZE;      
-      
+        maxsize = ENET_RXBUF_SIZE;
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* set buffer1 size */
         desc_bufsize = ENET_RXBUF_SIZE;
-      
-         /* configure DMA Rx descriptor table address register */
+
+        /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
-        dma_current_rxdesc = desc_tab; 
+        dma_current_rxdesc = desc_tab;
     }
     dma_current_ptp_rxdesc = NULL;
     dma_current_ptp_txdesc = NULL;
-    
-    /* configure each descriptor */   
-    for(num=0U; num < count; num++){
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status; 
-        desc->control_buffer_size = desc_bufsize;      
-        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);    
-    
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
         /* when it is the last descriptor */
-        if(num == (count - 1U)){
-            if (ENET_DMA_TX == direction){
-                /* configure transmit end of ring mode */  
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
                 desc->status |= ENET_TDES0_TERM;
-            }else{
+            } else {
                 /* configure receive end of ring mode */
                 desc->control_buffer_size |= ENET_RDES1_RERM;
             }
         }
-    }   
+    }
 }
 
 /*!
@@ -877,69 +878,69 @@ void enet_descriptors_ring_init(enet_dmadirection_enum direction)
 ErrStatus enet_frame_receive(uint8_t *buffer, uint32_t bufsize)
 {
     uint32_t offset = 0U, size = 0U;
-    
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)){
-        return ERROR; 
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
+        return ERROR;
     }
-    
+
 
     /* if buffer pointer is null, indicates that users has copied data in application */
-    if(NULL != buffer){
+    if(NULL != buffer) {
         /* if no error occurs, and the frame uses only one descriptor */
-        if((((uint32_t)RESET) == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) && 
-           (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&  
-           (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_FDES))){      
+        if((((uint32_t)RESET) == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
+                (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
             /* get the frame length except CRC */
             size = GET_RDES0_FRML(dma_current_rxdesc->status);
             size = size - 4U;
-            
-            /* if is a type frame, and CRC is not included in forwarding frame */ 
-            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))){
+
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
                 size = size + 4U;
             }
-            
+
             /* to avoid situation that the frame size exceeds the buffer length */
-            if(size > bufsize){
+            if(size > bufsize) {
                 return ERROR;
             }
-            
+
             /* copy data from Rx buffer to application buffer */
-            for(offset = 0U; offset<size; offset++){
-                (*(buffer + offset)) = (*(__IO uint8_t *) (uint32_t)((dma_current_rxdesc->buffer1_addr) + offset));
+            for(offset = 0U; offset < size; offset++) {
+                (*(buffer + offset)) = (*(__IO uint8_t *)(uint32_t)((dma_current_rxdesc->buffer1_addr) + offset));
             }
-            
-        }else{
+
+        } else {
             /* return ERROR */
             return ERROR;
         }
     }
     /* enable reception, descriptor is owned by DMA */
-    dma_current_rxdesc->status = ENET_RDES0_DAV; 
- 
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
     /* check Rx buffer unavailable flag status */
-    if ((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)){
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
         /* clear RBU flag */
         ENET_DMA_STAT = ENET_DMA_STAT_RBU;
         /* resume DMA reception by writing to the RPEN register*/
         ENET_DMA_RPEN = 0U;
     }
-  
-    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */      
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)){      
-        dma_current_rxdesc = (enet_descriptors_struct*) (dma_current_rxdesc->buffer2_next_desc_addr);    
-    }else{    
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
+    } else {
         /* ring mode */
-        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)){
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_rxdesc = (enet_descriptors_struct*) (ENET_DMA_RDTADDR);      
-        }else{ 
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_rxdesc = (enet_descriptors_struct*) (uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));      
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));
         }
     }
-  
+
     return SUCCESS;
 }
 
@@ -955,55 +956,55 @@ ErrStatus enet_frame_transmit(uint8_t *buffer, uint32_t length)
 {
     uint32_t offset = 0U;
     uint32_t dma_tbu_flag, dma_tu_flag;
-    
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)){
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
         return ERROR;
     }
-    
+
     /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
-    if(length > ENET_MAX_FRAME_SIZE){
+    if(length > ENET_MAX_FRAME_SIZE) {
         return ERROR;
-    } 
-    
+    }
+
     /* if buffer pointer is null, indicates that users has handled data in application */
-    if(NULL != buffer){    
+    if(NULL != buffer) {
         /* copy frame data from application buffer to Tx buffer */
-        for(offset = 0U; offset < length; offset++){
-            (*(__IO uint8_t *) (uint32_t)((dma_current_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
+        for(offset = 0U; offset < length; offset++) {
+            (*(__IO uint8_t *)(uint32_t)((dma_current_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
         }
     }
-    
+
     /* set the frame length */
     dma_current_txdesc->control_buffer_size = length;
-    /* set the segment of frame, frame is transmitted in one descriptor */    
+    /* set the segment of frame, frame is transmitted in one descriptor */
     dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
     /* enable the DMA transmission */
     dma_current_txdesc->status |= ENET_TDES0_DAV;
-    
+
     /* check Tx buffer unavailable flag status */
-    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU); 
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
     dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
-    
-    if ((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)){
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
         /* clear TBU and TU flag */
         ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
         /* resume DMA transmission by writing to the TPEN register*/
         ENET_DMA_TPEN = 0U;
     }
-  
-    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/  
+
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)){     
-        dma_current_txdesc = (enet_descriptors_struct*) (dma_current_txdesc->buffer2_next_desc_addr);    
-    }else{   
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_txdesc->buffer2_next_desc_addr);
+    } else {
         /* ring mode */
-        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)){
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_txdesc = (enet_descriptors_struct*) (ENET_DMA_TDTADDR);      
-        }else{
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_txdesc = (enet_descriptors_struct*) (uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));
+            dma_current_txdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));
         }
     }
 
@@ -1053,7 +1054,7 @@ void enet_disable(void)
 }
 
 /*!
-    \brief    configure MAC address 
+    \brief    configure MAC address
     \param[in]  mac_addr: select which MAC address will be set, refer to enet_macaddress_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_ADDRESS0: set MAC address 0 filter
@@ -1061,10 +1062,10 @@ void enet_disable(void)
       \arg        ENET_MAC_ADDRESS2: set MAC address 2 filter
       \arg        ENET_MAC_ADDRESS3: set MAC address 3 filter
     \param[in]  paddr: the buffer pointer which stores the MAC address
-                  (little-ending store, such as MAC address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa}) 
+                  (little-ending store, such as MAC address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa})
     \param[out] none
     \retval     none
-*/ 
+*/
 void enet_mac_address_set(enet_macaddress_enum mac_addr, uint8_t paddr[])
 {
     REG32(ENET_ADDRH_BASE + (uint32_t)mac_addr) = ENET_SET_MACADDRH(paddr);
@@ -1072,7 +1073,7 @@ void enet_mac_address_set(enet_macaddress_enum mac_addr, uint8_t paddr[])
 }
 
 /*!
-    \brief    get MAC address 
+    \brief    get MAC address
     \param[in]  mac_addr: select which MAC address will be get, refer to enet_macaddress_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_ADDRESS0: get MAC address 0 filter
@@ -1080,9 +1081,9 @@ void enet_mac_address_set(enet_macaddress_enum mac_addr, uint8_t paddr[])
       \arg        ENET_MAC_ADDRESS2: get MAC address 2 filter
       \arg        ENET_MAC_ADDRESS3: get MAC address 3 filter
     \param[out] paddr: the buffer pointer which is stored the MAC address
-                  (little-ending store, such as mac address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa}) 
+                  (little-ending store, such as mac address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa})
     \retval     none
-*/                                   
+*/
 void enet_mac_address_get(enet_macaddress_enum mac_addr, uint8_t paddr[])
 {
     paddr[0] = ENET_GET_MACADDR(mac_addr, 0U);
@@ -1094,12 +1095,12 @@ void enet_mac_address_get(enet_macaddress_enum mac_addr, uint8_t paddr[])
 }
 
 /*!
-    \brief    get the ENET MAC/MSC/PTP/DMA status flag 
+    \brief    get the ENET MAC/MSC/PTP/DMA status flag
     \param[in]  enet_flag: ENET status flag, refer to enet_flag_enum,
                 only one parameter can be selected which is shown as below
-      \arg        ENET_MAC_FLAG_MPKR: magic packet received flag 
+      \arg        ENET_MAC_FLAG_MPKR: magic packet received flag
       \arg        ENET_MAC_FLAG_WUFR: wakeup frame received flag
-      \arg        ENET_MAC_FLAG_FLOWCONTROL: flow control status flag 
+      \arg        ENET_MAC_FLAG_FLOWCONTROL: flow control status flag
       \arg        ENET_MAC_FLAG_WUM: WUM status flag
       \arg        ENET_MAC_FLAG_MSC: MSC status flag
       \arg        ENET_MAC_FLAG_MSCR: MSC receive status flag
@@ -1139,15 +1140,15 @@ void enet_mac_address_get(enet_macaddress_enum mac_addr, uint8_t paddr[])
 */
 FlagStatus enet_flag_get(enet_flag_enum enet_flag)
 {
-    if(RESET != (ENET_REG_VAL(enet_flag) & BIT(ENET_BIT_POS(enet_flag)))){
+    if(RESET != (ENET_REG_VAL(enet_flag) & BIT(ENET_BIT_POS(enet_flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear the ENET DMA status flag 
+    \brief    clear the ENET DMA status flag
     \param[in]  enet_flag: ENET DMA flag clear, refer to enet_flag_clear_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_DMA_FLAG_TS_CLR: transmit status flag clear
@@ -1175,7 +1176,7 @@ void enet_flag_clear(enet_flag_clear_enum enet_flag)
 }
 
 /*!
-    \brief    enable ENET MAC/MSC/DMA interrupt 
+    \brief    enable ENET MAC/MSC/DMA interrupt
     \param[in]  enet_int: ENET interrupt,, refer to enet_int_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_INT_WUMIM: WUM interrupt mask
@@ -1206,17 +1207,17 @@ void enet_flag_clear(enet_flag_clear_enum enet_flag)
 */
 void enet_interrupt_enable(enet_int_enum enet_int)
 {
-    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)){
+    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)) {
         /* ENET_DMA_INTEN register interrupt */
         ENET_REG_VAL(enet_int) |= BIT(ENET_BIT_POS(enet_int));
-    }else{
+    } else {
         /* other INTMSK register interrupt */
         ENET_REG_VAL(enet_int) &= ~BIT(ENET_BIT_POS(enet_int));
     }
 }
 
 /*!
-    \brief    disable ENET MAC/MSC/DMA interrupt 
+    \brief    disable ENET MAC/MSC/DMA interrupt
     \param[in]  enet_int: ENET interrupt, refer to enet_int_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_INT_WUMIM: WUM interrupt mask
@@ -1247,17 +1248,17 @@ void enet_interrupt_enable(enet_int_enum enet_int)
 */
 void enet_interrupt_disable(enet_int_enum enet_int)
 {
-    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)){
+    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)) {
         /* ENET_DMA_INTEN register interrupt */
         ENET_REG_VAL(enet_int) &= ~BIT(ENET_BIT_POS(enet_int));
-    }else{
+    } else {
         /* other INTMSK register interrupt */
         ENET_REG_VAL(enet_int) |= BIT(ENET_BIT_POS(enet_int));
     }
 }
 
 /*!
-    \brief    get ENET MAC/MSC/DMA interrupt flag 
+    \brief    get ENET MAC/MSC/DMA interrupt flag
     \param[in]  int_flag: ENET interrupt flag, refer to enet_int_flag_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_INT_FLAG_WUM: WUM status flag
@@ -1294,15 +1295,15 @@ void enet_interrupt_disable(enet_int_enum enet_int)
 */
 FlagStatus enet_interrupt_flag_get(enet_int_flag_enum int_flag)
 {
-    if(RESET != (ENET_REG_VAL(int_flag) & BIT(ENET_BIT_POS(int_flag)))){
+    if(RESET != (ENET_REG_VAL(int_flag) & BIT(ENET_BIT_POS(int_flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear ENET DMA interrupt flag 
+    \brief    clear ENET DMA interrupt flag
     \param[in]  int_flag_clear: clear ENET interrupt flag, refer to enet_int_flag_clear_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_DMA_INT_FLAG_TS_CLR: transmit status flag
@@ -1349,7 +1350,7 @@ void enet_tx_enable(void)
     \retval     none
 */
 void enet_tx_disable(void)
-{    
+{
     ENET_DMA_CTL &= ~ENET_DMA_CTL_STE;
     enet_txfifo_flush();
     ENET_MAC_CFG &= ~ENET_MAC_CFG_TEN;
@@ -1380,10 +1381,10 @@ void enet_rx_disable(void)
 }
 
 /*!
-    \brief    put registers value into the application buffer 
+    \brief    put registers value into the application buffer
     \param[in]  type: register type which will be get, refer to enet_registers_type_enum,
                 only one parameter can be selected which is shown as below
-      \arg        ALL_MAC_REG: get the registers within the offset scope between ENET_MAC_CFG and ENET_MAC_FCTH 
+      \arg        ALL_MAC_REG: get the registers within the offset scope between ENET_MAC_CFG and ENET_MAC_FCTH
       \arg        ALL_MSC_REG: get the registers within the offset scope between ENET_MSC_CTL and ENET_MSC_RGUFCNT
       \arg        ALL_PTP_REG: get the registers within the offset scope between ENET_PTP_TSCTL and ENET_PTP_PPSCTL
       \arg        ALL_DMA_REG: get the registers within the offset scope between ENET_DMA_BCTL and ENET_DMA_CRBADDR
@@ -1394,22 +1395,22 @@ void enet_rx_disable(void)
 void enet_registers_get(enet_registers_type_enum type, uint32_t *preg, uint32_t num)
 {
     uint32_t offset = 0U, max = 0U, limit = 0U;
-    
+
     offset = (uint32_t)type;
     max = (uint32_t)type + num;
-    limit = sizeof(enet_reg_tab)/sizeof(uint16_t);
-    
+    limit = sizeof(enet_reg_tab) / sizeof(uint16_t);
+
     /* prevent element in this array is out of range */
-    if(max > limit){ 
+    if(max > limit) {
         max = limit;
     }
-    
-    for(; offset < max; offset++){
+
+    for(; offset < max; offset++) {
         /* get value of the corresponding register */
-        *preg = REG32((ENET) + enet_reg_tab[offset]); 
+        *preg = REG32((ENET) + enet_reg_tab[offset]);
         preg++;
     }
-} 
+}
 
 /*!
     \brief    get the enet debug status from the debug register
@@ -1433,8 +1434,8 @@ void enet_registers_get(enet_registers_type_enum type, uint32_t *preg, uint32_t 
 uint32_t enet_debug_status_get(uint32_t mac_debug)
 {
     uint32_t temp_state = 0U;
-  
-    switch(mac_debug){
+
+    switch(mac_debug) {
     case ENET_RX_ASYNCHRONOUS_FIFO_STATE:
         temp_state = GET_MAC_DBG_RXAFS(ENET_MAC_DBG);
         break;
@@ -1451,16 +1452,16 @@ uint32_t enet_debug_status_get(uint32_t mac_debug)
         temp_state = GET_MAC_DBG_TXFRS(ENET_MAC_DBG);
         break;
     default:
-        if(RESET != (ENET_MAC_DBG & mac_debug)){
+        if(RESET != (ENET_MAC_DBG & mac_debug)) {
             temp_state = 0x1U;
         }
-        break;        
+        break;
     }
     return temp_state;
 }
 
 /*!
-    \brief    enable the MAC address filter 
+    \brief    enable the MAC address filter
     \param[in]  mac_addr: select which MAC address will be enable, refer to enet_macaddress_enum
       \arg        ENET_MAC_ADDRESS1: enable MAC address 1 filter
       \arg        ENET_MAC_ADDRESS2: enable MAC address 2 filter
@@ -1474,7 +1475,7 @@ void enet_address_filter_enable(enet_macaddress_enum mac_addr)
 }
 
 /*!
-    \brief    disable the MAC address filter 
+    \brief    disable the MAC address filter
     \param[in]  mac_addr: select which MAC address will be disable, refer to enet_macaddress_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_ADDRESS1: disable MAC address 1 filter
@@ -1489,7 +1490,7 @@ void enet_address_filter_disable(enet_macaddress_enum mac_addr)
 }
 
 /*!
-    \brief    configure the MAC address filter 
+    \brief    configure the MAC address filter
     \param[in]  mac_addr: select which MAC address will be configured, refer to enet_macaddress_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC_ADDRESS1: configure MAC address 1 filter
@@ -1498,7 +1499,7 @@ void enet_address_filter_disable(enet_macaddress_enum mac_addr)
     \param[in]  addr_mask: select which MAC address bytes will be mask
                 one or more parameters can be selected which are shown as below
       \arg        ENET_ADDRESS_MASK_BYTE0: mask ENET_MAC_ADDR1L[7:0] bits
-      \arg        ENET_ADDRESS_MASK_BYTE1: mask ENET_MAC_ADDR1L[15:8] bits 
+      \arg        ENET_ADDRESS_MASK_BYTE1: mask ENET_MAC_ADDR1L[15:8] bits
       \arg        ENET_ADDRESS_MASK_BYTE2: mask ENET_MAC_ADDR1L[23:16] bits
       \arg        ENET_ADDRESS_MASK_BYTE3: mask ENET_MAC_ADDR1L [31:24] bits
       \arg        ENET_ADDRESS_MASK_BYTE4: mask ENET_MAC_ADDR1H [7:0] bits
@@ -1513,7 +1514,7 @@ void enet_address_filter_disable(enet_macaddress_enum mac_addr)
 void enet_address_filter_config(enet_macaddress_enum mac_addr, uint32_t addr_mask, uint32_t filter_type)
 {
     uint32_t reg;
-    
+
     /* get the address filter register value which is to be configured */
     reg = REG32(ENET_ADDRH_BASE + mac_addr);
 
@@ -1528,55 +1529,55 @@ void enet_address_filter_config(enet_macaddress_enum mac_addr, uint32_t addr_mas
     \param[in]  none
     \param[out] none
     \retval     ErrStatus: SUCCESS or ERROR
-*/ 
+*/
 ErrStatus enet_phy_config(void)
 {
     uint32_t ahbclk;
     uint32_t reg;
     uint16_t phy_value;
     ErrStatus enet_state = ERROR;
-  
+
     /* clear the previous MDC clock */
     reg = ENET_MAC_PHY_CTL;
     reg &= ~ENET_MAC_PHY_CTL_CLR;
 
     /* get the HCLK frequency */
     ahbclk = rcu_clock_freq_get(CK_AHB);
-  
+
     /* configure MDC clock according to HCLK frequency range */
-    if(ENET_RANGE(ahbclk, 20000000U, 35000000U)){
+    if(ENET_RANGE(ahbclk, 20000000U, 35000000U)) {
         reg |= ENET_MDC_HCLK_DIV16;
-    }else if(ENET_RANGE(ahbclk, 35000000U, 60000000U)){
+    } else if(ENET_RANGE(ahbclk, 35000000U, 60000000U)) {
         reg |= ENET_MDC_HCLK_DIV26;
-    }else if(ENET_RANGE(ahbclk, 60000000U, 100000000U)){
+    } else if(ENET_RANGE(ahbclk, 60000000U, 100000000U)) {
         reg |= ENET_MDC_HCLK_DIV42;
-    }else if(ENET_RANGE(ahbclk, 100000000U, 150000000U)){
+    } else if(ENET_RANGE(ahbclk, 100000000U, 150000000U)) {
         reg |= ENET_MDC_HCLK_DIV62;
-    }else if((ENET_RANGE(ahbclk, 150000000U, 200000000U))||(200000000U == ahbclk)){
-        reg |= ENET_MDC_HCLK_DIV102;    
-    }else{
+    } else if((ENET_RANGE(ahbclk, 150000000U, 240000000U)) || (240000000U == ahbclk)) {
+        reg |= ENET_MDC_HCLK_DIV102;
+    } else {
         return enet_state;
     }
     ENET_MAC_PHY_CTL = reg;
 
     /* reset PHY */
     phy_value = PHY_RESET;
-    if(ERROR == (enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value))){
+    if(ERROR == (enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value))) {
         return enet_state;
     }
-    /* PHY reset need some time */    
+    /* PHY reset need some time */
     _ENET_DELAY_(ENET_DELAY_TO);
-    
+
     /* check whether PHY reset is complete */
-    if(ERROR == (enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &phy_value))){
+    if(ERROR == (enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &phy_value))) {
         return enet_state;
     }
 
     /* PHY reset complete */
-    if(RESET == (phy_value & PHY_RESET)){
+    if(RESET == (phy_value & PHY_RESET)) {
         enet_state = SUCCESS;
     }
-    
+
     return enet_state;
 }
 
@@ -1587,7 +1588,7 @@ ErrStatus enet_phy_config(void)
       \arg        ENET_PHY_READ:  read data from phy register
     \param[in]  phy_address: 0x0000 - 0x001F
     \param[in]  phy_reg: 0x0000 - 0x001F
-    \param[in]  pvalue: the value will be written to the PHY register in ENET_PHY_WRITE direction 
+    \param[in]  pvalue: the value will be written to the PHY register in ENET_PHY_WRITE direction
     \param[out] pvalue: the value will be read from the PHY register in ENET_PHY_READ direction
     \retval     ErrStatus: SUCCESS or ERROR
 */
@@ -1597,34 +1598,33 @@ ErrStatus enet_phy_write_read(enet_phydirection_enum direction, uint16_t phy_add
     uint32_t timeout = 0U;
     ErrStatus enet_state = ERROR;
 
-    /* configure ENET_MAC_PHY_CTL with write/read operation */  
+    /* configure ENET_MAC_PHY_CTL with write/read operation */
     reg = ENET_MAC_PHY_CTL;
     reg &= ~(ENET_MAC_PHY_CTL_PB | ENET_MAC_PHY_CTL_PW | ENET_MAC_PHY_CTL_PR | ENET_MAC_PHY_CTL_PA);
-    reg |= (direction | MAC_PHY_CTL_PR(phy_reg) | MAC_PHY_CTL_PA(phy_address) | ENET_MAC_PHY_CTL_PB); 
+    reg |= (direction | MAC_PHY_CTL_PR(phy_reg) | MAC_PHY_CTL_PA(phy_address) | ENET_MAC_PHY_CTL_PB);
 
     /* if do the write operation, write value to the register */
-    if(ENET_PHY_WRITE == direction){
-        ENET_MAC_PHY_DATA = *pvalue;        
+    if(ENET_PHY_WRITE == direction) {
+        ENET_MAC_PHY_DATA = *pvalue;
     }
-    
+
     /* do PHY write/read operation, and wait the operation complete  */
     ENET_MAC_PHY_CTL = reg;
-    do{
+    do {
         phy_flag = (ENET_MAC_PHY_CTL & ENET_MAC_PHY_CTL_PB);
         timeout++;
-    }
-    while((RESET != phy_flag) && (ENET_DELAY_TO != timeout));
+    } while((RESET != phy_flag) && (ENET_DELAY_TO != timeout));
 
-    /* write/read operation complete */    
-    if(RESET == (ENET_MAC_PHY_CTL & ENET_MAC_PHY_CTL_PB)){
+    /* write/read operation complete */
+    if(RESET == (ENET_MAC_PHY_CTL & ENET_MAC_PHY_CTL_PB)) {
         enet_state = SUCCESS;
     }
 
-    /* if do the read operation, get value from the register */    
-    if(ENET_PHY_READ == direction){
-        *pvalue = (uint16_t)ENET_MAC_PHY_DATA;        
+    /* if do the read operation, get value from the register */
+    if(ENET_PHY_READ == direction) {
+        *pvalue = (uint16_t)ENET_MAC_PHY_DATA;
     }
-    
+
     return enet_state;
 }
 
@@ -1640,7 +1640,7 @@ ErrStatus enet_phyloopback_enable(void)
     ErrStatus phy_state = ERROR;
 
     /* get the PHY configuration to update it */
-    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy); 
+    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
 
     /* enable the PHY loopback mode */
     temp_phy |= PHY_LOOPBACK;
@@ -1663,7 +1663,7 @@ ErrStatus enet_phyloopback_disable(void)
     ErrStatus phy_state = ERROR;
 
     /* get the PHY configuration to update it */
-    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy); 
+    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
 
     /* disable the PHY loopback mode */
     temp_phy &= (uint16_t)~PHY_LOOPBACK;
@@ -1688,10 +1688,10 @@ ErrStatus enet_phyloopback_disable(void)
 void enet_forward_feature_enable(uint32_t feature)
 {
     uint32_t mask;
-    
+
     mask = (feature & (~(ENET_FORWARD_ERRFRAMES | ENET_FORWARD_UNDERSZ_GOODFRAMES)));
     ENET_MAC_CFG |= mask;
-    
+
     mask = (feature & (~(ENET_AUTO_PADCRC_DROP | ENET_TYPEFRAME_CRC_DROP)));
     ENET_DMA_CTL |= (mask >> 2);
 }
@@ -1710,15 +1710,15 @@ void enet_forward_feature_enable(uint32_t feature)
 void enet_forward_feature_disable(uint32_t feature)
 {
     uint32_t mask;
-    
+
     mask = (feature & (~(ENET_FORWARD_ERRFRAMES | ENET_FORWARD_UNDERSZ_GOODFRAMES)));
     ENET_MAC_CFG &= ~mask;
-    
+
     mask = (feature & (~(ENET_AUTO_PADCRC_DROP | ENET_TYPEFRAME_CRC_DROP)));
     ENET_DMA_CTL &= ~(mask >> 2);
 }
-                            
-/*!                    
+
+/*!
     \brief      enable ENET fliter feature
     \param[in]  feature: the feature of ENET fliter mode
                 one or more parameters can be selected which are shown as below
@@ -1763,18 +1763,18 @@ void enet_fliter_feature_disable(uint32_t feature)
     \param[out] none
     \retval     ErrStatus: ERROR or SUCCESS
 */
-ErrStatus enet_pauseframe_generate(void)  
-{ 
-    ErrStatus enet_state =ERROR;
+ErrStatus enet_pauseframe_generate(void)
+{
+    ErrStatus enet_state = ERROR;
     uint32_t temp = 0U;
 
     /* in full-duplex mode, must make sure this bit is 0 before writing register */
     temp = ENET_MAC_FCTL & ENET_MAC_FCTL_FLCBBKPA;
-    if(RESET == temp){
+    if(RESET == temp) {
         ENET_MAC_FCTL |= ENET_MAC_FCTL_FLCBBKPA;
         enet_state = SUCCESS;
     }
-    return enet_state;    
+    return enet_state;
 }
 
 /*!
@@ -1783,7 +1783,7 @@ ErrStatus enet_pauseframe_generate(void)
                 only one parameter can be selected which is shown as below
       \arg        ENET_MAC0_AND_UNIQUE_ADDRESS_PAUSEDETECT: besides the unique multicast address, MAC can also
                                                             use the MAC0 address to detecting pause frame
-      \arg        ENET_UNIQUE_PAUSEDETECT: only the unique multicast address for pause frame which is specified 
+      \arg        ENET_UNIQUE_PAUSEDETECT: only the unique multicast address for pause frame which is specified
                                            in IEEE802.3 can be detected
     \param[out] none
     \retval     none
@@ -1839,7 +1839,7 @@ void enet_pauseframe_config(uint32_t pausetime, uint32_t pause_threshold)
 */
 void enet_flowcontrol_threshold_config(uint32_t deactive, uint32_t active)
 {
-    ENET_MAC_FCTH = ((deactive | active) >> 8); 
+    ENET_MAC_FCTH = ((deactive | active) >> 8);
 }
 
 /*!
@@ -1855,7 +1855,7 @@ void enet_flowcontrol_threshold_config(uint32_t deactive, uint32_t active)
 */
 void enet_flowcontrol_feature_enable(uint32_t feature)
 {
-    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)){
+    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)) {
         ENET_MAC_FCTL &= ~ENET_ZERO_QUANTA_PAUSE;
     }
     feature &= ~ENET_ZERO_QUANTA_PAUSE;
@@ -1875,7 +1875,7 @@ void enet_flowcontrol_feature_enable(uint32_t feature)
 */
 void enet_flowcontrol_feature_disable(uint32_t feature)
 {
-    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)){
+    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)) {
         ENET_MAC_FCTL |= ENET_ZERO_QUANTA_PAUSE;
     }
     feature &= ~ENET_ZERO_QUANTA_PAUSE;
@@ -1903,7 +1903,7 @@ uint32_t enet_dmaprocess_state_get(enet_dmadirection_enum direction)
 }
 
 /*!
-    \brief    poll the DMA transmission/reception enable by writing any value to the 
+    \brief    poll the DMA transmission/reception enable by writing any value to the
                 ENET_DMA_TPEN/ENET_DMA_RPEN register, this will make the DMA to resume transmission/reception
     \param[in]  direction: choose the direction of DMA process which users want to resume, refer to enet_dmadirection_enum
                 only one parameter can be selected which is shown as below
@@ -1914,15 +1914,15 @@ uint32_t enet_dmaprocess_state_get(enet_dmadirection_enum direction)
 */
 void enet_dmaprocess_resume(enet_dmadirection_enum direction)
 {
-    if(ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         ENET_DMA_TPEN = 0U;
-    }else{
+    } else {
         ENET_DMA_RPEN = 0U;
     }
 }
 
 /*!
-    \brief    check and recover the Rx process 
+    \brief    check and recover the Rx process
     \param[in]  none
     \param[out] none
     \retval     none
@@ -1931,15 +1931,15 @@ void enet_rxprocess_check_recovery(void)
 {
     uint32_t status;
 
-    /* get DAV information of current RxDMA descriptor */  
+    /* get DAV information of current RxDMA descriptor */
     status = dma_current_rxdesc->status;
     status &= ENET_RDES0_DAV;
-    
-    /* if current descriptor is owned by DMA, but the descriptor address mismatches with 
+
+    /* if current descriptor is owned by DMA, but the descriptor address mismatches with
     receive descriptor address pointer updated by RxDMA controller */
     if((ENET_DMA_CRDADDR != ((uint32_t)dma_current_rxdesc)) &&
-       (ENET_RDES0_DAV == status)){
-        dma_current_rxdesc = (enet_descriptors_struct*)ENET_DMA_CRDADDR;
+            (ENET_RDES0_DAV == status)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)ENET_DMA_CRDADDR;
     }
 }
 
@@ -1954,19 +1954,19 @@ ErrStatus enet_txfifo_flush(void)
     uint32_t flush_state;
     uint32_t timeout = 0U;
     ErrStatus enet_state = ERROR;
- 
+
     /* set the FTF bit for flushing transmit FIFO */
-    ENET_DMA_CTL |= ENET_DMA_CTL_FTF;   
+    ENET_DMA_CTL |= ENET_DMA_CTL_FTF;
     /* wait until the flush operation completes */
-    do{
-        flush_state = ENET_DMA_CTL & ENET_DMA_CTL_FTF; 
+    do {
+        flush_state = ENET_DMA_CTL & ENET_DMA_CTL_FTF;
         timeout++;
-    }while((RESET != flush_state) && (timeout < ENET_DELAY_TO));
+    } while((RESET != flush_state) && (timeout < ENET_DELAY_TO));
     /* return ERROR due to timeout */
-    if(RESET == flush_state){
+    if(RESET == flush_state) {
         enet_state = SUCCESS;
     }
-    
+
     return  enet_state;
 }
 
@@ -1982,14 +1982,14 @@ ErrStatus enet_txfifo_flush(void)
       \arg        ENET_TX_CURRENT_DESC: the start descriptor address of the current transmit descriptor read by
                                         the TxDMA controller
       \arg        ENET_TX_CURRENT_BUFFER: the current transmit buffer address being read by the TxDMA controller
-    \param[out] none    
+    \param[out] none
     \retval     address value
 */
 uint32_t enet_current_desc_address_get(enet_desc_reg_enum addr_get)
 {
     uint32_t reval = 0U;
 
-    reval = REG32((ENET) +(uint32_t)addr_get);
+    reval = REG32((ENET) + (uint32_t)addr_get);
     return reval;
 }
 
@@ -2011,36 +2011,36 @@ uint32_t enet_desc_information_get(enet_descriptors_struct *desc, enet_descstate
 {
     uint32_t reval = 0xFFFFFFFFU;
 
-    switch(info_get){
+    switch(info_get) {
     case RXDESC_BUFFER_1_SIZE:
         reval = GET_RDES1_RB1S(desc->control_buffer_size);
         break;
     case RXDESC_BUFFER_2_SIZE:
         reval = GET_RDES1_RB2S(desc->control_buffer_size);
-        break; 
-    case RXDESC_FRAME_LENGTH:    
+        break;
+    case RXDESC_FRAME_LENGTH:
         reval = GET_RDES0_FRML(desc->status);
-        if(reval > 4U){
+        if(reval > 4U) {
             reval = reval - 4U;
-        
-            /* if is a type frame, and CRC is not included in forwarding frame */ 
-            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (desc->status & ENET_RDES0_FRMT))){
+
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (desc->status & ENET_RDES0_FRMT))) {
                 reval = reval + 4U;
-            }    
-        }else{
+            }
+        } else {
             reval = 0U;
         }
-    
+
         break;
-    case RXDESC_BUFFER_1_ADDR:    
-        reval = desc->buffer1_addr;    
+    case RXDESC_BUFFER_1_ADDR:
+        reval = desc->buffer1_addr;
         break;
-    case TXDESC_BUFFER_1_ADDR:    
-        reval = desc->buffer1_addr;  
+    case TXDESC_BUFFER_1_ADDR:
+        reval = desc->buffer1_addr;
         break;
-    case TXDESC_COLLISION_COUNT:    
+    case TXDESC_COLLISION_COUNT:
         reval = GET_TDES0_COCNT(desc->status);
-        break;    
+        break;
     default:
         break;
     }
@@ -2057,7 +2057,7 @@ uint32_t enet_desc_information_get(enet_descriptors_struct *desc, enet_descstate
 void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
 {
     uint32_t temp_counter = 0U;
-  
+
     temp_counter = ENET_DMA_MFBOCNT;
     *rxfifo_drop = GET_DMA_MFBOCNT_MSFA(temp_counter);
     *rxdma_drop = GET_DMA_MFBOCNT_MSFC(temp_counter);
@@ -2068,7 +2068,7 @@ void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
     \param[in]  desc: the descriptor pointer which users want to get flag
     \param[in]  desc_flag: the bit flag of ENET DMA descriptor
                 only one parameter can be selected which is shown as below
-      \arg        ENET_TDES0_DB: deferred 
+      \arg        ENET_TDES0_DB: deferred
       \arg        ENET_TDES0_UFE: underflow error
       \arg        ENET_TDES0_EXD: excessive deferral
       \arg        ENET_TDES0_VFRM: VLAN frame
@@ -2081,18 +2081,18 @@ void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
       \arg        ENET_TDES0_JT: jabber timeout
       \arg        ENET_TDES0_ES: error summary
       \arg        ENET_TDES0_IPHE: IP header error
-      \arg        ENET_TDES0_TTMSS: transmit timestamp status 
+      \arg        ENET_TDES0_TTMSS: transmit timestamp status
       \arg        ENET_TDES0_TCHM: the second address chained mode
       \arg        ENET_TDES0_TERM: transmit end of ring mode
       \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
-      \arg        ENET_TDES0_DPAD: disable adding pad      
+      \arg        ENET_TDES0_DPAD: disable adding pad
       \arg        ENET_TDES0_DCRC: disable CRC
       \arg        ENET_TDES0_FSG: first segment
       \arg        ENET_TDES0_LSG: last segment
       \arg        ENET_TDES0_INTC: interrupt on completion
       \arg        ENET_TDES0_DAV: DAV bit
-      
-      \arg        ENET_RDES0_PCERR: payload checksum error 
+
+      \arg        ENET_RDES0_PCERR: payload checksum error
       \arg        ENET_RDES0_EXSV: extended status valid
       \arg        ENET_RDES0_CERR: CRC error
       \arg        ENET_RDES0_DBERR: dribble bit error
@@ -2105,11 +2105,11 @@ void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
       \arg        ENET_RDES0_LDES: last descriptor
       \arg        ENET_RDES0_FDES: first descriptor
       \arg        ENET_RDES0_VTAG: VLAN tag
-      \arg        ENET_RDES0_OERR: overflow error 
+      \arg        ENET_RDES0_OERR: overflow error
       \arg        ENET_RDES0_LERR: length error
       \arg        ENET_RDES0_SAFF: SA filter fail
       \arg        ENET_RDES0_DERR: descriptor error
-      \arg        ENET_RDES0_ERRS: error summary      
+      \arg        ENET_RDES0_ERRS: error summary
       \arg        ENET_RDES0_DAFF: destination address filter fail
       \arg        ENET_RDES0_DAV: descriptor available
     \param[out] none
@@ -2118,8 +2118,8 @@ void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
 FlagStatus enet_desc_flag_get(enet_descriptors_struct *desc, uint32_t desc_flag)
 {
     FlagStatus enet_flag = RESET;
-  
-    if ((uint32_t)RESET != (desc->status & desc_flag)){
+
+    if((uint32_t)RESET != (desc->status & desc_flag)) {
         enet_flag = SET;
     }
 
@@ -2136,13 +2136,13 @@ FlagStatus enet_desc_flag_get(enet_descriptors_struct *desc, uint32_t desc_flag)
       \arg        ENET_TDES0_TCHM: the second address chained mode
       \arg        ENET_TDES0_TERM: transmit end of ring mode
       \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
-      \arg        ENET_TDES0_DPAD: disable adding pad      
+      \arg        ENET_TDES0_DPAD: disable adding pad
       \arg        ENET_TDES0_DCRC: disable CRC
       \arg        ENET_TDES0_FSG: first segment
       \arg        ENET_TDES0_LSG: last segment
       \arg        ENET_TDES0_INTC: interrupt on completion
       \arg        ENET_TDES0_DAV: DAV bit
-      \arg        ENET_RDES0_DAV: descriptor available 
+      \arg        ENET_RDES0_DAV: descriptor available
     \param[out] none
     \retval     none
 */
@@ -2161,13 +2161,13 @@ void enet_desc_flag_set(enet_descriptors_struct *desc, uint32_t desc_flag)
       \arg        ENET_TDES0_TCHM: the second address chained mode
       \arg        ENET_TDES0_TERM: transmit end of ring mode
       \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
-      \arg        ENET_TDES0_DPAD: disable adding pad      
+      \arg        ENET_TDES0_DPAD: disable adding pad
       \arg        ENET_TDES0_DCRC: disable CRC
       \arg        ENET_TDES0_FSG: first segment
       \arg        ENET_TDES0_LSG: last segment
       \arg        ENET_TDES0_INTC: interrupt on completion
       \arg        ENET_TDES0_DAV: DAV bit
-      \arg        ENET_RDES0_DAV: descriptor available 
+      \arg        ENET_RDES0_DAV: descriptor available
     \param[out] none
     \retval     none
 */
@@ -2177,7 +2177,7 @@ void enet_desc_flag_clear(enet_descriptors_struct *desc, uint32_t desc_flag)
 }
 
 /*!
-    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will immediately set 
+    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will immediately set
     \param[in]  desc: the descriptor pointer which users want to configure
     \param[out] none
     \retval     none
@@ -2188,7 +2188,7 @@ void enet_rx_desc_immediate_receive_complete_interrupt(enet_descriptors_struct *
 }
 
 /*!
-    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will is set after a configurable delay time 
+    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will is set after a configurable delay time
     \param[in]  desc: the descriptor pointer which users want to configure
     \param[in]  delay_time: delay a time of 256*delay_time HCLK(0x00000000 - 0x000000FF)
     \param[out] none
@@ -2209,36 +2209,36 @@ void enet_rx_desc_delay_receive_complete_interrupt(enet_descriptors_struct *desc
 void enet_rxframe_drop(void)
 {
     /* enable reception, descriptor is owned by DMA */
-    dma_current_rxdesc->status = ENET_RDES0_DAV;  
-    
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)){     
-        if(NULL != dma_current_ptp_rxdesc){
-            dma_current_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->buffer2_next_desc_addr);
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        if(NULL != dma_current_ptp_rxdesc) {
+            dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->buffer2_next_desc_addr);
             /* if it is the last ptp descriptor */
-            if(0U != dma_current_ptp_rxdesc->status){
+            if(0U != dma_current_ptp_rxdesc->status) {
                 /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
-                dma_current_ptp_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->status);
-            }else{
+                dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+            } else {
                 /* ponter to the next ptp descriptor */
                 dma_current_ptp_rxdesc++;
             }
-        }else{
-            dma_current_rxdesc = (enet_descriptors_struct*) (dma_current_rxdesc->buffer2_next_desc_addr);
+        } else {
+            dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
         }
-            
-    }else{
-        /* ring mode */    
-        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)){
+
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_rxdesc = (enet_descriptors_struct*) (ENET_DMA_RDTADDR);
-            if(NULL != dma_current_ptp_rxdesc){
-                dma_current_ptp_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->status);
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+            if(NULL != dma_current_ptp_rxdesc) {
+                dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
             }
-        }else{
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_rxdesc = (enet_descriptors_struct*) (uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
-            if(NULL != dma_current_ptp_rxdesc){
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            if(NULL != dma_current_ptp_rxdesc) {
                 dma_current_ptp_rxdesc++;
             }
         }
@@ -2294,8 +2294,8 @@ void enet_dma_feature_disable(uint32_t feature)
 uint32_t enet_rx_desc_enhanced_status_get(enet_descriptors_struct *desc, uint32_t desc_status)
 {
     uint32_t reval = 0xFFFFFFFFU;
-  
-    switch (desc_status){
+
+    switch(desc_status) {
     case ENET_RDES4_IPPLDT:
         reval = GET_RDES4_IPPLDT(desc->extended_status);
         break;
@@ -2303,13 +2303,13 @@ uint32_t enet_rx_desc_enhanced_status_get(enet_descriptors_struct *desc, uint32_
         reval = GET_RDES4_PTPMT(desc->extended_status);
         break;
     default:
-        if ((uint32_t)RESET != (desc->extended_status & desc_status)){
+        if((uint32_t)RESET != (desc->extended_status & desc_status)) {
             reval = 1U;
-        }else{
+        } else {
             reval = 0U;
-        } 
+        }
     }
-    
+
     return reval;
 }
 
@@ -2339,59 +2339,59 @@ void enet_ptp_enhanced_descriptors_chain_init(enet_dmadirection_enum direction)
     uint32_t desc_status = 0U, desc_bufsize = 0U;
     enet_descriptors_struct *desc, *desc_tab;
     uint8_t *buf;
-  
+
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
-        maxsize = ENET_TXBUF_SIZE;        
-      
+        maxsize = ENET_TXBUF_SIZE;
+
         /* select chain mode, and enable transmit timestamp function */
         desc_status = ENET_TDES0_TCHM | ENET_TDES0_TTSEN;
-      
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
-    }else{
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
-        maxsize = ENET_RXBUF_SIZE;       
-  
+        maxsize = ENET_RXBUF_SIZE;
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* select receive chained mode and set buffer1 size */
         desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
-      
+
         /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
-        dma_current_rxdesc = desc_tab;   
+        dma_current_rxdesc = desc_tab;
     }
-      
-    /* configuration each descriptor */   
-    for(num = 0U; num < count; num++){
+
+    /* configuration each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status;         
+        desc->status = desc_status;
         desc->control_buffer_size = desc_bufsize;
         desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
-    
+
         /* if is not the last descriptor */
-        if(num < (count - 1U)){
+        if(num < (count - 1U)) {
             /* configure the next descriptor address */
             desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
-        }else{
-            /* when it is the last descriptor, the next descriptor address 
-            equals to first descriptor address in descriptor table */ 
-            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;  
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;
         }
-    } 
+    }
 }
 
 /*!
@@ -2409,69 +2409,69 @@ void enet_ptp_enhanced_descriptors_ring_init(enet_dmadirection_enum direction)
     uint32_t desc_status = 0U, desc_bufsize = 0U;
     enet_descriptors_struct *desc;
     enet_descriptors_struct *desc_tab;
-    uint8_t *buf; 
-  
+    uint8_t *buf;
+
     /* configure descriptor skip length */
     ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
     ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
-  
+
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
-        maxsize = ENET_TXBUF_SIZE;      
+        maxsize = ENET_TXBUF_SIZE;
 
         /* select ring mode, and enable transmit timestamp function */
         desc_status = ENET_TDES0_TTSEN;
-      
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
-    }else{
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
-        maxsize = ENET_RXBUF_SIZE;      
-      
+        maxsize = ENET_RXBUF_SIZE;
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* set buffer1 size */
         desc_bufsize = ENET_RXBUF_SIZE;
-      
-         /* configure DMA Rx descriptor table address register */
+
+        /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
-        dma_current_rxdesc = desc_tab; 
+        dma_current_rxdesc = desc_tab;
     }
-    
-    /* configure each descriptor */   
-    for(num=0U; num < count; num++){
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status; 
-        desc->control_buffer_size = desc_bufsize;      
-        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);    
-    
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
         /* when it is the last descriptor */
-        if(num == (count - 1U)){
-            if (ENET_DMA_TX == direction){
-                /* configure transmit end of ring mode */  
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
                 desc->status |= ENET_TDES0_TERM;
-            }else{
+            } else {
                 /* configure receive end of ring mode */
                 desc->control_buffer_size |= ENET_RDES1_RERM;
             }
         }
-    } 
+    }
 }
 
 /*!
-    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in enhanced mode 
+    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in enhanced mode
     \param[in]  bufsize: the size of buffer which is the parameter in function
     \param[out] buffer: pointer to the application buffer
                 note -- if the input is NULL, user should copy data in application by himself
@@ -2484,54 +2484,54 @@ ErrStatus enet_ptpframe_receive_enhanced_mode(uint8_t *buffer, uint32_t bufsize,
     uint32_t offset = 0U, size = 0U;
     uint32_t timeout = 0U;
     uint32_t rdes0_tsv_flag;
-    
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)){
-        return ERROR; 
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
+        return ERROR;
     }
-    
+
     /* if buffer pointer is null, indicates that users has copied data in application */
-    if(NULL != buffer){
-        /* if no error occurs, and the frame uses only one descriptor */    
-        if(((uint32_t)RESET == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) && 
-           ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&  
-           ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))){      
+    if(NULL != buffer) {
+        /* if no error occurs, and the frame uses only one descriptor */
+        if(((uint32_t)RESET == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
             /* get the frame length except CRC */
             size = GET_RDES0_FRML(dma_current_rxdesc->status) - 4U;
 
-            /* if is a type frame, and CRC is not included in forwarding frame */  
-            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))){
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
                 size = size + 4U;
             }
-            
+
             /* to avoid situation that the frame size exceeds the buffer length */
-            if(size > bufsize){
+            if(size > bufsize) {
                 return ERROR;
             }
 
             /* copy data from Rx buffer to application buffer */
-            for(offset = 0; offset < size; offset++){
+            for(offset = 0; offset < size; offset++) {
                 (*(buffer + offset)) = (*(__IO uint8_t *)((dma_current_rxdesc->buffer1_addr) + offset));
             }
-        }else{
+        } else {
             return ERROR;
         }
-    }  
-    
+    }
+
     /* if timestamp pointer is null, indicates that users don't care timestamp in application */
-    if(NULL != timestamp){
+    if(NULL != timestamp) {
         /* wait for ENET_RDES0_TSV flag to be set, the timestamp value is taken and
         write to the RDES6 and RDES7 */
-        do{   
+        do {
             rdes0_tsv_flag = (dma_current_rxdesc->status & ENET_RDES0_TSV);
             timeout++;
-        }while ((RESET == rdes0_tsv_flag) && (timeout < ENET_DELAY_TO));
-        
+        } while((RESET == rdes0_tsv_flag) && (timeout < ENET_DELAY_TO));
+
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             return ERROR;
         }
-        
+
         /* clear the ENET_RDES0_TSV flag */
         dma_current_rxdesc->status &= ~ENET_RDES0_TSV;
         /* get the timestamp value of the received frame */
@@ -2541,35 +2541,35 @@ ErrStatus enet_ptpframe_receive_enhanced_mode(uint8_t *buffer, uint32_t bufsize,
 
     /* enable reception, descriptor is owned by DMA */
     dma_current_rxdesc->status = ENET_RDES0_DAV;
-    
+
     /* check Rx buffer unavailable flag status */
-    if ((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)){
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
         /* Clear RBU flag */
         ENET_DMA_STAT = ENET_DMA_STAT_RBU;
         /* resume DMA reception by writing to the RPEN register*/
         ENET_DMA_RPEN = 0;
     }
-  
-    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */      
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)){      
-        dma_current_rxdesc = (enet_descriptors_struct*) (dma_current_rxdesc->buffer2_next_desc_addr);    
-    }else{   
-        /* ring mode */    
-        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)){
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_rxdesc = (enet_descriptors_struct*) (ENET_DMA_RDTADDR);      
-        }else{ 
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_rxdesc = (enet_descriptors_struct*) ((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));      
+            dma_current_rxdesc = (enet_descriptors_struct *)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
         }
     }
-  
+
     return SUCCESS;
 }
 
 /*!
-    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in enhanced mode 
+    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in enhanced mode
     \param[in]  buffer: pointer on the application buffer
                 note -- if the input is NULL, user should copy data in application by himself
     \param[in]  length: the length of frame data to be transmitted
@@ -2582,56 +2582,56 @@ ErrStatus enet_ptpframe_transmit_enhanced_mode(uint8_t *buffer, uint32_t length,
     uint32_t offset = 0;
     uint32_t dma_tbu_flag, dma_tu_flag;
     uint32_t tdes0_ttmss_flag;
-    uint32_t timeout = 0; 
-    
+    uint32_t timeout = 0;
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)){
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
         return ERROR;
     }
-    
+
     /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
-    if(length > ENET_MAX_FRAME_SIZE){
+    if(length > ENET_MAX_FRAME_SIZE) {
         return ERROR;
-    }  
+    }
 
     /* if buffer pointer is null, indicates that users has handled data in application */
-    if(NULL != buffer){
+    if(NULL != buffer) {
         /* copy frame data from application buffer to Tx buffer */
-        for(offset = 0; offset < length; offset++){
+        for(offset = 0; offset < length; offset++) {
             (*(__IO uint8_t *)((dma_current_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
         }
     }
     /* set the frame length */
     dma_current_txdesc->control_buffer_size = length;
-    /* set the segment of frame, frame is transmitted in one descriptor */   
+    /* set the segment of frame, frame is transmitted in one descriptor */
     dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
     /* enable the DMA transmission */
     dma_current_txdesc->status |= ENET_TDES0_DAV;
 
     /* check Tx buffer unavailable flag status */
-    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU); 
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
     dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
-    
-    if ((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)){
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
         /* Clear TBU and TU flag */
         ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
         /* resume DMA transmission by writing to the TPEN register*/
         ENET_DMA_TPEN = 0;
     }
-    
+
     /* if timestamp pointer is null, indicates that users don't care timestamp in application */
-    if(NULL != timestamp){
+    if(NULL != timestamp) {
         /* wait for ENET_TDES0_TTMSS flag to be set, a timestamp was captured */
-        do{
+        do {
             tdes0_ttmss_flag = (dma_current_txdesc->status & ENET_TDES0_TTMSS);
             timeout++;
-        }while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
-        
+        } while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
+
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             return ERROR;
         }
-     
+
         /* clear the ENET_TDES0_TTMSS flag */
         dma_current_txdesc->status &= ~ENET_TDES0_TTMSS;
         /* get the timestamp value of the transmit frame */
@@ -2639,18 +2639,18 @@ ErrStatus enet_ptpframe_transmit_enhanced_mode(uint8_t *buffer, uint32_t length,
         timestamp[1] = dma_current_txdesc->timestamp_high;
     }
 
-    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/  
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)){     
-        dma_current_txdesc = (enet_descriptors_struct*) (dma_current_txdesc->buffer2_next_desc_addr);    
-    }else{
-        /* ring mode */        
-        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)){
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_txdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_txdesc = (enet_descriptors_struct*) (ENET_DMA_TDTADDR);      
-        }else{ 
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_txdesc = (enet_descriptors_struct*) ((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            dma_current_txdesc = (enet_descriptors_struct *)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
         }
     }
 
@@ -2686,67 +2686,67 @@ void enet_ptp_normal_descriptors_chain_init(enet_dmadirection_enum direction, en
     uint32_t desc_status = 0U, desc_bufsize = 0U;
     enet_descriptors_struct *desc, *desc_tab;
     uint8_t *buf;
-  
+
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
-        maxsize = ENET_TXBUF_SIZE;        
-      
+        maxsize = ENET_TXBUF_SIZE;
+
         /* select chain mode, and enable transmit timestamp function */
         desc_status = ENET_TDES0_TCHM | ENET_TDES0_TTSEN;
-      
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
         dma_current_ptp_txdesc = desc_ptptab;
-    }else{
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
-        maxsize = ENET_RXBUF_SIZE;       
-  
+        maxsize = ENET_RXBUF_SIZE;
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* select receive chained mode and set buffer1 size */
         desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
-      
+
         /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
         dma_current_rxdesc = desc_tab;
-        dma_current_ptp_rxdesc = desc_ptptab;      
+        dma_current_ptp_rxdesc = desc_ptptab;
     }
-      
-    /* configure each descriptor */   
-    for(num = 0U; num < count; num++){
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status;         
+        desc->status = desc_status;
         desc->control_buffer_size = desc_bufsize;
         desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
-    
+
         /* if is not the last descriptor */
-        if(num < (count - 1U)){
+        if(num < (count - 1U)) {
             /* configure the next descriptor address */
             desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
-        }else{
-            /* when it is the last descriptor, the next descriptor address 
-            equals to first descriptor address in descriptor table */ 
-            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;  
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;
         }
         /* set desc_ptptab equal to desc_tab */
         (&desc_ptptab[num])->buffer1_addr = desc->buffer1_addr;
         (&desc_ptptab[num])->buffer2_next_desc_addr = desc->buffer2_next_desc_addr;
-    } 
-    /* when it is the last ptp descriptor, preserve the first descriptor 
+    }
+    /* when it is the last ptp descriptor, preserve the first descriptor
     address of desc_ptptab in ptp descriptor status */
-    (&desc_ptptab[num-1U])->status = (uint32_t)desc_ptptab;
+    (&desc_ptptab[num - 1U])->status = (uint32_t)desc_ptptab;
 }
 
 /*!
@@ -2769,57 +2769,57 @@ void enet_ptp_normal_descriptors_ring_init(enet_dmadirection_enum direction, ene
     /* configure descriptor skip length */
     ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
     ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
-    
+
     /* if want to initialize DMA Tx descriptors */
-    if (ENET_DMA_TX == direction){
+    if(ENET_DMA_TX == direction) {
         /* save a copy of the DMA Tx descriptors */
         desc_tab = txdesc_tab;
         buf = &tx_buff[0][0];
         count = ENET_TXBUF_NUM;
-        maxsize = ENET_TXBUF_SIZE;        
-      
+        maxsize = ENET_TXBUF_SIZE;
+
         /* select ring mode, and enable transmit timestamp function */
         desc_status = ENET_TDES0_TTSEN;
-      
+
         /* configure DMA Tx descriptor table address register */
         ENET_DMA_TDTADDR = (uint32_t)desc_tab;
         dma_current_txdesc = desc_tab;
         dma_current_ptp_txdesc = desc_ptptab;
-    }else{
+    } else {
         /* if want to initialize DMA Rx descriptors */
         /* save a copy of the DMA Rx descriptors */
         desc_tab = rxdesc_tab;
         buf = &rx_buff[0][0];
         count = ENET_RXBUF_NUM;
-        maxsize = ENET_RXBUF_SIZE;       
-  
+        maxsize = ENET_RXBUF_SIZE;
+
         /* enable receiving */
         desc_status = ENET_RDES0_DAV;
         /* select receive ring mode and set buffer1 size */
         desc_bufsize = (uint32_t)ENET_RXBUF_SIZE;
-      
+
         /* configure DMA Rx descriptor table address register */
         ENET_DMA_RDTADDR = (uint32_t)desc_tab;
         dma_current_rxdesc = desc_tab;
-        dma_current_ptp_rxdesc = desc_ptptab;      
+        dma_current_ptp_rxdesc = desc_ptptab;
     }
-      
-    /* configure each descriptor */   
-    for(num = 0U; num < count; num++){
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
         /* get the pointer to the next descriptor of the descriptor table */
         desc = desc_tab + num;
 
         /* configure descriptors */
-        desc->status = desc_status;         
+        desc->status = desc_status;
         desc->control_buffer_size = desc_bufsize;
         desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
-    
+
         /* when it is the last descriptor */
-        if(num == (count - 1U)){
-            if (ENET_DMA_TX == direction){
-                /* configure transmit end of ring mode */  
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
                 desc->status |= ENET_TDES0_TERM;
-            }else{
+            } else {
                 /* configure receive end of ring mode */
                 desc->control_buffer_size |= ENET_RDES1_RERM;
             }
@@ -2827,14 +2827,14 @@ void enet_ptp_normal_descriptors_ring_init(enet_dmadirection_enum direction, ene
         /* set desc_ptptab equal to desc_tab */
         (&desc_ptptab[num])->buffer1_addr = desc->buffer1_addr;
         (&desc_ptptab[num])->buffer2_next_desc_addr = desc->buffer2_next_desc_addr;
-    } 
-    /* when it is the last ptp descriptor, preserve the first descriptor 
+    }
+    /* when it is the last ptp descriptor, preserve the first descriptor
     address of desc_ptptab in ptp descriptor status */
-    (&desc_ptptab[num-1U])->status = (uint32_t)desc_ptptab;
+    (&desc_ptptab[num - 1U])->status = (uint32_t)desc_ptptab;
 }
 
 /*!
-    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in normal mode   
+    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in normal mode
     \param[in]  bufsize: the size of buffer which is the parameter in function
     \param[out] buffer: pointer to the application buffer
                 note -- if the input is NULL, user should copy data in application by himself
@@ -2844,37 +2844,37 @@ void enet_ptp_normal_descriptors_ring_init(enet_dmadirection_enum direction, ene
 ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, uint32_t timestamp[])
 {
     uint32_t offset = 0U, size = 0U;
-    
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)){
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
         return ERROR;
     }
-    
+
     /* if buffer pointer is null, indicates that users has copied data in application */
-    if(NULL != buffer){
+    if(NULL != buffer) {
         /* if no error occurs, and the frame uses only one descriptor */
         if(((uint32_t)RESET == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
-           ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
-           ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))){
-            
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
+
             /* get the frame length except CRC */
             size = GET_RDES0_FRML(dma_current_rxdesc->status) - 4U;
             /* if is a type frame, and CRC is not included in forwarding frame */
-            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))){
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
                 size = size + 4U;
             }
-            
+
             /* to avoid situation that the frame size exceeds the buffer length */
-            if(size > bufsize){
+            if(size > bufsize) {
                 return ERROR;
             }
 
             /* copy data from Rx buffer to application buffer */
-            for(offset = 0U; offset < size; offset++){
+            for(offset = 0U; offset < size; offset++) {
                 (*(buffer + offset)) = (*(__IO uint8_t *)(uint32_t)((dma_current_ptp_rxdesc->buffer1_addr) + offset));
             }
-            
-        }else{
+
+        } else {
             return ERROR;
         }
     }
@@ -2884,42 +2884,42 @@ ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, u
 
     dma_current_rxdesc->buffer1_addr = dma_current_ptp_rxdesc ->buffer1_addr ;
     dma_current_rxdesc->buffer2_next_desc_addr = dma_current_ptp_rxdesc ->buffer2_next_desc_addr;
-    
+
     /* enable reception, descriptor is owned by DMA */
     dma_current_rxdesc->status = ENET_RDES0_DAV;
-    
+
     /* check Rx buffer unavailable flag status */
-    if ((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)){
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
         /* clear RBU flag */
         ENET_DMA_STAT = ENET_DMA_STAT_RBU;
         /* resume DMA reception by writing to the RPEN register*/
         ENET_DMA_RPEN = 0U;
     }
-    
 
-    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */      
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)){
-        dma_current_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->buffer2_next_desc_addr);
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->buffer2_next_desc_addr);
         /* if it is the last ptp descriptor */
-        if(0U != dma_current_ptp_rxdesc->status){
+        if(0U != dma_current_ptp_rxdesc->status) {
             /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
-            dma_current_ptp_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->status);
-        }else{
+            dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+        } else {
             /* ponter to the next ptp descriptor */
             dma_current_ptp_rxdesc++;
         }
-    }else{
-        /* ring mode */   
-        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)){
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_rxdesc = (enet_descriptors_struct*) (ENET_DMA_RDTADDR);
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
             /* RDES2 and RDES3 will not be covered by buffer address, so do not need to preserve a new table,
             use the same table with RxDMA descriptor */
-            dma_current_ptp_rxdesc = (enet_descriptors_struct*) (dma_current_ptp_rxdesc->status);          
-        }else{
+            dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_rxdesc = (enet_descriptors_struct*) (uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));      
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
             dma_current_ptp_rxdesc ++;
         }
     }
@@ -2928,7 +2928,7 @@ ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, u
 }
 
 /*!
-    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in normal mode 
+    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in normal mode
     \param[in]  buffer: pointer on the application buffer
                 note -- if the input is NULL, user should copy data in application by himself
     \param[in]  length: the length of frame data to be transmitted
@@ -2939,23 +2939,23 @@ ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, u
 ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, uint32_t timestamp[])
 {
     uint32_t offset = 0U, timeout = 0U;
-    uint32_t dma_tbu_flag, dma_tu_flag, tdes0_ttmss_flag; 
-    
+    uint32_t dma_tbu_flag, dma_tu_flag, tdes0_ttmss_flag;
+
     /* the descriptor is busy due to own by the DMA */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)){
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
         return ERROR;
     }
 
     /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
-    if(length > ENET_MAX_FRAME_SIZE){
+    if(length > ENET_MAX_FRAME_SIZE) {
         return ERROR;
     }
-    
+
     /* if buffer pointer is null, indicates that users has handled data in application */
-    if(NULL != buffer){
+    if(NULL != buffer) {
         /* copy frame data from application buffer to Tx buffer */
-        for(offset = 0U; offset < length; offset++){
-            (*(__IO uint8_t *) (uint32_t)((dma_current_ptp_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
+        for(offset = 0U; offset < length; offset++) {
+            (*(__IO uint8_t *)(uint32_t)((dma_current_ptp_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
         }
     }
     /* set the frame length */
@@ -2964,31 +2964,31 @@ ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, u
     dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
     /* enable the DMA transmission */
     dma_current_txdesc->status |= ENET_TDES0_DAV;
-    
+
     /* check Tx buffer unavailable flag status */
-    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU); 
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
     dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
-    
-    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)){
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
         /* clear TBU and TU flag */
         ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
         /* resume DMA transmission by writing to the TPEN register*/
         ENET_DMA_TPEN = 0U;
     }
-    
+
     /* if timestamp pointer is null, indicates that users don't care timestamp in application */
-    if(NULL != timestamp){
+    if(NULL != timestamp) {
         /* wait for ENET_TDES0_TTMSS flag to be set, a timestamp was captured */
-        do{   
+        do {
             tdes0_ttmss_flag = (dma_current_txdesc->status & ENET_TDES0_TTMSS);
             timeout++;
-        }while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
-       
+        } while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
+
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             return ERROR;
-        } 
-    
+        }
+
         /* clear the ENET_TDES0_TTMSS flag */
         dma_current_txdesc->status &= ~ENET_TDES0_TTMSS;
         /* get the timestamp value of the transmit frame */
@@ -2998,30 +2998,30 @@ ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, u
     dma_current_txdesc->buffer1_addr = dma_current_ptp_txdesc ->buffer1_addr ;
     dma_current_txdesc->buffer2_next_desc_addr = dma_current_ptp_txdesc ->buffer2_next_desc_addr;
 
-    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table */   
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table */
     /* chained mode */
-    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)){   
-        dma_current_txdesc = (enet_descriptors_struct*) (dma_current_ptp_txdesc->buffer2_next_desc_addr);
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->buffer2_next_desc_addr);
         /* if it is the last ptp descriptor */
-        if(0U != dma_current_ptp_txdesc->status){ 
+        if(0U != dma_current_ptp_txdesc->status) {
             /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
-            dma_current_ptp_txdesc = (enet_descriptors_struct*) (dma_current_ptp_txdesc->status);
-        }else{
+            dma_current_ptp_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->status);
+        } else {
             /* ponter to the next ptp descriptor */
             dma_current_ptp_txdesc++;
         }
-    }else{
-        /* ring mode */   
-        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)){
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
             /* if is the last descriptor in table, the next descriptor is the table header */
-            dma_current_txdesc = (enet_descriptors_struct*) (ENET_DMA_TDTADDR); 
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
             /* TDES2 and TDES3 will not be covered by buffer address, so do not need to preserve a new table,
             use the same table with TxDMA descriptor */
-            dma_current_ptp_txdesc = (enet_descriptors_struct*) (dma_current_ptp_txdesc->status);
-        }else{
+            dma_current_ptp_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->status);
+        } else {
             /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
-            dma_current_txdesc = (enet_descriptors_struct*) (uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));      
-            dma_current_ptp_txdesc ++;      
+            dma_current_txdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            dma_current_ptp_txdesc ++;
         }
     }
     return SUCCESS;
@@ -3030,7 +3030,7 @@ ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, u
 #endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
 
 /*!
-    \brief    wakeup frame filter register pointer reset 
+    \brief    wakeup frame filter register pointer reset
     \param[in]  none
     \param[out] none
     \retval     none
@@ -3041,7 +3041,7 @@ void enet_wum_filter_register_pointer_reset(void)
 }
 
 /*!
-    \brief    set the remote wakeup frame registers 
+    \brief    set the remote wakeup frame registers
     \param[in]  pdata: pointer to buffer data which is written to remote wakeup frame registers (8 words total)
     \param[out] none
     \retval     none
@@ -3049,15 +3049,15 @@ void enet_wum_filter_register_pointer_reset(void)
 void enet_wum_filter_config(uint32_t pdata[])
 {
     uint32_t num = 0U;
-  
+
     /* configure ENET_MAC_RWFF register */
-    for(num = 0U; num < ETH_WAKEUP_REGISTER_LENGTH; num++){
+    for(num = 0U; num < ETH_WAKEUP_REGISTER_LENGTH; num++) {
         ENET_MAC_RWFF = pdata[num];
     }
 }
 
 /*!
-    \brief    enable wakeup management features  
+    \brief    enable wakeup management features
     \param[in]  feature: the wake up type which is selected
                 one or more parameters can be selected which are shown as below
       \arg        ENET_WUM_POWER_DOWN: power down mode
@@ -3073,7 +3073,7 @@ void enet_wum_feature_enable(uint32_t feature)
 }
 
 /*!
-    \brief    disable wakeup management features  
+    \brief    disable wakeup management features
     \param[in]  feature: the wake up type which is selected
                 one or more parameters can be selected which are shown as below
       \arg        ENET_WUM_MAGIC_PACKET_FRAME: enable a wakeup event due to magic packet reception
@@ -3088,8 +3088,8 @@ void enet_wum_feature_disable(uint32_t feature)
 }
 
 /*!
-    \brief    reset the MAC statistics counters  
-    \param[in]  none 
+    \brief    reset the MAC statistics counters
+    \param[in]  none
     \param[out] none
     \retval     none
 */
@@ -3117,7 +3117,7 @@ void enet_msc_feature_enable(uint32_t feature)
 /*!
     \brief    disable the MAC statistics counter features
     \param[in]  feature: the feature of MAC statistics counter
-                one or more parameters can be selected which are shown as below 
+                one or more parameters can be selected which are shown as below
       \arg        ENET_MSC_COUNTER_STOP_ROLLOVER: counter stop rollover
       \arg        ENET_MSC_RESET_ON_READ: reset on read
       \arg        ENET_MSC_COUNTERS_FREEZE: MSC counter freeze
@@ -3126,11 +3126,11 @@ void enet_msc_feature_enable(uint32_t feature)
 */
 void enet_msc_feature_disable(uint32_t feature)
 {
-     ENET_MSC_CTL &= (~feature);
+    ENET_MSC_CTL &= (~feature);
 }
 
 /*!
-    \brief    configure MAC statistics counters preset mode   
+    \brief    configure MAC statistics counters preset mode
     \param[in]  mode: MSC counters preset mode, refer to enet_msc_preset_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MSC_PRESET_NONE: do not preset MSC counter
@@ -3146,7 +3146,7 @@ void enet_msc_counters_preset_config(enet_msc_preset_enum mode)
 }
 
 /*!
-    \brief    get MAC statistics counter  
+    \brief    get MAC statistics counter
     \param[in]  counter: MSC counters which is selected, refer to enet_msc_counter_enum
                 only one parameter can be selected which is shown as below
       \arg        ENET_MSC_TX_SCCNT: MSC transmitted good frames after a single collision counter
@@ -3161,9 +3161,9 @@ void enet_msc_counters_preset_config(enet_msc_preset_enum mode)
 uint32_t enet_msc_counters_get(enet_msc_counter_enum counter)
 {
     uint32_t reval;
-    
+
     reval = REG32((ENET + (uint32_t)counter));
-    
+
     return reval;
 }
 
@@ -3223,7 +3223,7 @@ void enet_ptp_feature_disable(uint32_t feature)
       \arg        ENET_SNOOPING_PTP_VERSION_2: version 2
       \arg        ENET_SNOOPING_PTP_VERSION_1: version 1
       \arg        ENET_EVENT_TYPE_MESSAGES_SNAPSHOT: only event type messages are taken snapshot
-      \arg        ENET_ALL_TYPE_MESSAGES_SNAPSHOT: all type messages are taken snapshot except announce, 
+      \arg        ENET_ALL_TYPE_MESSAGES_SNAPSHOT: all type messages are taken snapshot except announce,
                                                    management and signaling message
       \arg        ENET_MASTER_NODE_MESSAGE_SNAPSHOT: snapshot is only take for master node message
       \arg        ENET_SLAVE_NODE_MESSAGE_SNAPSHOT: snapshot is only taken for slave node message
@@ -3236,7 +3236,7 @@ ErrStatus enet_ptp_timestamp_function_config(enet_ptp_function_enum func)
     uint32_t timeout = 0U;
     ErrStatus enet_state = SUCCESS;
 
-    switch(func){
+    switch(func) {
     case ENET_CKNT_ORDINARY:
     case ENET_CKNT_BOUNDARY:
     case ENET_CKNT_END_TO_END:
@@ -3244,53 +3244,53 @@ ErrStatus enet_ptp_timestamp_function_config(enet_ptp_function_enum func)
         ENET_PTP_TSCTL &= ~ENET_PTP_TSCTL_CKNT;
         ENET_PTP_TSCTL |= (uint32_t)func;
         break;
-    case ENET_PTP_ADDEND_UPDATE: 
+    case ENET_PTP_ADDEND_UPDATE:
         /* this bit must be read as zero before application set it */
-        do{
-            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSARU; 
+        do {
+            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSARU;
             timeout++;
-        }while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             enet_state = ERROR;
-        }else{
+        } else {
             ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSARU;
-        }    
+        }
         break;
     case ENET_PTP_SYSTIME_UPDATE:
         /* both the TMSSTU and TMSSTI bits must be read as zero before application set this bit */
-        do{
-            temp_state = ENET_PTP_TSCTL & (ENET_PTP_TSCTL_TMSSTU | ENET_PTP_TSCTL_TMSSTI); 
+        do {
+            temp_state = ENET_PTP_TSCTL & (ENET_PTP_TSCTL_TMSSTU | ENET_PTP_TSCTL_TMSSTI);
             timeout++;
-        }while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             enet_state = ERROR;
-        }else{
+        } else {
             ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSSTU;
-        }    
-        break; 
+        }
+        break;
     case ENET_PTP_SYSTIME_INIT:
         /* this bit must be read as zero before application set it */
-        do{
-            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSSTI; 
+        do {
+            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSSTI;
             timeout++;
-        }while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
         /* return ERROR due to timeout */
-        if(ENET_DELAY_TO == timeout){
+        if(ENET_DELAY_TO == timeout) {
             enet_state = ERROR;
-        }else{
+        } else {
             ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSSTI;
-        }    
-        break;        
-    default:
-        temp_config = (uint32_t)func & (~BIT(31)); 
-        if(RESET != ((uint32_t)func & BIT(31))){
-            ENET_PTP_TSCTL |= temp_config;    
-        }else{
-            ENET_PTP_TSCTL &= ~temp_config;     
         }
-        break; 
+        break;
+    default:
+        temp_config = (uint32_t)func & (~BIT(31));
+        if(RESET != ((uint32_t)func & BIT(31))) {
+            ENET_PTP_TSCTL |= temp_config;
+        } else {
+            ENET_PTP_TSCTL &= ~temp_config;
+        }
+        break;
     }
 
     return enet_state;
@@ -3325,7 +3325,7 @@ void enet_ptp_timestamp_addend_config(uint32_t add)
       \arg        ENET_PTP_ADD_TO_TIME: timestamp update value is added to system time
       \arg        ENET_PTP_SUBSTRACT_FROM_TIME: timestamp update value is subtracted from system time
     \param[in]  second: initializing or adding/subtracting to second of the system time
-    \param[in]  subsecond: the current subsecond of the system time 
+    \param[in]  subsecond: the current subsecond of the system time
                 with 0.46 ns accuracy if required accuracy is 20 ns
     \param[out] none
     \retval     none
@@ -3333,7 +3333,7 @@ void enet_ptp_timestamp_addend_config(uint32_t add)
 void enet_ptp_timestamp_update_config(uint32_t sign, uint32_t second, uint32_t subsecond)
 {
     ENET_PTP_TSUH = second;
-    ENET_PTP_TSUL = sign | PTP_TSUL_TMSUSS(subsecond); 
+    ENET_PTP_TSUL = sign | PTP_TSUL_TMSUSS(subsecond);
 }
 
 /*!
@@ -3352,7 +3352,7 @@ void enet_ptp_expected_time_config(uint32_t second, uint32_t nanosecond)
 /*!
     \brief    get the current system time
     \param[in]  none
-    \param[out] systime_struct: pointer to a enet_ptp_systime_struct structure which contains 
+    \param[out] systime_struct: pointer to a enet_ptp_systime_struct structure which contains
                 parameters of PTP system time
                 members of the structure and the member values are shown as below:
                   second: 0x0 - 0xFFFF FFFF
@@ -3365,9 +3365,9 @@ void enet_ptp_system_time_get(enet_ptp_systime_struct *systime_struct)
     uint32_t temp_sec = 0U, temp_subs = 0U;
 
     /* get the value of sysytem time registers */
-    temp_sec = (uint32_t)ENET_PTP_TSH;   
+    temp_sec = (uint32_t)ENET_PTP_TSH;
     temp_subs = (uint32_t)ENET_PTP_TSL;
-   
+
     /* get sysytem time and construct the enet_ptp_systime_struct structure */
     systime_struct->second = temp_sec;
     systime_struct->subsecond = GET_PTP_TSL_STMSS(temp_subs);
@@ -3379,15 +3379,15 @@ void enet_ptp_system_time_get(enet_ptp_systime_struct *systime_struct)
     \param[in]  freq: PPS output frequency
                 only one parameter can be selected which is shown as below
       \arg        ENET_PPSOFC_1HZ: PPS output 1Hz frequency
-      \arg        ENET_PPSOFC_2HZ: PPS output 2Hz frequency 
-      \arg        ENET_PPSOFC_4HZ: PPS output 4Hz frequency 
-      \arg        ENET_PPSOFC_8HZ: PPS output 8Hz frequency 
-      \arg        ENET_PPSOFC_16HZ: PPS output 16Hz frequency 
-      \arg        ENET_PPSOFC_32HZ: PPS output 32Hz frequency 
+      \arg        ENET_PPSOFC_2HZ: PPS output 2Hz frequency
+      \arg        ENET_PPSOFC_4HZ: PPS output 4Hz frequency
+      \arg        ENET_PPSOFC_8HZ: PPS output 8Hz frequency
+      \arg        ENET_PPSOFC_16HZ: PPS output 16Hz frequency
+      \arg        ENET_PPSOFC_32HZ: PPS output 32Hz frequency
       \arg        ENET_PPSOFC_64HZ: PPS output 64Hz frequency
       \arg        ENET_PPSOFC_128HZ: PPS output 128Hz frequency
       \arg        ENET_PPSOFC_256HZ: PPS output 256Hz frequency
-      \arg        ENET_PPSOFC_512HZ: PPS output 512Hz frequency 
+      \arg        ENET_PPSOFC_512HZ: PPS output 512Hz frequency
       \arg        ENET_PPSOFC_1024HZ: PPS output 1024Hz frequency
       \arg        ENET_PPSOFC_2048HZ: PPS output 2048Hz frequency
       \arg        ENET_PPSOFC_4096HZ: PPS output 4096Hz frequency
@@ -3416,7 +3416,7 @@ void enet_initpara_reset(void)
     enet_initpara.dma_maxburst = 0U;
     enet_initpara.dma_arbitration = 0U;
     enet_initpara.store_forward_mode = 0U;
-    enet_initpara.dma_function = 0U; 
+    enet_initpara.dma_function = 0U;
     enet_initpara.vlan_config = 0U;
     enet_initpara.flow_control = 0U;
     enet_initpara.hashtable_high = 0U;
@@ -3425,10 +3425,10 @@ void enet_initpara_reset(void)
     enet_initpara.halfduplex_param = 0U;
     enet_initpara.timer_config = 0U;
     enet_initpara.interframegap = 0U;
-} 
+}
 
 /*!
-    \brief    initialize ENET peripheral with generally concerned parameters, call it by enet_init() 
+    \brief    initialize ENET peripheral with generally concerned parameters, call it by enet_init()
     \param[in]  none
     \param[out] none
     \retval     none
@@ -3442,20 +3442,20 @@ static void enet_default_init(void)
     reg_value = ENET_MAC_CFG;
     reg_value &= MAC_CFG_MASK;
     reg_value |= ENET_WATCHDOG_ENABLE | ENET_JABBER_ENABLE | ENET_INTERFRAMEGAP_96BIT \
-                | ENET_SPEEDMODE_10M |ENET_MODE_HALFDUPLEX | ENET_LOOPBACKMODE_DISABLE \
-                | ENET_CARRIERSENSE_ENABLE | ENET_RECEIVEOWN_ENABLE \
-                | ENET_RETRYTRANSMISSION_ENABLE | ENET_BACKOFFLIMIT_10 \
-                | ENET_DEFERRALCHECK_DISABLE \
-                | ENET_TYPEFRAME_CRC_DROP_DISABLE \
-                | ENET_AUTO_PADCRC_DROP_DISABLE \
-                | ENET_CHECKSUMOFFLOAD_DISABLE;
+                 | ENET_SPEEDMODE_10M | ENET_MODE_HALFDUPLEX | ENET_LOOPBACKMODE_DISABLE \
+                 | ENET_CARRIERSENSE_ENABLE | ENET_RECEIVEOWN_ENABLE \
+                 | ENET_RETRYTRANSMISSION_ENABLE | ENET_BACKOFFLIMIT_10 \
+                 | ENET_DEFERRALCHECK_DISABLE \
+                 | ENET_TYPEFRAME_CRC_DROP_DISABLE \
+                 | ENET_AUTO_PADCRC_DROP_DISABLE \
+                 | ENET_CHECKSUMOFFLOAD_DISABLE;
     ENET_MAC_CFG = reg_value;
-  
+
     /* configure ENET_MAC_FRMF register */
-    ENET_MAC_FRMF = ENET_SRC_FILTER_DISABLE |ENET_DEST_FILTER_INVERSE_DISABLE \
-                   |ENET_MULTICAST_FILTER_PERFECT |ENET_UNICAST_FILTER_PERFECT \
-                   |ENET_PCFRM_PREVENT_ALL |ENET_BROADCASTFRAMES_ENABLE \
-                   |ENET_PROMISCUOUS_DISABLE |ENET_RX_FILTER_ENABLE;
+    ENET_MAC_FRMF = ENET_SRC_FILTER_DISABLE | ENET_DEST_FILTER_INVERSE_DISABLE \
+                    | ENET_MULTICAST_FILTER_PERFECT | ENET_UNICAST_FILTER_PERFECT \
+                    | ENET_PCFRM_PREVENT_ALL | ENET_BROADCASTFRAMES_ENABLE \
+                    | ENET_PROMISCUOUS_DISABLE | ENET_RX_FILTER_ENABLE;
 
     /* configure ENET_MAC_HLH, ENET_MAC_HLL register */
     ENET_MAC_HLH = 0x0U;
@@ -3465,31 +3465,31 @@ static void enet_default_init(void)
     /* configure ENET_MAC_FCTL, ENET_MAC_FCTH register */
     reg_value = ENET_MAC_FCTL;
     reg_value &= MAC_FCTL_MASK;
-    reg_value |= MAC_FCTL_PTM(0) |ENET_ZERO_QUANTA_PAUSE_DISABLE \
-                |ENET_PAUSETIME_MINUS4 |ENET_UNIQUE_PAUSEDETECT \
-                |ENET_RX_FLOWCONTROL_DISABLE |ENET_TX_FLOWCONTROL_DISABLE;
+    reg_value |= MAC_FCTL_PTM(0) | ENET_ZERO_QUANTA_PAUSE_DISABLE \
+                 | ENET_PAUSETIME_MINUS4 | ENET_UNIQUE_PAUSEDETECT \
+                 | ENET_RX_FLOWCONTROL_DISABLE | ENET_TX_FLOWCONTROL_DISABLE;
     ENET_MAC_FCTL = reg_value;
 
     /* configure ENET_MAC_VLT register */
-    ENET_MAC_VLT = ENET_VLANTAGCOMPARISON_16BIT |MAC_VLT_VLTI(0);
+    ENET_MAC_VLT = ENET_VLANTAGCOMPARISON_16BIT | MAC_VLT_VLTI(0);
 
     /* DMA */
     /* configure ENET_DMA_CTL register */
     reg_value = ENET_DMA_CTL;
     reg_value &= DMA_CTL_MASK;
-    reg_value |= ENET_TCPIP_CKSUMERROR_DROP |ENET_RX_MODE_STOREFORWARD \
-                |ENET_FLUSH_RXFRAME_ENABLE |ENET_TX_MODE_STOREFORWARD \
-                |ENET_TX_THRESHOLD_64BYTES |ENET_RX_THRESHOLD_64BYTES \
-                |ENET_SECONDFRAME_OPT_DISABLE;
+    reg_value |= ENET_TCPIP_CKSUMERROR_DROP | ENET_RX_MODE_STOREFORWARD \
+                 | ENET_FLUSH_RXFRAME_ENABLE | ENET_TX_MODE_STOREFORWARD \
+                 | ENET_TX_THRESHOLD_64BYTES | ENET_RX_THRESHOLD_64BYTES \
+                 | ENET_SECONDFRAME_OPT_DISABLE;
     ENET_DMA_CTL = reg_value;
 
     /* configure ENET_DMA_BCTL register */
     reg_value = ENET_DMA_BCTL;
     reg_value &= DMA_BCTL_MASK;
-    reg_value = ENET_ADDRESS_ALIGN_ENABLE |ENET_ARBITRATION_RXTX_2_1 \
-               |ENET_RXDP_32BEAT |ENET_PGBL_32BEAT |ENET_RXTX_DIFFERENT_PGBL \
-               |ENET_FIXED_BURST_ENABLE |ENET_MIXED_BURST_DISABLE \
-               |ENET_NORMAL_DESCRIPTOR;
+    reg_value = ENET_ADDRESS_ALIGN_ENABLE | ENET_ARBITRATION_RXTX_2_1 \
+                | ENET_RXDP_32BEAT | ENET_PGBL_32BEAT | ENET_RXTX_DIFFERENT_PGBL \
+                | ENET_FIXED_BURST_ENABLE | ENET_MIXED_BURST_DISABLE \
+                | ENET_NORMAL_DESCRIPTOR;
     ENET_DMA_BCTL = reg_value;
 }
 
@@ -3502,9 +3502,9 @@ static void enet_default_init(void)
 */
 static void enet_delay(uint32_t ncount)
 {
-    __IO uint32_t delay_time = 0U; 
-    
-    for(delay_time = ncount; delay_time != 0U; delay_time--){
+    __IO uint32_t delay_time = 0U;
+
+    for(delay_time = ncount; delay_time != 0U; delay_time--) {
     }
 }
 #endif /* USE_DELAY */

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_exmc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_exmc.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_exmc.c
     \brief   EXMC driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -112,9 +113,6 @@ OF SUCH DAMAGE.
 
 #define SDARI_ARINTV_OFFSET               ((uint32_t)1U)
 
-#define SDRSCTL_SSCR_OFFSET               ((uint32_t)1U)
-#define SDRSCTL_SDSC_OFFSET               ((uint32_t)4U)
-
 #define SDSTAT_STA0_OFFSET                ((uint32_t)1U)
 #define SDSTAT_STA1_OFFSET                ((uint32_t)3U)
 
@@ -145,7 +143,7 @@ void exmc_norsram_deinit(uint32_t exmc_norsram_region)
     \param[out] exmc_norsram_init_struct: the initialized struct exmc_norsram_parameter_struct pointer
     \retval     none
 */
-void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct)
+void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct *exmc_norsram_init_struct)
 {
     /* configure the structure with default values */
     exmc_norsram_init_struct->norsram_region = EXMC_BANK0_NORSRAM_REGION0;
@@ -184,7 +182,7 @@ void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct* exmc_norsram_i
     \param[in]  exmc_norsram_parameter_struct: configure the EXMC NOR/SRAM parameter
                   norsram_region: EXMC_BANK0_NORSRAM_REGIONx, x=0..3
                   write_mode: EXMC_ASYN_WRITE, EXMC_SYN_WRITE
-                  extended_mode: ENABLE or DISABLE 
+                  extended_mode: ENABLE or DISABLE
                   asyn_wait: ENABLE or DISABLE
                   nwait_signal: ENABLE or DISABLE
                   memory_write: ENABLE or DISABLE
@@ -198,8 +196,8 @@ void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct* exmc_norsram_i
                   read_write_timing: struct exmc_norsram_timing_parameter_struct set the time
                     asyn_access_mode: EXMC_ACCESS_MODE_A, EXMC_ACCESS_MODE_B, EXMC_ACCESS_MODE_C, EXMC_ACCESS_MODE_D
                     syn_data_latency: EXMC_DATALAT_x_CLK, x=2..17
-                    syn_clk_division: EXMC_SYN_CLOCK_RATIO_x_CLK, x=2..16
-                    bus_latency: 0x0U~0xFU 
+                    syn_clk_division: EXMC_SYN_CLOCK_RATIO_DISABLE, EXMC_SYN_CLOCK_RATIO_x_CLK, x=2..16
+                    bus_latency: 0x0U~0xFU
                     asyn_data_setuptime: 0x01U~0xFFU
                     asyn_address_holdtime: 0x1U~0xFU
                     asyn_address_setuptime: 0x0U~0xFU
@@ -207,60 +205,60 @@ void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct* exmc_norsram_i
                     asyn_access_mode: EXMC_ACCESS_MODE_A, EXMC_ACCESS_MODE_B, EXMC_ACCESS_MODE_C, EXMC_ACCESS_MODE_D
                     syn_data_latency: EXMC_DATALAT_x_CLK, x=2..17
                     syn_clk_division: EXMC_SYN_CLOCK_RATIO_x_CLK, x=2..16
-                    bus_latency: 0x0U~0xFU 
+                    bus_latency: 0x0U~0xFU
                     asyn_data_setuptime: 0x01U~0xFFU
                     asyn_address_holdtime: 0x1U~0xFU
                     asyn_address_setuptime: 0x0U~0xFU
     \param[out] none
     \retval     none
 */
-void exmc_norsram_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct)
+void exmc_norsram_init(exmc_norsram_parameter_struct *exmc_norsram_init_struct)
 {
-    uint32_t snctl = 0x00000000U,sntcfg = 0x00000000U,snwtcfg = 0x00000000U;
+    uint32_t snctl = 0x00000000U, sntcfg = 0x00000000U, snwtcfg = 0x00000000U;
 
     /* get the register value */
     snctl = EXMC_SNCTL(exmc_norsram_init_struct->norsram_region);
 
     /* clear relative bits */
-    snctl &= ((uint32_t)~(EXMC_SNCTL_NREN | EXMC_SNCTL_NRTP | EXMC_SNCTL_NRW | EXMC_SNCTL_SBRSTEN | 
-                          EXMC_SNCTL_NRWTPOL | EXMC_SNCTL_WRAPEN | EXMC_SNCTL_NRWTCFG | EXMC_SNCTL_WREN | 
-                          EXMC_SNCTL_NRWTEN | EXMC_SNCTL_EXMODEN | EXMC_SNCTL_ASYNCWAIT | EXMC_SNCTL_SYNCWR | 
-                          EXMC_SNCTL_NRMUX ));
+    snctl &= ((uint32_t)~(EXMC_SNCTL_NREN | EXMC_SNCTL_NRTP | EXMC_SNCTL_NRW | EXMC_SNCTL_SBRSTEN |
+                          EXMC_SNCTL_NRWTPOL | EXMC_SNCTL_WRAPEN | EXMC_SNCTL_NRWTCFG | EXMC_SNCTL_WEN |
+                          EXMC_SNCTL_NRWTEN | EXMC_SNCTL_EXMODEN | EXMC_SNCTL_ASYNCWTEN | EXMC_SNCTL_SYNCWR |
+                          EXMC_SNCTL_NRMUX));
 
     snctl |= (uint32_t)(exmc_norsram_init_struct->address_data_mux << SNCTL_NRMUX_OFFSET) |
-                        exmc_norsram_init_struct->memory_type |
-                        exmc_norsram_init_struct->databus_width |
-                       (exmc_norsram_init_struct->burst_mode << SNCTL_SBRSTEN_OFFSET) |
-                        exmc_norsram_init_struct->nwait_polarity |
-                       (exmc_norsram_init_struct->wrap_burst_mode << SNCTL_WRAPEN_OFFSET) |
-                        exmc_norsram_init_struct->nwait_config |
-                       (exmc_norsram_init_struct->memory_write << SNCTL_WREN_OFFSET) |
-                       (exmc_norsram_init_struct->nwait_signal << SNCTL_NRWTEN_OFFSET) |
-                       (exmc_norsram_init_struct->extended_mode << SNCTL_EXMODEN_OFFSET) |
-                       (exmc_norsram_init_struct->asyn_wait << SNCTL_ASYNCWAIT_OFFSET) |
-                        exmc_norsram_init_struct->write_mode;
+             exmc_norsram_init_struct->memory_type |
+             exmc_norsram_init_struct->databus_width |
+             (exmc_norsram_init_struct->burst_mode << SNCTL_SBRSTEN_OFFSET) |
+             exmc_norsram_init_struct->nwait_polarity |
+             (exmc_norsram_init_struct->wrap_burst_mode << SNCTL_WRAPEN_OFFSET) |
+             exmc_norsram_init_struct->nwait_config |
+             (exmc_norsram_init_struct->memory_write << SNCTL_WREN_OFFSET) |
+             (exmc_norsram_init_struct->nwait_signal << SNCTL_NRWTEN_OFFSET) |
+             (exmc_norsram_init_struct->extended_mode << SNCTL_EXMODEN_OFFSET) |
+             (exmc_norsram_init_struct->asyn_wait << SNCTL_ASYNCWAIT_OFFSET) |
+             exmc_norsram_init_struct->write_mode;
 
     sntcfg = (uint32_t)exmc_norsram_init_struct->read_write_timing->asyn_address_setuptime |
-                      (exmc_norsram_init_struct->read_write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET) |
-                      (exmc_norsram_init_struct->read_write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
-                      (exmc_norsram_init_struct->read_write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
-                       exmc_norsram_init_struct->read_write_timing->syn_clk_division |
-                       exmc_norsram_init_struct->read_write_timing->syn_data_latency |
-                       exmc_norsram_init_struct->read_write_timing->asyn_access_mode;
+             (exmc_norsram_init_struct->read_write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET) |
+             (exmc_norsram_init_struct->read_write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
+             (exmc_norsram_init_struct->read_write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
+             exmc_norsram_init_struct->read_write_timing->syn_clk_division |
+             exmc_norsram_init_struct->read_write_timing->syn_data_latency |
+             exmc_norsram_init_struct->read_write_timing->asyn_access_mode;
 
     /* nor flash access enable */
-    if(EXMC_MEMORY_TYPE_NOR == exmc_norsram_init_struct->memory_type){
+    if(EXMC_MEMORY_TYPE_NOR == exmc_norsram_init_struct->memory_type) {
         snctl |= (uint32_t)EXMC_SNCTL_NREN;
     }
 
     /* extended mode configure */
-    if(ENABLE == exmc_norsram_init_struct->extended_mode){
+    if(ENABLE == exmc_norsram_init_struct->extended_mode) {
         snwtcfg = (uint32_t)exmc_norsram_init_struct->write_timing->asyn_address_setuptime |
-                           (exmc_norsram_init_struct->write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET )|
-                           (exmc_norsram_init_struct->write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
-                           (exmc_norsram_init_struct->write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
-                            exmc_norsram_init_struct->write_timing->asyn_access_mode;
-    }else{
+                  (exmc_norsram_init_struct->write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET) |
+                  (exmc_norsram_init_struct->write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
+                  (exmc_norsram_init_struct->write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
+                  exmc_norsram_init_struct->write_timing->asyn_access_mode;
+    } else {
         snwtcfg = BANK0_SNWTCFG_RESET;
     }
 
@@ -272,7 +270,7 @@ void exmc_norsram_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct)
 
 /*!
     \brief    enable EXMC NOR/PSRAM bank region
-    \param[in]  exmc_norsram_region: specifie the region of NOR/PSRAM bank
+    \param[in]  exmc_norsram_region: specify the region of NOR/PSRAM bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
     \param[out] none
@@ -285,7 +283,7 @@ void exmc_norsram_enable(uint32_t exmc_norsram_region)
 
 /*!
     \brief    disable EXMC NOR/PSRAM bank region
-    \param[in]  exmc_norsram_region: specifie the region of NOR/PSRAM Bank
+    \param[in]  exmc_norsram_region: specify the region of NOR/PSRAM Bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
     \param[out] none
@@ -319,7 +317,7 @@ void exmc_nand_deinit(uint32_t exmc_nand_bank)
     \param[out] the initialized struct exmc_norsram_parameter_struct pointer
     \retval     none
 */
-void exmc_nand_struct_para_init(exmc_nand_parameter_struct* exmc_nand_init_struct)
+void exmc_nand_struct_para_init(exmc_nand_parameter_struct *exmc_nand_init_struct)
 {
     /* configure the structure with default values */
     exmc_nand_init_struct->nand_bank = EXMC_BANK1_NAND;
@@ -362,27 +360,27 @@ void exmc_nand_struct_para_init(exmc_nand_parameter_struct* exmc_nand_init_struc
     \param[out] none
     \retval     none
 */
-void exmc_nand_init(exmc_nand_parameter_struct* exmc_nand_init_struct)
+void exmc_nand_init(exmc_nand_parameter_struct *exmc_nand_init_struct)
 {
     uint32_t npctl = 0x00000000U, npctcfg = 0x00000000U, npatcfg = 0x00000000U;
-    
-    npctl = (uint32_t)(exmc_nand_init_struct->wait_feature << NPCTL_NDWTEN_OFFSET)|
-                       EXMC_NPCTL_NDTP |
-                       exmc_nand_init_struct->databus_width |
-                      (exmc_nand_init_struct->ecc_logic << NPCTL_ECCEN_OFFSET)|
-                       exmc_nand_init_struct->ecc_size |
-                       exmc_nand_init_struct->ctr_latency |
-                       exmc_nand_init_struct->atr_latency;
 
-    npctcfg = (uint32_t)((exmc_nand_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET ) |
-                        (((exmc_nand_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT ) |
-                        ((exmc_nand_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD ) |
-                        (((exmc_nand_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ );
+    npctl = (uint32_t)(exmc_nand_init_struct->wait_feature << NPCTL_NDWTEN_OFFSET) |
+            EXMC_NPCTL_NDTP |
+            exmc_nand_init_struct->databus_width |
+            (exmc_nand_init_struct->ecc_logic << NPCTL_ECCEN_OFFSET) |
+            exmc_nand_init_struct->ecc_size |
+            exmc_nand_init_struct->ctr_latency |
+            exmc_nand_init_struct->atr_latency;
 
-    npatcfg = (uint32_t)((exmc_nand_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET ) |
-                        (((exmc_nand_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT ) |
-                        ((exmc_nand_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD ) |
-                        ((exmc_nand_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ );
+    npctcfg = (uint32_t)((exmc_nand_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET) |
+              (((exmc_nand_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT) |
+              ((exmc_nand_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD) |
+              (((exmc_nand_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ);
+
+    npatcfg = (uint32_t)((exmc_nand_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET) |
+              (((exmc_nand_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT) |
+              ((exmc_nand_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD) |
+              ((exmc_nand_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ);
 
     /* EXMC_BANK1_NAND or EXMC_BANK2_NAND initialize */
     EXMC_NPCTL(exmc_nand_init_struct->nand_bank) = npctl;
@@ -392,7 +390,7 @@ void exmc_nand_init(exmc_nand_parameter_struct* exmc_nand_init_struct)
 
 /*!
     \brief    enable NAND bank
-    \param[in]  exmc_nand_bank: specifie the NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANKx_NAND(x=1,2)
     \param[out] none
@@ -405,7 +403,7 @@ void exmc_nand_enable(uint32_t exmc_nand_bank)
 
 /*!
     \brief    disable NAND bank
-    \param[in]  exmc_nand_bank: specifie the NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANKx_NAND(x=1,2)
     \param[out] none
@@ -438,7 +436,7 @@ void exmc_pccard_deinit(void)
     \param[out] the initialized struct exmc_pccard_parameter_struct pointer
     \retval     none
 */
-void exmc_pccard_struct_para_init(exmc_pccard_parameter_struct* exmc_pccard_init_struct)
+void exmc_pccard_struct_para_init(exmc_pccard_parameter_struct *exmc_pccard_init_struct)
 {
     /* configure the structure with default values */
     exmc_pccard_init_struct->wait_feature = DISABLE;
@@ -482,31 +480,31 @@ void exmc_pccard_struct_para_init(exmc_pccard_parameter_struct* exmc_pccard_init
     \param[out] none
     \retval     none
 */
-void exmc_pccard_init(exmc_pccard_parameter_struct* exmc_pccard_init_struct)
+void exmc_pccard_init(exmc_pccard_parameter_struct *exmc_pccard_init_struct)
 {
     /* configure the EXMC bank3 PC card control register */
     EXMC_NPCTL3 = (uint32_t)(exmc_pccard_init_struct->wait_feature << NPCTL_NDWTEN_OFFSET) |
-                                            EXMC_NAND_DATABUS_WIDTH_16B |  
-                                            exmc_pccard_init_struct->ctr_latency |
-                                            exmc_pccard_init_struct->atr_latency ;
-            
+                  EXMC_NAND_DATABUS_WIDTH_16B |
+                  exmc_pccard_init_struct->ctr_latency |
+                  exmc_pccard_init_struct->atr_latency ;
+
     /* configure the EXMC bank3 PC card common space timing configuration register */
-    EXMC_NPCTCFG3 = (uint32_t)((exmc_pccard_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET ) |
-                                            (((exmc_pccard_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT ) |
-                                            ((exmc_pccard_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD ) |
-                                            (((exmc_pccard_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ );
+    EXMC_NPCTCFG3 = (uint32_t)((exmc_pccard_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET) |
+                    (((exmc_pccard_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT) |
+                    ((exmc_pccard_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD) |
+                    (((exmc_pccard_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ);
 
     /* configure the EXMC bank3 PC card attribute space timing configuration register */
-    EXMC_NPATCFG3 = (uint32_t)((exmc_pccard_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET ) |
-                                            (((exmc_pccard_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT ) |
-                                            ((exmc_pccard_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD ) |
-                                            ((exmc_pccard_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ);
+    EXMC_NPATCFG3 = (uint32_t)((exmc_pccard_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET) |
+                    (((exmc_pccard_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT) |
+                    ((exmc_pccard_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD) |
+                    ((exmc_pccard_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ);
 
     /* configure the EXMC bank3 PC card io space timing configuration register */
-    EXMC_PIOTCFG3 = (uint32_t)((exmc_pccard_init_struct->io_space_timing->setuptime - 1U) & EXMC_PIOTCFG3_IOSET ) |
-                                            (((exmc_pccard_init_struct->io_space_timing->waittime - 1U) << PIOTCFG_IOWAIT_OFFSET) & EXMC_PIOTCFG3_IOWAIT ) |
-                                            ((exmc_pccard_init_struct->io_space_timing->holdtime << PIOTCFG_IOHLD_OFFSET) & EXMC_PIOTCFG3_IOHLD ) |
-                                            ((exmc_pccard_init_struct->io_space_timing->databus_hiztime << PIOTCFG_IOHIZ_OFFSET) & EXMC_PIOTCFG3_IOHIZ );
+    EXMC_PIOTCFG3 = (uint32_t)((exmc_pccard_init_struct->io_space_timing->setuptime - 1U) & EXMC_PIOTCFG3_IOSET) |
+                    (((exmc_pccard_init_struct->io_space_timing->waittime - 1U) << PIOTCFG_IOWAIT_OFFSET) & EXMC_PIOTCFG3_IOWAIT) |
+                    ((exmc_pccard_init_struct->io_space_timing->holdtime << PIOTCFG_IOHLD_OFFSET) & EXMC_PIOTCFG3_IOHLD) |
+                    ((exmc_pccard_init_struct->io_space_timing->databus_hiztime << PIOTCFG_IOHIZ_OFFSET) & EXMC_PIOTCFG3_IOHIZ);
 }
 
 /*!
@@ -528,7 +526,7 @@ void exmc_pccard_enable(void)
 */
 void exmc_pccard_disable(void)
 {
-   EXMC_NPCTL3 &= ~EXMC_NPCTL_NDBKEN;
+    EXMC_NPCTL3 &= ~EXMC_NPCTL_NDBKEN;
 }
 
 /*!
@@ -556,7 +554,7 @@ void exmc_sdram_deinit(uint32_t exmc_sdram_device)
     \param[out] the initialized struct exmc_pccard_parameter_struct pointer
     \retval     none
 */
-void exmc_sdram_struct_para_init(exmc_sdram_parameter_struct* exmc_sdram_init_struct)
+void exmc_sdram_struct_para_init(exmc_sdram_parameter_struct *exmc_sdram_init_struct)
 {
     /* configure the structure with default values */
     exmc_sdram_init_struct->sdram_device = EXMC_SDRAM_DEVICE0;
@@ -603,62 +601,62 @@ void exmc_sdram_struct_para_init(exmc_sdram_parameter_struct* exmc_sdram_init_st
     \param[out] none
     \retval     none
 */
-void exmc_sdram_init(exmc_sdram_parameter_struct* exmc_sdram_init_struct)
+void exmc_sdram_init(exmc_sdram_parameter_struct *exmc_sdram_init_struct)
 {
     uint32_t sdctl0, sdctl1, sdtcfg0, sdtcfg1;
 
-    /* configuration EXMC_SDCTL0 or EXMC_SDCTL1 */ 
-    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_init_struct->sdram_device){
+    /* configuration EXMC_SDCTL0 or EXMC_SDCTL1 */
+    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_init_struct->sdram_device) {
         /* configuration EXMC_SDCTL0 */
         EXMC_SDCTL(EXMC_SDRAM_DEVICE0)  = (uint32_t)exmc_sdram_init_struct->column_address_width |
-                                                    exmc_sdram_init_struct->row_address_width |
-                                                    exmc_sdram_init_struct->data_width |
-                                                    exmc_sdram_init_struct->internal_bank_number |
-                                                    exmc_sdram_init_struct->cas_latency |
-                                                   (exmc_sdram_init_struct->write_protection << SDCTL_WPEN_OFFSET)|
-                                                    exmc_sdram_init_struct->sdclock_config |
-                                                   (exmc_sdram_init_struct->brust_read_switch << SDCTL_BRSTRD_OFFSET)| 
-                                                    exmc_sdram_init_struct->pipeline_read_delay;
-        
+                                          exmc_sdram_init_struct->row_address_width |
+                                          exmc_sdram_init_struct->data_width |
+                                          exmc_sdram_init_struct->internal_bank_number |
+                                          exmc_sdram_init_struct->cas_latency |
+                                          (exmc_sdram_init_struct->write_protection << SDCTL_WPEN_OFFSET) |
+                                          exmc_sdram_init_struct->sdclock_config |
+                                          (exmc_sdram_init_struct->brust_read_switch << SDCTL_BRSTRD_OFFSET) |
+                                          exmc_sdram_init_struct->pipeline_read_delay;
+
         /* configuration EXMC_SDTCFG0 */
-        EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) = (uint32_t)((exmc_sdram_init_struct->timing->load_mode_register_delay)-1U) |
-                                                   (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay)-1U) << SDTCFG_XSRD_OFFSET) |
-                                                   (((exmc_sdram_init_struct->timing->row_address_select_delay)-1U) << SDTCFG_RASD_OFFSET) |
-                                                   (((exmc_sdram_init_struct->timing->auto_refresh_delay)-1U) << SDTCFG_ARFD_OFFSET) |
-                                                   (((exmc_sdram_init_struct->timing->write_recovery_delay)-1U) << SDTCFG_WRD_OFFSET) |
-                                                   (((exmc_sdram_init_struct->timing->row_precharge_delay)-1U) << SDTCFG_RPD_OFFSET) |
-                                                   (((exmc_sdram_init_struct->timing->row_to_column_delay)-1U) << SDTCFG_RCD_OFFSET);
-    }else{
+        EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) = (uint32_t)((exmc_sdram_init_struct->timing->load_mode_register_delay) - 1U) |
+                                          (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay) - 1U) << SDTCFG_XSRD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_address_select_delay) - 1U) << SDTCFG_RASD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->auto_refresh_delay) - 1U) << SDTCFG_ARFD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->write_recovery_delay) - 1U) << SDTCFG_WRD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_precharge_delay) - 1U) << SDTCFG_RPD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_to_column_delay) - 1U) << SDTCFG_RCD_OFFSET);
+    } else {
         /* configuration EXMC_SDCTL0 and EXMC_SDCTL1 */
         /* some bits in the EXMC_SDCTL1 register are reserved */
-        sdctl0 = EXMC_SDCTL(EXMC_SDRAM_DEVICE0) & (~( EXMC_SDCTL_PIPED | EXMC_SDCTL_BRSTRD | EXMC_SDCTL_SDCLK ));
-        
+        sdctl0 = EXMC_SDCTL(EXMC_SDRAM_DEVICE0) & (~(EXMC_SDCTL_PIPED | EXMC_SDCTL_BRSTRD | EXMC_SDCTL_SDCLK));
+
         sdctl0 |= (uint32_t)exmc_sdram_init_struct->sdclock_config |
-                            exmc_sdram_init_struct->brust_read_switch | 
-                            exmc_sdram_init_struct->pipeline_read_delay;
-        
+                  exmc_sdram_init_struct->brust_read_switch |
+                  exmc_sdram_init_struct->pipeline_read_delay;
+
         sdctl1 = (uint32_t)exmc_sdram_init_struct->column_address_width |
-                           exmc_sdram_init_struct->row_address_width |
-                           exmc_sdram_init_struct->data_width |
-                           exmc_sdram_init_struct->internal_bank_number |
-                           exmc_sdram_init_struct->cas_latency |
-                           exmc_sdram_init_struct->write_protection ;
+                 exmc_sdram_init_struct->row_address_width |
+                 exmc_sdram_init_struct->data_width |
+                 exmc_sdram_init_struct->internal_bank_number |
+                 exmc_sdram_init_struct->cas_latency |
+                 exmc_sdram_init_struct->write_protection ;
 
         EXMC_SDCTL(EXMC_SDRAM_DEVICE0) = sdctl0;
         EXMC_SDCTL(EXMC_SDRAM_DEVICE1) = sdctl1;
-        
+
         /* configuration EXMC_SDTCFG0 and EXMC_SDTCFG1 */
         /* some bits in the EXMC_SDTCFG1 register are reserved */
         sdtcfg0 = EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) & (~(EXMC_SDTCFG_RPD | EXMC_SDTCFG_WRD | EXMC_SDTCFG_ARFD));
 
-        sdtcfg0 |= (uint32_t)(((exmc_sdram_init_struct->timing->auto_refresh_delay)-1U) << SDTCFG_ARFD_OFFSET) |
-                             (((exmc_sdram_init_struct->timing->row_precharge_delay)-1U) << SDTCFG_RPD_OFFSET) |
-                             (((exmc_sdram_init_struct->timing->write_recovery_delay)-1U) << SDTCFG_WRD_OFFSET);
+        sdtcfg0 |= (uint32_t)(((exmc_sdram_init_struct->timing->auto_refresh_delay) - 1U) << SDTCFG_ARFD_OFFSET) |
+                   (((exmc_sdram_init_struct->timing->row_precharge_delay) - 1U) << SDTCFG_RPD_OFFSET) |
+                   (((exmc_sdram_init_struct->timing->write_recovery_delay) - 1U) << SDTCFG_WRD_OFFSET);
 
-        sdtcfg1 = (uint32_t)((exmc_sdram_init_struct->timing->load_mode_register_delay)-1U) |
-                           (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay)-1U) << SDTCFG_XSRD_OFFSET) |
-                           (((exmc_sdram_init_struct->timing->row_address_select_delay)-1U) << SDTCFG_RASD_OFFSET) |
-                           (((exmc_sdram_init_struct->timing->row_to_column_delay)-1U) << SDTCFG_RCD_OFFSET);    
+        sdtcfg1 = (uint32_t)((exmc_sdram_init_struct->timing->load_mode_register_delay) - 1U) |
+                  (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay) - 1U) << SDTCFG_XSRD_OFFSET) |
+                  (((exmc_sdram_init_struct->timing->row_address_select_delay) - 1U) << SDTCFG_RASD_OFFSET) |
+                  (((exmc_sdram_init_struct->timing->row_to_column_delay) - 1U) << SDTCFG_RCD_OFFSET);
 
         EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) = sdtcfg0;
         EXMC_SDTCFG(EXMC_SDRAM_DEVICE1) = sdtcfg1;
@@ -687,7 +685,7 @@ void exmc_sqpipsram_deinit(void)
     \param[out] none
     \retval     none
 */
-void exmc_sqpipsram_struct_para_init(exmc_sqpipsram_parameter_struct* exmc_sqpipsram_init_struct)
+void exmc_sqpipsram_struct_para_init(exmc_sqpipsram_parameter_struct *exmc_sqpipsram_init_struct)
 {
     /* configure the structure with default values */
     exmc_sqpipsram_init_struct->sample_polarity = EXMC_SQPIPSRAM_SAMPLE_RISING_EDGE;
@@ -706,18 +704,18 @@ void exmc_sqpipsram_struct_para_init(exmc_sqpipsram_parameter_struct* exmc_sqpip
     \param[out] none
     \retval     none
 */
-void exmc_sqpipsram_init(exmc_sqpipsram_parameter_struct* exmc_sqpipsram_init_struct)
+void exmc_sqpipsram_init(exmc_sqpipsram_parameter_struct *exmc_sqpipsram_init_struct)
 {
     /* initialize SQPI controller */
     EXMC_SINIT = (uint32_t)exmc_sqpipsram_init_struct->sample_polarity |
-                           exmc_sqpipsram_init_struct->id_length |
-                           exmc_sqpipsram_init_struct->address_bits |
-                           exmc_sqpipsram_init_struct->command_bits;
+                 exmc_sqpipsram_init_struct->id_length |
+                 exmc_sqpipsram_init_struct->address_bits |
+                 exmc_sqpipsram_init_struct->command_bits;
 }
 
 /*!
     \brief    configure consecutive clock
-    \param[in]  clock_mode: specifie when the clock is generated
+    \param[in]  clock_mode: specify when the clock is generated
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_CLOCK_SYN_MODE: the clock is generated only during synchronous access
       \arg        EXMC_CLOCK_UNCONDITIONALLY: the clock is generated unconditionally
@@ -726,9 +724,9 @@ void exmc_sqpipsram_init(exmc_sqpipsram_parameter_struct* exmc_sqpipsram_init_st
 */
 void exmc_norsram_consecutive_clock_config(uint32_t clock_mode)
 {
-    if (EXMC_CLOCK_UNCONDITIONALLY == clock_mode){
+    if(EXMC_CLOCK_UNCONDITIONALLY == clock_mode) {
         EXMC_SNCTL(EXMC_BANK0_NORSRAM_REGION0) |= EXMC_CLOCK_UNCONDITIONALLY;
-    }else{
+    } else {
         EXMC_SNCTL(EXMC_BANK0_NORSRAM_REGION0) &= ~EXMC_CLOCK_UNCONDITIONALLY;
     }
 }
@@ -759,7 +757,7 @@ void exmc_norsram_page_size_config(uint32_t exmc_norsram_region, uint32_t page_s
 
 /*!
     \brief    enable or disable the EXMC NAND ECC function
-    \param[in]  exmc_nand_bank: specifie the NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANKx_NAND(x=1,2)
     \param[in]  newvalue: ENABLE or DISABLE
@@ -768,10 +766,10 @@ void exmc_norsram_page_size_config(uint32_t exmc_norsram_region, uint32_t page_s
 */
 void exmc_nand_ecc_config(uint32_t exmc_nand_bank, ControlStatus newvalue)
 {
-    if (ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         /* enable the selected NAND bank ECC function */
         EXMC_NPCTL(exmc_nand_bank) |= EXMC_NPCTL_ECCEN;
-    }else{
+    } else {
         /* disable the selected NAND bank ECC function */
         EXMC_NPCTL(exmc_nand_bank) &= ~EXMC_NPCTL_ECCEN;
     }
@@ -779,7 +777,7 @@ void exmc_nand_ecc_config(uint32_t exmc_nand_bank, ControlStatus newvalue)
 
 /*!
     \brief    get the EXMC ECC value
-    \param[in]  exmc_nand_bank: specifie the NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANKx_NAND(x=1,2)
     \param[out] none
@@ -798,9 +796,9 @@ uint32_t exmc_ecc_get(uint32_t exmc_nand_bank)
 */
 void exmc_sdram_readsample_enable(ControlStatus newvalue)
 {
-    if (ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         EXMC_SDRSCTL |=  EXMC_SDRSCTL_RSEN;
-    }else{
+    } else {
         EXMC_SDRSCTL &= (uint32_t)(~EXMC_SDRSCTL_RSEN);
     }
 }
@@ -819,34 +817,33 @@ void exmc_sdram_readsample_enable(ControlStatus newvalue)
 void exmc_sdram_readsample_config(uint32_t delay_cell, uint32_t extra_hclk)
 {
     uint32_t sdrsctl = 0U;
-    
+
     /* reset the bits */
     sdrsctl = EXMC_SDRSCTL & (~(EXMC_SDRSCTL_SDSC | EXMC_SDRSCTL_SSCR));
     /* set the bits */
-    sdrsctl |= (uint32_t)(delay_cell  & EXMC_SDRSCTL_SDSC) |
-                        ((extra_hclk << SDRSCTL_SSCR_OFFSET) & EXMC_SDRSCTL_SSCR);
+    sdrsctl |= (uint32_t)(delay_cell | extra_hclk);
     EXMC_SDRSCTL = sdrsctl;
 }
 
 /*!
     \brief    configure the SDRAM memory command
-    \param[in]  exmc_sdram_command_init_struct: initialize EXMC SDRAM command 
+    \param[in]  exmc_sdram_command_init_struct: initialize EXMC SDRAM command
                   mode_register_content:
                   auto_refresh_number: EXMC_SDRAM_AUTO_REFLESH_x_SDCLK, x=1..15
-                  bank_select: EXMC_SDRAM_DEVICE0_SELECT, EXMC_SDRAM_DEVICE1_SELECT, EXMC_SDRAM_DEVICE0_1_SELECT 
-                  command: EXMC_SDRAM_NORMAL_OPERATION, EXMC_SDRAM_CLOCK_ENABLE, EXMC_SDRAM_PRECHARGE_ALL, 
-                           EXMC_SDRAM_AUTO_REFRESH, EXMC_SDRAM_LOAD_MODE_REGISTER, EXMC_SDRAM_SELF_REFRESH, 
-                           EXMC_SDRAM_POWERDOWN_ENTRY 
+                  bank_select: EXMC_SDRAM_DEVICE0_SELECT, EXMC_SDRAM_DEVICE1_SELECT, EXMC_SDRAM_DEVICE0_1_SELECT
+                  command: EXMC_SDRAM_NORMAL_OPERATION, EXMC_SDRAM_CLOCK_ENABLE, EXMC_SDRAM_PRECHARGE_ALL,
+                           EXMC_SDRAM_AUTO_REFRESH, EXMC_SDRAM_LOAD_MODE_REGISTER, EXMC_SDRAM_SELF_REFRESH,
+                           EXMC_SDRAM_POWERDOWN_ENTRY
     \param[out] none
     \retval     none
 */
-void exmc_sdram_command_config(exmc_sdram_command_parameter_struct* exmc_sdram_command_init_struct)
+void exmc_sdram_command_config(exmc_sdram_command_parameter_struct *exmc_sdram_command_init_struct)
 {
     /* configure command register */
     EXMC_SDCMD = (uint32_t)((exmc_sdram_command_init_struct->command) |
-                           (exmc_sdram_command_init_struct->bank_select) |
-                           ((exmc_sdram_command_init_struct->auto_refresh_number)) |
-                           ((exmc_sdram_command_init_struct->mode_register_content)<<SDCMD_MRC_OFFSET) );
+                            (exmc_sdram_command_init_struct->bank_select) |
+                            ((exmc_sdram_command_init_struct->auto_refresh_number)) |
+                            ((exmc_sdram_command_init_struct->mode_register_content) << SDCMD_MRC_OFFSET));
 }
 
 /*!
@@ -877,7 +874,7 @@ void exmc_sdram_autorefresh_number_set(uint32_t exmc_number)
 
 /*!
     \brief    config the write protection function
-    \param[in]  exmc_sdram_device: specifie the SDRAM device
+    \param[in]  exmc_sdram_device: specify the SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_SDRAM_DEVICEx(x=0,1)
     \param[in]  newvalue: ENABLE or DISABLE
@@ -886,9 +883,9 @@ void exmc_sdram_autorefresh_number_set(uint32_t exmc_number)
 */
 void exmc_sdram_write_protection_config(uint32_t exmc_sdram_device, ControlStatus newvalue)
 {
-    if (ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         EXMC_SDCTL(exmc_sdram_device) |= (uint32_t)EXMC_SDCTL_WPEN;
-    }else{
+    } else {
         EXMC_SDCTL(exmc_sdram_device) &= ~((uint32_t)EXMC_SDCTL_WPEN);
     }
 
@@ -896,7 +893,7 @@ void exmc_sdram_write_protection_config(uint32_t exmc_sdram_device, ControlStatu
 
 /*!
     \brief    get the status of SDRAM device0 or device1
-    \param[in]  exmc_sdram_device: specifie the SDRAM device
+    \param[in]  exmc_sdram_device: specify the SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_SDRAM_DEVICEx(x=0,1)
     \param[out] none
@@ -906,9 +903,9 @@ uint32_t exmc_sdram_bankstatus_get(uint32_t exmc_sdram_device)
 {
     uint32_t sdstat = 0U;
 
-    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_device){
+    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_device) {
         sdstat = ((uint32_t)(EXMC_SDSTAT & EXMC_SDSDAT_STA0) >> SDSTAT_STA0_OFFSET);
-    }else{
+    } else {
         sdstat = ((uint32_t)(EXMC_SDSTAT & EXMC_SDSDAT_STA1) >> SDSTAT_STA1_OFFSET);
     }
 
@@ -928,13 +925,13 @@ uint32_t exmc_sdram_bankstatus_get(uint32_t exmc_sdram_device)
     \param[out] none
     \retval     none
 */
-void exmc_sqpipsram_read_command_set(uint32_t read_command_mode,uint32_t read_wait_cycle, uint32_t read_command_code)
+void exmc_sqpipsram_read_command_set(uint32_t read_command_mode, uint32_t read_wait_cycle, uint32_t read_command_code)
 {
     uint32_t srcmd;
-    
+
     srcmd = (uint32_t) read_command_mode |
-                     ((read_wait_cycle << SRCMD_RWAITCYCLE_OFFSET) & EXMC_SRCMD_RWAITCYCLE) |
-                     ((read_command_code & EXMC_SRCMD_RCMD));
+            ((read_wait_cycle << SRCMD_RWAITCYCLE_OFFSET) & EXMC_SRCMD_RWAITCYCLE) |
+            ((read_command_code & EXMC_SRCMD_RCMD));
     EXMC_SRCMD = srcmd;
 }
 
@@ -951,13 +948,13 @@ void exmc_sqpipsram_read_command_set(uint32_t read_command_mode,uint32_t read_wa
     \param[out] none
     \retval     none
 */
-void exmc_sqpipsram_write_command_set(uint32_t write_command_mode,uint32_t write_wait_cycle, uint32_t write_command_code)
+void exmc_sqpipsram_write_command_set(uint32_t write_command_mode, uint32_t write_wait_cycle, uint32_t write_command_code)
 {
     uint32_t swcmd;
-    
+
     swcmd = (uint32_t) write_command_mode |
-                     ((write_wait_cycle << SWCMD_WWAITCYCLE_OFFSET) & EXMC_SWCMD_WWAITCYCLE) |
-                     ((write_command_code & EXMC_SWCMD_WCMD));
+            ((write_wait_cycle << SWCMD_WWAITCYCLE_OFFSET) & EXMC_SWCMD_WWAITCYCLE) |
+            ((write_command_code & EXMC_SWCMD_WCMD));
     EXMC_SWCMD = swcmd;
 }
 
@@ -1017,18 +1014,18 @@ uint32_t exmc_sqpipsram_high_id_get(void)
 FlagStatus exmc_sqpipsram_send_command_state_get(uint32_t send_command_flag)
 {
     uint32_t flag = 0x00000000U;
-    
-    if(EXMC_SEND_COMMAND_FLAG_RDID == send_command_flag){
+
+    if(EXMC_SEND_COMMAND_FLAG_RDID == send_command_flag) {
         flag = EXMC_SRCMD;
-    }else if(EXMC_SEND_COMMAND_FLAG_SC == send_command_flag){
+    } else if(EXMC_SEND_COMMAND_FLAG_SC == send_command_flag) {
         flag = EXMC_SWCMD;
-    }else{
+    } else {
     }
-    
-    if (flag & send_command_flag){
+
+    if(flag & send_command_flag) {
         /* flag is set */
         return SET;
-    }else{
+    } else {
         /* flag is reset */
         return RESET;
     }
@@ -1036,14 +1033,14 @@ FlagStatus exmc_sqpipsram_send_command_state_get(uint32_t send_command_flag)
 
 /*!
     \brief    enable EXMC interrupt
-    \param[in]  exmc_bank: specifies the NAND bank,PC card bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank,PC card bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
       \arg        EXMC_BANK3_PCCARD: the PC card bank
       \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
       \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
-    \param[in]  interrupt: specify get which interrupt flag
+    \param[in]  interrupt: specify EXMC interrupt flag
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
       \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
@@ -1054,10 +1051,10 @@ FlagStatus exmc_sqpipsram_send_command_state_get(uint32_t send_command_flag)
 */
 void exmc_interrupt_enable(uint32_t exmc_bank, uint32_t interrupt)
 {
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         EXMC_NPINTEN(exmc_bank) |= interrupt;
-    }else{
+    } else {
         /* SDRAM device0 or device1 */
         EXMC_SDARI |= EXMC_SDARI_REIE;
     }
@@ -1065,14 +1062,14 @@ void exmc_interrupt_enable(uint32_t exmc_bank, uint32_t interrupt)
 
 /*!
     \brief    disable EXMC interrupt
-    \param[in]  exmc_bank: specifies the NAND bank , PC card bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
       \arg        EXMC_BANK3_PCCARD: the PC card bank
       \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
       \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
-    \param[in]  interrupt: specify get which interrupt flag
+    \param[in]  interrupt: specify EXMC interrupt flag
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
       \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
@@ -1083,10 +1080,10 @@ void exmc_interrupt_enable(uint32_t exmc_bank, uint32_t interrupt)
 */
 void exmc_interrupt_disable(uint32_t exmc_bank, uint32_t interrupt)
 {
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         EXMC_NPINTEN(exmc_bank) &= ~interrupt;
-    }else{
+    } else {
         /* SDRAM device0 or device1 */
         EXMC_SDARI &= ~EXMC_SDARI_REIE;
     }
@@ -1094,7 +1091,7 @@ void exmc_interrupt_disable(uint32_t exmc_bank, uint32_t interrupt)
 
 /*!
     \brief    get EXMC flag status
-    \param[in]  exmc_bank: specifies the NAND bank , PC card bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
@@ -1112,22 +1109,22 @@ void exmc_interrupt_disable(uint32_t exmc_bank, uint32_t interrupt)
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
-FlagStatus exmc_flag_get(uint32_t exmc_bank,uint32_t flag)
+FlagStatus exmc_flag_get(uint32_t exmc_bank, uint32_t flag)
 {
     uint32_t status = 0x00000000U;
 
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         status = EXMC_NPINTEN(exmc_bank);
-    }else{
-         /* SDRAM device0 or device1 */
+    } else {
+        /* SDRAM device0 or device1 */
         status = EXMC_SDSTAT;
     }
-    
-    if ((status & flag) != (uint32_t)flag ){
+
+    if((status & flag) != (uint32_t)flag) {
         /* flag is reset */
         return RESET;
-    }else{
+    } else {
         /* flag is set */
         return SET;
     }
@@ -1135,7 +1132,7 @@ FlagStatus exmc_flag_get(uint32_t exmc_bank,uint32_t flag)
 
 /*!
     \brief    clear EXMC flag status
-    \param[in]  exmc_bank: specifie the NAND bank , PCCARD bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank , PCCARD bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
@@ -1155,18 +1152,18 @@ FlagStatus exmc_flag_get(uint32_t exmc_bank,uint32_t flag)
 */
 void exmc_flag_clear(uint32_t exmc_bank, uint32_t flag)
 {
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         EXMC_NPINTEN(exmc_bank) &= ~flag;
-    }else{
+    } else {
         /* SDRAM device0 or device1 */
         EXMC_SDSTAT &= ~flag;
-    } 
+    }
 }
 
 /*!
     \brief    get EXMC interrupt flag
-    \param[in]  exmc_bank: specifies the NAND bank , PC card bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
@@ -1184,24 +1181,24 @@ void exmc_flag_clear(uint32_t exmc_bank, uint32_t flag)
 */
 FlagStatus exmc_interrupt_flag_get(uint32_t exmc_bank, uint32_t interrupt)
 {
-    uint32_t status = 0x00000000U,interrupt_enable = 0x00000000U,interrupt_state = 0x00000000U;
+    uint32_t status = 0x00000000U, interrupt_enable = 0x00000000U, interrupt_state = 0x00000000U;
 
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         status = EXMC_NPINTEN(exmc_bank);
         interrupt_state = (status & (interrupt >> INTEN_INTS_OFFSET));
-    }else{
-         /* SDRAM device0 or device1 */
+    } else {
+        /* SDRAM device0 or device1 */
         status = EXMC_SDARI;
         interrupt_state = (EXMC_SDSTAT & EXMC_SDSDAT_REIF);
     }
 
     interrupt_enable = (status & interrupt);
 
-    if ((interrupt_enable) && (interrupt_state)){
+    if((interrupt_enable) && (interrupt_state)) {
         /* interrupt flag is set */
         return SET;
-    }else{
+    } else {
         /* interrupt flag is reset */
         return RESET;
     }
@@ -1209,7 +1206,7 @@ FlagStatus exmc_interrupt_flag_get(uint32_t exmc_bank, uint32_t interrupt)
 
 /*!
     \brief    clear EXMC interrupt flag
-    \param[in]  exmc_bank: specifies the NAND bank , PC card bank or SDRAM device
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
                 only one parameter can be selected which is shown as below:
       \arg        EXMC_BANK1_NAND: the NAND bank1
       \arg        EXMC_BANK2_NAND: the NAND bank2
@@ -1227,10 +1224,10 @@ FlagStatus exmc_interrupt_flag_get(uint32_t exmc_bank, uint32_t interrupt)
 */
 void exmc_interrupt_flag_clear(uint32_t exmc_bank, uint32_t interrupt)
 {
-    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)){
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
         /* NAND bank1,bank2 or PC card bank3 */
         EXMC_NPINTEN(exmc_bank) &= ~(interrupt >> INTEN_INTS_OFFSET);
-    }else{
+    } else {
         /* SDRAM device0 or device1 */
         EXMC_SDARI |= EXMC_SDARI_REC;
     }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_exti.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_exti.c
@@ -1,36 +1,36 @@
 /*!
     \file    gd32f4xx_exti.c
     \brief   EXTI driver
-    
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
-    \version 2018-12-12, V2.0.1, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -71,17 +71,17 @@ void exti_deinit(void)
     \retval     none
 */
 void exti_init(exti_line_enum linex, \
-                exti_mode_enum mode, \
-                exti_trig_type_enum trig_type)
+               exti_mode_enum mode, \
+               exti_trig_type_enum trig_type)
 {
     /* reset the EXTI line x */
     EXTI_INTEN &= ~(uint32_t)linex;
     EXTI_EVEN &= ~(uint32_t)linex;
     EXTI_RTEN &= ~(uint32_t)linex;
     EXTI_FTEN &= ~(uint32_t)linex;
-    
+
     /* set the EXTI mode and enable the interrupts or events from EXTI line x */
-    switch(mode){
+    switch(mode) {
     case EXTI_INTERRUPT:
         EXTI_INTEN |= (uint32_t)linex;
         break;
@@ -91,9 +91,9 @@ void exti_init(exti_line_enum linex, \
     default:
         break;
     }
-    
+
     /* set the EXTI trigger type */
-    switch(trig_type){
+    switch(trig_type) {
     case EXTI_TRIG_RISING:
         EXTI_RTEN |= (uint32_t)linex;
         EXTI_FTEN &= ~(uint32_t)linex;
@@ -200,11 +200,11 @@ void exti_software_interrupt_disable(exti_line_enum linex)
 */
 FlagStatus exti_flag_get(exti_line_enum linex)
 {
-    if(RESET != (EXTI_PD & (uint32_t)linex)){
+    if(RESET != (EXTI_PD & (uint32_t)linex)) {
         return SET;
-    }else{
+    } else {
         return RESET;
-    } 
+    }
 }
 
 /*!
@@ -231,13 +231,13 @@ void exti_flag_clear(exti_line_enum linex)
 FlagStatus exti_interrupt_flag_get(exti_line_enum linex)
 {
     uint32_t flag_left, flag_right;
-    
+
     flag_left = EXTI_PD & (uint32_t)linex;
     flag_right = EXTI_INTEN & (uint32_t)linex;
-    
-    if((RESET != flag_left) && (RESET != flag_right)){
+
+    if((RESET != flag_left) && (RESET != flag_right)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -254,4 +254,3 @@ void exti_interrupt_flag_clear(exti_line_enum linex)
 {
     EXTI_PD = (uint32_t)linex;
 }
-

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_fmc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_fmc.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -63,7 +64,7 @@ OF SUCH DAMAGE.
 void fmc_wscnt_set(uint32_t wscnt)
 {
     uint32_t reg;
-    
+
     reg = FMC_WS;
     /* set the wait state counter value */
     reg &= ~FMC_WC_WSCNT;
@@ -78,7 +79,7 @@ void fmc_wscnt_set(uint32_t wscnt)
 */
 void fmc_unlock(void)
 {
-    if((RESET != (FMC_CTL & FMC_CTL_LK))){
+    if((RESET != (FMC_CTL & FMC_CTL_LK))) {
         /* write the FMC key */
         FMC_KEY = UNLOCK_KEY0;
         FMC_KEY = UNLOCK_KEY1;
@@ -97,38 +98,11 @@ void fmc_lock(void)
     FMC_CTL |= FMC_CTL_LK;
 }
 
+#if defined (GD32F425) || defined (GD32F427) || defined (GD32F470)
+
 /*!
-    \brief    erase sector
-    \param[in]  fmc_sector: select the sector to erase
-                only one parameter can be selected which is shown as below:
-      \arg        CTL_SECTOR_NUMBER_0: sector 0 
-      \arg        CTL_SECTOR_NUMBER_1: sector 1 
-      \arg        CTL_SECTOR_NUMBER_2: sector 2 
-      \arg        CTL_SECTOR_NUMBER_3: sector 3 
-      \arg        CTL_SECTOR_NUMBER_4: sector 4 
-      \arg        CTL_SECTOR_NUMBER_5: sector 5 
-      \arg        CTL_SECTOR_NUMBER_6: sector 6 
-      \arg        CTL_SECTOR_NUMBER_7: sector 7 
-      \arg        CTL_SECTOR_NUMBER_8: sector 8 
-      \arg        CTL_SECTOR_NUMBER_9: sector 9 
-      \arg        CTL_SECTOR_NUMBER_10: sector 10 
-      \arg        CTL_SECTOR_NUMBER_11: sector 11 
-      \arg        CTL_SECTOR_NUMBER_12: sector 12 
-      \arg        CTL_SECTOR_NUMBER_13: sector 13 
-      \arg        CTL_SECTOR_NUMBER_14: sector 14 
-      \arg        CTL_SECTOR_NUMBER_15: sector 15 
-      \arg        CTL_SECTOR_NUMBER_16: sector 16 
-      \arg        CTL_SECTOR_NUMBER_17: sector 17 
-      \arg        CTL_SECTOR_NUMBER_18: sector 18 
-      \arg        CTL_SECTOR_NUMBER_19: sector 19 
-      \arg        CTL_SECTOR_NUMBER_20: sector 20 
-      \arg        CTL_SECTOR_NUMBER_21: sector 21 
-      \arg        CTL_SECTOR_NUMBER_22: sector 22 
-      \arg        CTL_SECTOR_NUMBER_23: sector 23 
-      \arg        CTL_SECTOR_NUMBER_24: sector 24 
-      \arg        CTL_SECTOR_NUMBER_25: sector 25 
-      \arg        CTL_SECTOR_NUMBER_26: sector 26 
-      \arg        CTL_SECTOR_NUMBER_27: sector 27 
+    \brief      FMC erase page
+    \param[in]  page_addr: the page address to be erased.
     \param[out] none
     \retval     state of FMC
       \arg        FMC_READY: the operation has been completed
@@ -138,7 +112,79 @@ void fmc_lock(void)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_page_erase(uint32_t page_addr)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* unlock  */
+        FMC_PEKEY = UNLOCK_PE_KEY;
+
+        /* start page erase */
+        FMC_PECFG = FMC_PE_EN | page_addr;
+        FMC_CTL &= ~FMC_CTL_SN;
+        FMC_CTL |= FMC_CTL_SER;
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        FMC_PECFG &= ~FMC_PE_EN;
+        FMC_CTL &= ~FMC_CTL_SER;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+#endif
+
+/*!
+    \brief    erase sector
+    \param[in]  fmc_sector: select the sector to erase
+                only one parameter can be selected which is shown as below:
+      \arg        CTL_SECTOR_NUMBER_0: sector 0
+      \arg        CTL_SECTOR_NUMBER_1: sector 1
+      \arg        CTL_SECTOR_NUMBER_2: sector 2
+      \arg        CTL_SECTOR_NUMBER_3: sector 3
+      \arg        CTL_SECTOR_NUMBER_4: sector 4
+      \arg        CTL_SECTOR_NUMBER_5: sector 5
+      \arg        CTL_SECTOR_NUMBER_6: sector 6
+      \arg        CTL_SECTOR_NUMBER_7: sector 7
+      \arg        CTL_SECTOR_NUMBER_8: sector 8
+      \arg        CTL_SECTOR_NUMBER_9: sector 9
+      \arg        CTL_SECTOR_NUMBER_10: sector 10
+      \arg        CTL_SECTOR_NUMBER_11: sector 11
+      \arg        CTL_SECTOR_NUMBER_12: sector 12
+      \arg        CTL_SECTOR_NUMBER_13: sector 13
+      \arg        CTL_SECTOR_NUMBER_14: sector 14
+      \arg        CTL_SECTOR_NUMBER_15: sector 15
+      \arg        CTL_SECTOR_NUMBER_16: sector 16
+      \arg        CTL_SECTOR_NUMBER_17: sector 17
+      \arg        CTL_SECTOR_NUMBER_18: sector 18
+      \arg        CTL_SECTOR_NUMBER_19: sector 19
+      \arg        CTL_SECTOR_NUMBER_20: sector 20
+      \arg        CTL_SECTOR_NUMBER_21: sector 21
+      \arg        CTL_SECTOR_NUMBER_22: sector 22
+      \arg        CTL_SECTOR_NUMBER_23: sector 23
+      \arg        CTL_SECTOR_NUMBER_24: sector 24
+      \arg        CTL_SECTOR_NUMBER_25: sector 25
+      \arg        CTL_SECTOR_NUMBER_26: sector 26
+      \arg        CTL_SECTOR_NUMBER_27: sector 27
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_sector_erase(uint32_t fmc_sector)
@@ -147,7 +193,7 @@ fmc_state_enum fmc_sector_erase(uint32_t fmc_sector)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         /* start sector erase */
         FMC_CTL &= ~FMC_CTL_SN;
         FMC_CTL |= (FMC_CTL_SER | fmc_sector);
@@ -177,7 +223,6 @@ fmc_state_enum fmc_sector_erase(uint32_t fmc_sector)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_mass_erase(void)
@@ -186,7 +231,7 @@ fmc_state_enum fmc_mass_erase(void)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){ 
+    if(FMC_READY == fmc_state) {
         /* start whole chip erase */
         FMC_CTL |= (FMC_CTL_MER0 | FMC_CTL_MER1);
         FMC_CTL |= FMC_CTL_START;
@@ -214,7 +259,6 @@ fmc_state_enum fmc_mass_erase(void)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_bank0_erase(void)
@@ -223,7 +267,7 @@ fmc_state_enum fmc_bank0_erase(void)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         /* start FMC bank0 erase */
         FMC_CTL |= FMC_CTL_MER0;
         FMC_CTL |= FMC_CTL_START;
@@ -251,7 +295,6 @@ fmc_state_enum fmc_bank0_erase(void)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_bank1_erase(void)
@@ -260,7 +303,7 @@ fmc_state_enum fmc_bank1_erase(void)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-   if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         /* start FMC bank1 erase */
         FMC_CTL |= FMC_CTL_MER1;
         FMC_CTL |= FMC_CTL_START;
@@ -289,7 +332,6 @@ fmc_state_enum fmc_bank1_erase(void)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_word_program(uint32_t address, uint32_t data)
@@ -298,11 +340,11 @@ fmc_state_enum fmc_word_program(uint32_t address, uint32_t data)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         /* set the PG bit to start program */
         FMC_CTL &= ~FMC_CTL_PSZ;
         FMC_CTL |= CTL_PSZ_WORD;
-        FMC_CTL |= FMC_CTL_PG; 
+        FMC_CTL |= FMC_CTL_PG;
 
         REG32(address) = data;
 
@@ -330,7 +372,6 @@ fmc_state_enum fmc_word_program(uint32_t address, uint32_t data)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_halfword_program(uint32_t address, uint16_t data)
@@ -339,7 +380,7 @@ fmc_state_enum fmc_halfword_program(uint32_t address, uint16_t data)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         /* set the PG bit to start program */
         FMC_CTL &= ~FMC_CTL_PSZ;
         FMC_CTL |= CTL_PSZ_HALF_WORD;
@@ -371,7 +412,6 @@ fmc_state_enum fmc_halfword_program(uint32_t address, uint16_t data)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_byte_program(uint32_t address, uint8_t data)
@@ -379,8 +419,8 @@ fmc_state_enum fmc_byte_program(uint32_t address, uint8_t data)
     fmc_state_enum fmc_state = FMC_READY;
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
-  
-    if(FMC_READY == fmc_state){
+
+    if(FMC_READY == fmc_state) {
         /* set the PG bit to start program */
         FMC_CTL &= ~FMC_CTL_PSZ;
         FMC_CTL |= CTL_PSZ_BYTE;
@@ -407,7 +447,7 @@ fmc_state_enum fmc_byte_program(uint32_t address, uint8_t data)
 */
 void ob_unlock(void)
 {
-    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_OB_LK)){
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_OB_LK)) {
         /* write the FMC key */
         FMC_OBKEY = OB_UNLOCK_KEY0;
         FMC_OBKEY = OB_UNLOCK_KEY1;
@@ -434,14 +474,8 @@ void ob_lock(void)
 */
 void ob_start(void)
 {
-    fmc_state_enum fmc_state = FMC_READY;
     /* set the OB_START bit in OBCTL0 register */
     FMC_OBCTL0 |= FMC_OBCTL0_OB_START;
-    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
-        if(FMC_READY != fmc_state){
-            while(1){
-            }
-        }
 }
 
 /*!
@@ -456,10 +490,10 @@ void ob_erase(void)
     fmc_state_enum fmc_state = FMC_READY;
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+    reg = FMC_OBCTL0;
+    reg1 = FMC_OBCTL1;
 
-    if(FMC_READY == fmc_state){
-        reg = FMC_OBCTL0;
-        reg1 = FMC_OBCTL1;
+    if(FMC_READY == fmc_state) {
 
         /* reset the OB_FWDGT, OB_DEEPSLEEP and OB_STDBY, set according to ob_fwdgt ,ob_deepsleep and ob_stdby */
         reg |= (FMC_OBCTL0_NWDG_HW | FMC_OBCTL0_NRST_DPSLP | FMC_OBCTL0_NRST_STDBY);
@@ -490,25 +524,28 @@ void ob_erase(void)
       \arg        OB_WP_23_27: sector23~27
       \arg        OB_WP_ALL: all sector
     \param[out] none
-    \retval     none
+    \retval     SUCCESS or ERROR
 */
-void ob_write_protection_enable(uint32_t ob_wp)
+ErrStatus ob_write_protection_enable(uint32_t ob_wp)
 {
     uint32_t reg0 = FMC_OBCTL0;
     uint32_t reg1 = FMC_OBCTL1;
     fmc_state_enum fmc_state = FMC_READY;
-    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)){
-        while(1){
-        }
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)) {
+        return ERROR;
     }
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
-        reg0 &= (~((uint32_t)ob_wp << 16));
+    if(FMC_READY == fmc_state) {
+        reg0 &= (~((uint32_t)ob_wp << 16U));
         reg1 &= (~(ob_wp & 0xFFFF0000U));
         FMC_OBCTL0 = reg0;
         FMC_OBCTL1 = reg1;
+
+        return SUCCESS;
+    } else {
+        return ERROR;
     }
 }
 
@@ -520,31 +557,34 @@ void ob_write_protection_enable(uint32_t ob_wp)
       \arg        OB_WP_23_27: sector23~27
       \arg        OB_WP_ALL: all sector
     \param[out] none
-    \retval     none
+    \retval     SUCCESS or ERROR
 */
-void ob_write_protection_disable(uint32_t ob_wp)
+ErrStatus ob_write_protection_disable(uint32_t ob_wp)
 {
     uint32_t reg0 = FMC_OBCTL0;
     uint32_t reg1 = FMC_OBCTL1;
     fmc_state_enum fmc_state = FMC_READY;
-    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)){
-        while(1){
-        }
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)) {
+        return ERROR;
     }
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
-        reg0 |= ((uint32_t)ob_wp << 16);
+    if(FMC_READY == fmc_state) {
+        reg0 |= ((uint32_t)ob_wp << 16U);
         reg1 |= (ob_wp & 0xFFFF0000U);
         FMC_OBCTL0 = reg0;
         FMC_OBCTL1 = reg1;
+
+        return SUCCESS;
+    } else {
+        return ERROR;
     }
 }
 
 /*!
     \brief    enable erase/program protection and D-bus read protection
-    \param[in]  ob_drp: enable the WPx bits used as erase/program protection and D-bus read protection of each sector 
+    \param[in]  ob_drp: enable the WPx bits used as erase/program protection and D-bus read protection of each sector
                 one or more parameters can be selected which are shown as below:
       \arg        OB_DRP_x(x=0..22): sector x(x = 0,1,2...22)
       \arg        OB_DRP_23_27: sector23~27
@@ -560,22 +600,21 @@ void ob_drp_enable(uint32_t ob_drp)
     uint32_t drp_state = FMC_OBCTL0 & FMC_OBCTL0_DRP;
     uint32_t wp0_state = FMC_OBCTL0 & FMC_OBCTL0_WP0;
     uint32_t wp1_state = FMC_OBCTL1 & FMC_OBCTL1_WP1;
-    /*disable write protection before enable D-bus read protection*/
-    if((RESET != drp_state) && ((FMC_OBCTL0_WP0 != wp0_state) && (FMC_OBCTL1_WP1 != wp1_state))){
-        while(1){
-        }
-    }
+
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
-        reg0 &= ~FMC_OBCTL0_WP0;
-        reg1 &= ~FMC_OBCTL1_WP1;
-        reg0 |= ((uint32_t)ob_drp << 16);
+    if(FMC_READY == fmc_state) {
+        if(RESET == drp_state) {
+            reg0 &= ~FMC_OBCTL0_WP0;
+            reg1 &= ~FMC_OBCTL1_WP1;
+        }
+        reg0 |= ((uint32_t)ob_drp << 16U);
+        reg0 |= FMC_OBCTL0_DRP;
         reg1 |= ((uint32_t)ob_drp & 0xFFFF0000U);
+
         FMC_OBCTL0 = reg0;
         FMC_OBCTL1 = reg1;
-        FMC_OBCTL0 |= FMC_OBCTL0_DRP;
     }
 }
 
@@ -589,7 +628,7 @@ void ob_drp_enable(uint32_t ob_drp)
     \param[out] none
     \retval     none
 */
-void ob_drp_disable(uint32_t ob_drp)
+void ob_drp_disable(void)
 {
     uint32_t reg0 = FMC_OBCTL0;
     uint32_t reg1 = FMC_OBCTL1;
@@ -597,27 +636,26 @@ void ob_drp_disable(uint32_t ob_drp)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
-        if(((uint8_t)(reg0 >> 8)) == (uint8_t)FMC_NSPC){
+    if(FMC_READY == fmc_state) {
+        if(((uint8_t)(reg0 >> 8U)) == (uint8_t)FMC_NSPC) {
             /* security protection should be set as low level protection before disable D-BUS read protection */
             reg0 &= ~FMC_OBCTL0_SPC;
-            reg0 |= ((uint32_t)FMC_LSPC << 8);
+            reg0 |= ((uint32_t)FMC_LSPC << 8U);
             FMC_OBCTL0 = reg0;
-            ob_start();
-            while(FMC_READY != fmc_ready_wait(FMC_TIMEOUT_COUNT));
-        }else if(((uint8_t)(reg0 >> 8)) == (uint8_t)FMC_HSPC){
-            return;
+            /* set the OB_START bit in OBCTL0 register */
+            FMC_OBCTL0 |= FMC_OBCTL0_OB_START;
         }
 
         /* it is necessary to disable the security protection at the same time when D-BUS read protection is disabled */
         reg0 &= ~FMC_OBCTL0_SPC;
-        reg0 |= ((uint32_t)FMC_NSPC << 8);
+        reg0 |= ((uint32_t)FMC_NSPC << 8U);
         reg0 |= FMC_OBCTL0_WP0;
         reg0 &= (~FMC_OBCTL0_DRP);
         FMC_OBCTL0 = reg0;
 
         reg1 |= FMC_OBCTL1_WP1;
         FMC_OBCTL1 = reg1;
+
     }
 }
 
@@ -637,19 +675,19 @@ void ob_security_protection_config(uint8_t ob_spc)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         uint32_t reg;
 
         reg = FMC_OBCTL0;
         /* reset the OBCTL0_SPC, set according to ob_spc */
         reg &= ~FMC_OBCTL0_SPC;
-        reg |= ((uint32_t)ob_spc << 8);
+        reg |= ((uint32_t)ob_spc << 8U);
         FMC_OBCTL0 = reg;
     }
 }
 
 /*!
-    \brief    program the FMC user option byte 
+    \brief    program the FMC user option byte
     \param[in]  ob_fwdgt: option byte watchdog value
                 only one parameter can be selected which is shown as below:
       \arg        OB_FWDGT_SW: software free watchdog
@@ -657,11 +695,11 @@ void ob_security_protection_config(uint8_t ob_spc)
     \param[in]  ob_deepsleep: option byte deepsleep reset value
                 only one parameter can be selected which is shown as below:
       \arg        OB_DEEPSLEEP_NRST: no reset when entering deepsleep mode
-      \arg        OB_DEEPSLEEP_RST: generate a reset instead of entering deepsleep mode 
+      \arg        OB_DEEPSLEEP_RST: generate a reset instead of entering deepsleep mode
     \param[in]  ob_stdby:option byte standby reset value
                 only one parameter can be selected which is shown as below:
       \arg        OB_STDBY_NRST: no reset when entering standby mode
-      \arg        OB_STDBY_RST: generate a reset instead of entering standby mode 
+      \arg        OB_STDBY_RST: generate a reset instead of entering standby mode
     \param[out] none
     \retval     none
 */
@@ -672,7 +710,7 @@ void ob_user_write(uint32_t ob_fwdgt, uint32_t ob_deepsleep, uint32_t ob_stdby)
     /* wait for the FMC ready */
     fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
 
-    if(FMC_READY == fmc_state){
+    if(FMC_READY == fmc_state) {
         uint32_t reg;
 
         reg = FMC_OBCTL0;
@@ -696,7 +734,7 @@ void ob_user_write(uint32_t ob_fwdgt, uint32_t ob_deepsleep, uint32_t ob_stdby)
 void ob_user_bor_threshold(uint32_t ob_bor_th)
 {
     uint32_t reg;
-    
+
     reg = FMC_OBCTL0;
     /* set the BOR level */
     reg &= ~FMC_OBCTL0_BOR_TH;
@@ -715,7 +753,7 @@ void ob_user_bor_threshold(uint32_t ob_bor_th)
 void ob_boot_mode_config(uint32_t boot_mode)
 {
     uint32_t reg;
-    
+
     reg = FMC_OBCTL0;
     /* set option byte boot bank value */
     reg &= ~FMC_OBCTL0_BB;
@@ -730,7 +768,7 @@ void ob_boot_mode_config(uint32_t boot_mode)
 */
 uint8_t ob_user_get(void)
 {
-    return (uint8_t)((uint8_t)(FMC_OBCTL0 >> 5) & (uint8_t)0x07);
+    return (uint8_t)((uint8_t)(FMC_OBCTL0 >> 5U) & 0x07U);
 }
 
 /*!
@@ -742,7 +780,7 @@ uint8_t ob_user_get(void)
 uint16_t ob_write_protection0_get(void)
 {
     /* return the FMC write protection option byte value */
-    return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16)) & (uint16_t)0x0FFF);
+    return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16U)) & 0x0FFFU);
 }
 
 /*!
@@ -754,7 +792,7 @@ uint16_t ob_write_protection0_get(void)
 uint16_t ob_write_protection1_get(void)
 {
     /* return the the FMC write protection option byte value */
-    return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16)) & (uint16_t)0x0FFF);
+    return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16U)) & 0x0FFFU);
 }
 
 /*!
@@ -766,7 +804,11 @@ uint16_t ob_write_protection1_get(void)
 uint16_t ob_drp0_get(void)
 {
     /* return the FMC erase/program protection and D-bus read protection option bytes value */
-    return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16)) & (uint16_t)0x0FFF);
+    if(FMC_OBCTL0 & FMC_OBCTL0_DRP) {
+        return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16U)) & 0x0FFFU);
+    } else {
+        return 0xF000U;
+    }
 }
 
 /*!
@@ -778,7 +820,11 @@ uint16_t ob_drp0_get(void)
 uint16_t ob_drp1_get(void)
 {
     /* return the FMC erase/program protection and D-bus read protection option bytes value */
-    return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16)) & (uint16_t)0x0FFF);
+    if(FMC_OBCTL0 & FMC_OBCTL0_DRP) {
+        return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16U)) & 0x0FFFU);
+    } else {
+        return 0xF000U;
+    }
 }
 
 /*!
@@ -790,10 +836,10 @@ uint16_t ob_drp1_get(void)
 FlagStatus ob_spc_get(void)
 {
     FlagStatus spc_state = RESET;
-  
-    if (((uint8_t)(FMC_OBCTL0 >> 8)) != (uint8_t)FMC_NSPC){
+
+    if(((uint8_t)(FMC_OBCTL0 >> 8U)) != FMC_NSPC) {
         spc_state = SET;
-    }else{
+    } else {
         spc_state = RESET;
     }
     return spc_state;
@@ -808,7 +854,49 @@ FlagStatus ob_spc_get(void)
 uint8_t ob_user_bor_threshold_get(void)
 {
     /* return the FMC BOR threshold value */
-    return (uint8_t)((uint8_t)FMC_OBCTL0 & (uint8_t)0x0C);
+    return (uint8_t)((uint8_t)FMC_OBCTL0 & 0x0CU);
+}
+
+/*!
+    \brief    get flag set or reset
+    \param[in]  fmc_flag: check FMC flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_FLAG_BUSY: FMC busy flag bit
+      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
+      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
+      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
+      \arg        FMC_FLAG_WPERR: FMC Erase/Program protection error flag bit
+      \arg        FMC_FLAG_OPERR: FMC operation error flag bit
+      \arg        FMC_FLAG_END: FMC end of operation flag bit
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus fmc_flag_get(uint32_t fmc_flag)
+{
+    if(FMC_STAT & fmc_flag) {
+        return SET;
+    }
+    /* return the state of corresponding FMC flag */
+    return RESET;
+}
+
+/*!
+    \brief    clear the FMC pending flag
+    \param[in]  FMC_flag: clear FMC flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
+      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
+      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
+      \arg        FMC_FLAG_WPERR: FMC erase/program protection error flag bit
+      \arg        FMC_FLAG_OPERR: FMC operation error flag bit
+      \arg        FMC_FLAG_END: FMC end of operation flag bit
+    \param[out] none
+    \retval     none
+*/
+void fmc_flag_clear(uint32_t fmc_flag)
+{
+    /* clear the flags */
+    FMC_STAT = fmc_flag;
 }
 
 /*!
@@ -840,45 +928,56 @@ void fmc_interrupt_disable(uint32_t fmc_int)
 }
 
 /*!
-    \brief    get flag set or reset
-    \param[in]  fmc_flag: check FMC flag
+    \brief    get FMC interrupt flag set or reset
+    \param[in]  fmc_int_flag: FMC interrupt flag
                 only one parameter can be selected which is shown as below:
-      \arg        FMC_FLAG_BUSY: FMC busy flag bit
-      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
-      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
-      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
-      \arg        FMC_FLAG_WPERR: FMC Erase/Program protection error flag bit
-      \arg        FMC_FLAG_OPERR: FMC operation error flag bit 
-      \arg        FMC_FLAG_END: FMC end of operation flag bit
+      \arg        FMC_INT_FLAG_RDDERR: FMC read D-bus protection error interrupt flag
+      \arg        FMC_INT_FLAG_PGSERR: FMC program sequence error interrupt flag
+      \arg        FMC_INT_FLAG_PGMERR: FMC program size not match error interrupt flag
+      \arg        FMC_INT_FLAG_WPERR: FMC Erase/Program protection error interrupt flag
+      \arg        FMC_INT_FLAG_OPERR: FMC operation error interrupt flag
+      \arg        FMC_INT_FLAG_END: FMC end of operation interrupt flag
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
-FlagStatus fmc_flag_get(uint32_t fmc_flag)
+FlagStatus fmc_interrupt_flag_get(uint32_t fmc_int_flag)
 {
-    if(FMC_STAT & fmc_flag){
-        return  SET;
+    if(FMC_FLAG_END == fmc_int_flag) {
+        /* end of operation interrupt flag */
+        if(FMC_CTL & FMC_CTL_ENDIE) {
+            if(FMC_STAT & fmc_int_flag) {
+                return SET;
+            }
+        }
+    } else {
+        /* error interrupt flags */
+        if(FMC_CTL & FMC_CTL_ERRIE) {
+            if(FMC_STAT & fmc_int_flag) {
+                return SET;
+            }
+        }
     }
-    /* return the state of corresponding FMC flag */
-    return RESET; 
+
+    return RESET;
 }
 
 /*!
-    \brief    clear the FMC pending flag
-    \param[in]  FMC_flag: clear FMC flag
+    \brief    clear the FMC interrupt flag
+    \param[in]  fmc_int_flag: FMC interrupt flag
                 only one parameter can be selected which is shown as below:
-      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
-      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
-      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
-      \arg        FMC_FLAG_WPERR: FMC erase/program protection error flag bit
-      \arg        FMC_FLAG_OPERR: FMC operation error flag bit 
-      \arg        FMC_FLAG_END: FMC end of operation flag bit
+      \arg        FMC_INT_FLAG_RDDERR: FMC read D-bus protection error interrupt flag
+      \arg        FMC_INT_FLAG_PGSERR: FMC program sequence error interrupt flag
+      \arg        FMC_INT_FLAG_PGMERR: FMC program size not match error interrupt flag
+      \arg        FMC_INT_FLAG_WPERR: FMC Erase/Program protection error interrupt flag
+      \arg        FMC_INT_FLAG_OPERR: FMC operation error interrupt flag
+      \arg        FMC_INT_FLAG_END: FMC end of operation interrupt flag
     \param[out] none
     \retval     none
 */
-void fmc_flag_clear(uint32_t fmc_flag)
+void fmc_interrupt_flag_clear(uint32_t fmc_int_flag)
 {
-    /* clear the flags */
-    FMC_STAT = fmc_flag;
+    /* clear the interrupt flag */
+    FMC_STAT = fmc_int_flag;
 }
 
 /*!
@@ -893,33 +992,28 @@ void fmc_flag_clear(uint32_t fmc_flag)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
 */
 fmc_state_enum fmc_state_get(void)
 {
     fmc_state_enum fmc_state = FMC_READY;
-  
-    if((FMC_STAT & FMC_FLAG_BUSY) == FMC_FLAG_BUSY){
+    uint32_t temp_val = FMC_STAT;
+
+    if(RESET != (temp_val & FMC_FLAG_BUSY)) {
         fmc_state = FMC_BUSY;
-    }else{
-        if((FMC_STAT & FMC_FLAG_WPERR) != (uint32_t)0x00){ 
-            fmc_state = FMC_WPERR;
-        }else{
-            if((FMC_STAT & FMC_FLAG_RDDERR) != (uint32_t)0x00){ 
-                fmc_state = FMC_RDDERR;
-            }else{
-                if((FMC_STAT & (uint32_t)0xEF) != (uint32_t)0x00){
-                    fmc_state = FMC_PGERR; 
-                }else{
-                    if((FMC_STAT & FMC_FLAG_OPERR) != (uint32_t)0x00){
-                        fmc_state = FMC_OPERR;
-                    }else{
-                        fmc_state = FMC_READY;
-                    }
-                }
-            }
-        }
+    } else if(RESET != (temp_val & FMC_FLAG_RDDERR)) {
+        fmc_state = FMC_RDDERR;
+    } else if(RESET != (temp_val & FMC_FLAG_PGSERR)) {
+        fmc_state = FMC_PGSERR;
+    } else if(RESET != (temp_val & FMC_FLAG_PGMERR)) {
+        fmc_state = FMC_PGMERR;
+    } else if(RESET != (temp_val & FMC_FLAG_WPERR)) {
+        fmc_state = FMC_WPERR;
+    } else if(RESET != (temp_val & FMC_FLAG_OPERR)) {
+        fmc_state = FMC_OPERR;
+    } else {
+        fmc_state = FMC_READY;
     }
+
     /* return the FMC state */
     return fmc_state;
 }
@@ -936,7 +1030,6 @@ fmc_state_enum fmc_state_get(void)
       \arg        FMC_PGMERR: program size not match error
       \arg        FMC_WPERR: erase/program protection error
       \arg        FMC_OPERR: operation error
-      \arg        FMC_PGERR: program error
       \arg        FMC_TOERR: timeout error
 */
 fmc_state_enum fmc_ready_wait(uint32_t timeout)
@@ -944,15 +1037,16 @@ fmc_state_enum fmc_ready_wait(uint32_t timeout)
     fmc_state_enum fmc_state = FMC_BUSY;
 
     /* wait for FMC ready */
-    do{
+    do {
         /* get FMC state */
         fmc_state = fmc_state_get();
         timeout--;
-    }while((FMC_BUSY == fmc_state) && (0U != timeout));
+    } while((FMC_BUSY == fmc_state) && (0U != timeout));
 
-    if(FMC_BUSY == fmc_state){
+    if(0U == timeout) {
         fmc_state = FMC_TOERR;
     }
+
     /* return the FMC state */
     return fmc_state;
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_fwdgt.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_fwdgt.c
@@ -1,14 +1,15 @@
 /*!
     \file    gd32f4xx_fwdgt.c
     \brief   FWDGT driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_gpio.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_gpio.c
@@ -1,44 +1,45 @@
 /*!
     \file    gd32f4xx_gpio.c
     \brief   GPIO driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_gpio.h"
 
 /*!
-    \brief    reset GPIO port
-    \param[in]  gpio_periph: GPIO port 
+    \brief      reset GPIO port
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[out] none
@@ -46,7 +47,7 @@ OF SUCH DAMAGE.
 */
 void gpio_deinit(uint32_t gpio_periph)
 {
-    switch(gpio_periph){
+    switch(gpio_periph) {
     case GPIOA:
         /* reset GPIOA */
         rcu_periph_reset_enable(RCU_GPIOARST);
@@ -98,8 +99,8 @@ void gpio_deinit(uint32_t gpio_periph)
 }
 
 /*!
-    \brief    set GPIO mode
-    \param[in]  gpio_periph: GPIO port 
+    \brief      set GPIO mode
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  mode: GPIO pin mode
@@ -125,8 +126,8 @@ void gpio_mode_set(uint32_t gpio_periph, uint32_t mode, uint32_t pull_up_down, u
     ctl = GPIO_CTL(gpio_periph);
     pupd = GPIO_PUD(gpio_periph);
 
-    for(i = 0U;i < 16U;i++){
-        if((1U << i) & pin){
+    for(i = 0U; i < 16U; i++) {
+        if((1U << i) & pin) {
             /* clear the specified pin mode bits */
             ctl &= ~GPIO_MODE_MASK(i);
             /* set the specified pin mode bits */
@@ -144,18 +145,18 @@ void gpio_mode_set(uint32_t gpio_periph, uint32_t mode, uint32_t pull_up_down, u
 }
 
 /*!
-    \brief    set GPIO output type and speed
-    \param[in]  gpio_periph: GPIO port 
+    \brief      set GPIO output type and speed
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  otype: GPIO pin output mode
       \arg        GPIO_OTYPE_PP: push pull mode
       \arg        GPIO_OTYPE_OD: open drain mode
     \param[in]  speed: GPIO pin output max speed
-      \arg        GPIO_OSPEED_2MHZ: output max speed 2MHz 
-      \arg        GPIO_OSPEED_25MHZ: output max speed 25MHz 
+      \arg        GPIO_OSPEED_2MHZ: output max speed 2MHz
+      \arg        GPIO_OSPEED_25MHZ: output max speed 25MHz
       \arg        GPIO_OSPEED_50MHZ: output max speed 50MHz
-      \arg        GPIO_OSPEED_200MHZ: output max speed 200MHz
+      \arg        GPIO_OSPEED_MAX: output max speed more than 50MHz
     \param[in]  pin: GPIO pin
                 one or more parameters can be selected which are shown as below:
       \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
@@ -167,21 +168,21 @@ void gpio_output_options_set(uint32_t gpio_periph, uint8_t otype, uint32_t speed
     uint16_t i;
     uint32_t ospeedr;
 
-    if(GPIO_OTYPE_OD == otype){
+    if(GPIO_OTYPE_OD == otype) {
         GPIO_OMODE(gpio_periph) |= (uint32_t)pin;
-    }else{
+    } else {
         GPIO_OMODE(gpio_periph) &= (uint32_t)(~pin);
     }
 
     /* get the specified pin output speed bits value */
     ospeedr = GPIO_OSPD(gpio_periph);
 
-    for(i = 0U;i < 16U;i++){
-        if((1U << i) & pin){
+    for(i = 0U; i < 16U; i++) {
+        if((1U << i) & pin) {
             /* clear the specified pin output speed bits */
             ospeedr &= ~GPIO_OSPEED_MASK(i);
             /* set the specified pin output speed bits */
-            ospeedr |= GPIO_OSPEED_SET(i,speed);
+            ospeedr |= GPIO_OSPEED_SET(i, speed);
         }
     }
     GPIO_OSPD(gpio_periph) = ospeedr;
@@ -189,7 +190,7 @@ void gpio_output_options_set(uint32_t gpio_periph, uint8_t otype, uint32_t speed
 
 /*!
     \brief    set GPIO pin bit
-    \param[in]  gpio_periph: GPIO port 
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -204,8 +205,8 @@ void gpio_bit_set(uint32_t gpio_periph, uint32_t pin)
 }
 
 /*!
-    \brief    reset GPIO pin bit
-    \param[in]  gpio_periph: GPIO port 
+    \brief      reset GPIO pin bit
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -220,8 +221,8 @@ void gpio_bit_reset(uint32_t gpio_periph, uint32_t pin)
 }
 
 /*!
-    \brief    write data to the specified GPIO pin
-    \param[in]  gpio_periph: GPIO port 
+    \brief      write data to the specified GPIO pin
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -235,16 +236,16 @@ void gpio_bit_reset(uint32_t gpio_periph, uint32_t pin)
 */
 void gpio_bit_write(uint32_t gpio_periph, uint32_t pin, bit_status bit_value)
 {
-    if(RESET != bit_value){
+    if(RESET != bit_value) {
         GPIO_BOP(gpio_periph) = (uint32_t)pin;
-    }else{
+    } else {
         GPIO_BC(gpio_periph) = (uint32_t)pin;
     }
 }
 
 /*!
-    \brief    write data to the specified GPIO port
-    \param[in]  gpio_periph: GPIO port 
+    \brief      write data to the specified GPIO port
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  data: specify the value to be written to the port output control register
@@ -257,8 +258,8 @@ void gpio_port_write(uint32_t gpio_periph, uint16_t data)
 }
 
 /*!
-    \brief    get GPIO pin input status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      get GPIO pin input status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -269,16 +270,16 @@ void gpio_port_write(uint32_t gpio_periph, uint16_t data)
 */
 FlagStatus gpio_input_bit_get(uint32_t gpio_periph, uint32_t pin)
 {
-    if((uint32_t)RESET != (GPIO_ISTAT(gpio_periph)&(pin))){
-        return SET; 
-    }else{
+    if((uint32_t)RESET != (GPIO_ISTAT(gpio_periph) & (pin))) {
+        return SET;
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    get GPIO all pins input status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      get GPIO all pins input status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[out] none
@@ -290,8 +291,8 @@ uint16_t gpio_input_port_get(uint32_t gpio_periph)
 }
 
 /*!
-    \brief    get GPIO pin output status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      get GPIO pin output status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -302,18 +303,18 @@ uint16_t gpio_input_port_get(uint32_t gpio_periph)
 */
 FlagStatus gpio_output_bit_get(uint32_t gpio_periph, uint32_t pin)
 {
-    if((uint32_t)RESET !=(GPIO_OCTL(gpio_periph)&(pin))){
+    if((uint32_t)RESET != (GPIO_OCTL(gpio_periph) & (pin))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    get GPIO all pins output status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      get GPIO port output status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
-      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I) 
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[out] none
     \retval     output status of GPIO all pins
 */
@@ -323,8 +324,8 @@ uint16_t gpio_output_port_get(uint32_t gpio_periph)
 }
 
 /*!
-    \brief    set GPIO alternate function
-    \param[in]  gpio_periph: GPIO port 
+    \brief      set GPIO alternate function
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  alt_func_num: GPIO pin af function
@@ -334,10 +335,10 @@ uint16_t gpio_output_port_get(uint32_t gpio_periph)
       \arg        GPIO_AF_3: TIMER7, TIMER8, TIMER9, TIMER10
       \arg        GPIO_AF_4: I2C0, I2C1, I2C2
       \arg        GPIO_AF_5: SPI0, SPI1, SPI2, SPI3, SPI4, SPI5
-      \arg        GPIO_AF_6: SPI1, SPI2, SAI0 
-      \arg        GPIO_AF_7: USART0, USART1, USART2
+      \arg        GPIO_AF_6: SPI2, SPI3, SPI4
+      \arg        GPIO_AF_7: USART0, USART1, USART2, SPI1, SPI2
       \arg        GPIO_AF_8: UART3, UART4, USART5, UART6, UART7
-      \arg        GPIO_AF_9: CAN0, CAN1, TLI, TIMER11, TIMER12, TIMER13
+      \arg        GPIO_AF_9: CAN0, CAN1, TLI, TIMER11, TIMER12, TIMER13, I2C1, I2C2, CTC
       \arg        GPIO_AF_10: USB_FS, USB_HS
       \arg        GPIO_AF_11: ENET
       \arg        GPIO_AF_12: EXMC, SDIO, USB_HS
@@ -358,19 +359,19 @@ void gpio_af_set(uint32_t gpio_periph, uint32_t alt_func_num, uint32_t pin)
     afrl = GPIO_AFSEL0(gpio_periph);
     afrh = GPIO_AFSEL1(gpio_periph);
 
-    for(i = 0U;i < 8U;i++){
-        if((1U << i) & pin){
+    for(i = 0U; i < 8U; i++) {
+        if((1U << i) & pin) {
             /* clear the specified pin alternate function bits */
             afrl &= ~GPIO_AFR_MASK(i);
-            afrl |= GPIO_AFR_SET(i,alt_func_num);
+            afrl |= GPIO_AFR_SET(i, alt_func_num);
         }
     }
 
-    for(i = 8U;i < 16U;i++){
-        if((1U << i) & pin){
+    for(i = 8U; i < 16U; i++) {
+        if((1U << i) & pin) {
             /* clear the specified pin alternate function bits */
             afrh &= ~GPIO_AFR_MASK(i - 8U);
-            afrh |= GPIO_AFR_SET(i - 8U,alt_func_num);
+            afrh |= GPIO_AFR_SET(i - 8U, alt_func_num);
         }
     }
 
@@ -379,8 +380,8 @@ void gpio_af_set(uint32_t gpio_periph, uint32_t alt_func_num, uint32_t pin)
 }
 
 /*!
-    \brief    lock GPIO pin bit
-    \param[in]  gpio_periph: GPIO port 
+    \brief      lock GPIO pin bit
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -403,8 +404,8 @@ void gpio_pin_lock(uint32_t gpio_periph, uint32_t pin)
 }
 
 /*!
-    \brief    toggle GPIO pin status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      toggle GPIO pin status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
     \param[in]  pin: GPIO pin
@@ -419,8 +420,8 @@ void gpio_bit_toggle(uint32_t gpio_periph, uint32_t pin)
 }
 
 /*!
-    \brief    toggle GPIO port status
-    \param[in]  gpio_periph: GPIO port 
+    \brief      toggle GPIO port status
+    \param[in]  gpio_periph: GPIO port
                 only one parameter can be selected which is shown as below:
       \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
 

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
@@ -6,54 +6,57 @@
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2019-04-16, V2.0.2, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_i2c.h"
 
 /* I2C register bit mask */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003CU)             /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */
 
 /* I2C register bit offset */
-#define STAT1_PECV_OFFSET             ((uint32_t)8U)     /* bit offset of PECV in I2C_STAT1 */
+#define STAT1_PECV_OFFSET             ((uint32_t)0x00000008U)             /* bit offset of PECV in I2C_STAT1 */
 
 /*!
-    \brief    reset I2C
+    \brief      reset I2C
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_deinit(uint32_t i2c_periph)
 {
-    switch(i2c_periph){
+    switch(i2c_periph) {
     case I2C0:
         /* reset I2C0 */
         rcu_periph_reset_enable(RCU_I2C0RST);
@@ -75,13 +78,13 @@ void i2c_deinit(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    configure I2C clock
+    \brief      configure I2C clock
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  clkspeed: I2C clock speed, supports standard mode (up to 100 kHz), fast mode (up to 400 kHz)
     \param[in]  dutycyc: duty cycle in fast mode
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_DTCY_2: T_low/T_high=2 
-      \arg        I2C_DTCY_16_9: T_low/T_high=16/9
+      \arg        I2C_DTCY_2: T_low/T_high = 2 in fast mode
+      \arg        I2C_DTCY_16_9: T_low/T_high = 16/9 in fast mode
     \param[out] none
     \retval     none
 */
@@ -89,59 +92,61 @@ void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc)
 {
     uint32_t pclk1, clkc, freq, risetime;
     uint32_t temp;
-    
+
     pclk1 = rcu_clock_freq_get(CK_APB1);
     /* I2C peripheral clock frequency */
-    freq = (uint32_t)(pclk1/1000000U);
-    if(freq >= I2CCLK_MAX){
+    freq = (uint32_t)(pclk1 / 1000000U);
+    if(freq >= I2CCLK_MAX) {
         freq = I2CCLK_MAX;
     }
     temp = I2C_CTL1(i2c_periph);
     temp &= ~I2C_CTL1_I2CCLK;
     temp |= freq;
-    
+
     I2C_CTL1(i2c_periph) = temp;
-    
-    if(100000U >= clkspeed){
+
+    if(100000U >= clkspeed) {
         /* the maximum SCL rise time is 1000ns in standard mode */
-        risetime = (uint32_t)((pclk1/1000000U)+1U);
-        if(risetime >= I2CCLK_MAX){
+        risetime = (uint32_t)((pclk1 / 1000000U) + 1U);
+        if(risetime >= I2CCLK_MAX) {
             I2C_RT(i2c_periph) = I2CCLK_MAX;
-        }else{
+        } else if(risetime <= I2CCLK_MIN) {
+            I2C_RT(i2c_periph) = I2CCLK_MIN;
+        } else {
             I2C_RT(i2c_periph) = risetime;
         }
-        clkc = (uint32_t)(pclk1/(clkspeed*2U)); 
-        if(clkc < 0x04U){
+        clkc = (uint32_t)(pclk1 / (clkspeed * 2U));
+        if(clkc < 0x04U) {
             /* the CLKC in standard mode minmum value is 4 */
             clkc = 0x04U;
         }
-        
+
         I2C_CKCFG(i2c_periph) |= (I2C_CKCFG_CLKC & clkc);
 
-    }else if(400000U >= clkspeed){
+    } else if(400000U >= clkspeed) {
         /* the maximum SCL rise time is 300ns in fast mode */
-        I2C_RT(i2c_periph) = (uint32_t)(((freq*(uint32_t)300U)/(uint32_t)1000U)+(uint32_t)1U);
-        if(I2C_DTCY_2 == dutycyc){
+        I2C_RT(i2c_periph) = (uint32_t)(((freq * (uint32_t)300U) / (uint32_t)1000U) + (uint32_t)1U);
+        if(I2C_DTCY_2 == dutycyc) {
             /* I2C duty cycle is 2 */
-            clkc = (uint32_t)(pclk1/(clkspeed*3U));
+            clkc = (uint32_t)(pclk1 / (clkspeed * 3U));
             I2C_CKCFG(i2c_periph) &= ~I2C_CKCFG_DTCY;
-        }else{
+        } else {
             /* I2C duty cycle is 16/9 */
-            clkc = (uint32_t)(pclk1/(clkspeed*25U));
+            clkc = (uint32_t)(pclk1 / (clkspeed * 25U));
             I2C_CKCFG(i2c_periph) |= I2C_CKCFG_DTCY;
         }
-        if(0U == (clkc & I2C_CKCFG_CLKC)){
+        if(0U == (clkc & I2C_CKCFG_CLKC)) {
             /* the CLKC in fast mode minmum value is 1 */
-            clkc |= 0x0001U;  
+            clkc |= 0x0001U;
         }
         I2C_CKCFG(i2c_periph) |= I2C_CKCFG_FAST;
         I2C_CKCFG(i2c_periph) |= clkc;
-    }else{
+    } else {
     }
 }
 
 /*!
-    \brief    configure I2C address 
+    \brief      configure I2C address
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  mode:
                 only one parameter can be selected which is shown as below:
@@ -149,8 +154,8 @@ void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc)
       \arg        I2C_SMBUSMODE_ENABLE: SMBus mode
     \param[in]  addformat: 7bits or 10bits
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_ADDFORMAT_7BITS: 7bits
-      \arg        I2C_ADDFORMAT_10BITS: 10bits
+      \arg        I2C_ADDFORMAT_7BITS: address format is 7 bits
+      \arg        I2C_ADDFORMAT_10BITS: address format is 10 bits
     \param[in]  addr: I2C address
     \param[out] none
     \retval     none
@@ -159,9 +164,9 @@ void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat
 {
     /* SMBus/I2C mode selected */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SMBEN); 
+    ctl &= ~(I2C_CTL0_SMBEN);
     ctl |= mode;
     I2C_CTL0(i2c_periph) = ctl;
     /* configure address */
@@ -170,26 +175,26 @@ void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat
 }
 
 /*!
-    \brief    SMBus type selection
+    \brief      select SMBus type
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  type:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SMBUS_DEVICE: device
-      \arg        I2C_SMBUS_HOST: host
+      \arg        I2C_SMBUS_DEVICE: SMBus mode device type
+      \arg        I2C_SMBUS_HOST: SMBus mode host type
     \param[out] none
     \retval     none
 */
 void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type)
 {
-    if(I2C_SMBUS_HOST == type){
+    if(I2C_SMBUS_HOST == type) {
         I2C_CTL0(i2c_periph) |= I2C_CTL0_SMBSEL;
-    }else{
+    } else {
         I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_SMBSEL);
     }
 }
 
 /*!
-    \brief    whether or not to send an ACK
+    \brief      whether or not to send an ACK
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  ack:
                 only one parameter can be selected which is shown as below:
@@ -200,50 +205,51 @@ void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type)
 */
 void i2c_ack_config(uint32_t i2c_periph, uint32_t ack)
 {
-    if(I2C_ACK_ENABLE == ack){
-        I2C_CTL0(i2c_periph) |= I2C_CTL0_ACKEN;
-    }else{
-        I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_ACKEN);
-    }
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_ACKEN);
+    ctl |= ack;
+    I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    configure I2C POAP position
+    \brief      configure I2C POAP position
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  pos:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_ACKPOS_CURRENT: whether to send ACK or not for the current
-      \arg        I2C_ACKPOS_NEXT: whether to send ACK or not for the next byte
+      \arg        I2C_ACKPOS_CURRENT: ACKEN bit decides whether or not to send ACK or not for the current byte
+      \arg        I2C_ACKPOS_NEXT: ACKEN bit decides whether or not to send ACK for the next byte
     \param[out] none
     \retval     none
 */
 void i2c_ackpos_config(uint32_t i2c_periph, uint32_t pos)
 {
+    uint32_t ctl = 0U;
     /* configure I2C POAP position */
-    if(I2C_ACKPOS_NEXT == pos){
-        I2C_CTL0(i2c_periph) |= I2C_CTL0_POAP;
-    }else{
-        I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_POAP);
-    }
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_POAP);
+    ctl |= pos;
+    I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    master sends slave address
+    \brief      master sends slave address
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
-    \param[in]  addr: slave address  
+    \param[in]  addr: slave address
     \param[in]  trandirection: transmitter or receiver
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_TRANSMITTER: transmitter  
-      \arg        I2C_RECEIVER:    receiver  
+      \arg        I2C_TRANSMITTER: transmitter
+      \arg        I2C_RECEIVER: receiver
     \param[out] none
     \retval     none
 */
 void i2c_master_addressing(uint32_t i2c_periph, uint32_t addr, uint32_t trandirection)
 {
     /* master is a transmitter or a receiver */
-    if(I2C_TRANSMITTER == trandirection){
+    if(I2C_TRANSMITTER == trandirection) {
         addr = addr & I2C_TRANSMITTER;
-    }else{
+    } else {
         addr = addr | I2C_RECEIVER;
     }
     /* send slave address */
@@ -251,7 +257,7 @@ void i2c_master_addressing(uint32_t i2c_periph, uint32_t addr, uint32_t trandire
 }
 
 /*!
-    \brief    enable dual-address mode
+    \brief      enable dual-address mode
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  addr: the second address in dual-address mode
     \param[out] none
@@ -265,8 +271,8 @@ void i2c_dualaddr_enable(uint32_t i2c_periph, uint32_t addr)
 }
 
 /*!
-    \brief    disable dual-address mode
-    \param[in]  i2c_periph: I2Cx(x=0,1,2) 
+    \brief      disable dual-address mode
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
@@ -276,8 +282,8 @@ void i2c_dualaddr_disable(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    enable I2C
-    \param[in]  i2c_periph: I2Cx(x=0,1,2) 
+    \brief      enable I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
@@ -287,8 +293,8 @@ void i2c_enable(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    disable I2C
-    \param[in]  i2c_periph: I2Cx(x=0,1,2) 
+    \brief      disable I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
@@ -298,7 +304,7 @@ void i2c_disable(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    generate a START condition on I2C bus
+    \brief      generate a START condition on I2C bus
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
@@ -309,7 +315,7 @@ void i2c_start_on_bus(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    generate a STOP condition on I2C bus
+    \brief      generate a STOP condition on I2C bus
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
@@ -320,9 +326,9 @@ void i2c_stop_on_bus(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    I2C transmit data function
+    \brief      I2C transmit data function
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
-    \param[in]  data: data of transmission 
+    \param[in]  data: data of transmission
     \param[out] none
     \retval     none
 */
@@ -332,7 +338,7 @@ void i2c_data_transmit(uint32_t i2c_periph, uint8_t data)
 }
 
 /*!
-    \brief    I2C receive data function
+    \brief      I2C receive data function
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     data of received
@@ -343,28 +349,28 @@ uint8_t i2c_data_receive(uint32_t i2c_periph)
 }
 
 /*!
-    \brief    enable I2C DMA mode 
+    \brief      configure I2C DMA mode
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  dmastate:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_DMA_ON: DMA mode enable
-      \arg        I2C_DMA_OFF: DMA mode disable
+      \arg        I2C_DMA_ON: enable DMA mode
+      \arg        I2C_DMA_OFF: disable DMA mode
     \param[out] none
     \retval     none
 */
-void i2c_dma_enable(uint32_t i2c_periph, uint32_t dmastate)
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate)
 {
     /* configure I2C DMA function */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL1(i2c_periph);
-    ctl &= ~(I2C_CTL1_DMAON); 
+    ctl &= ~(I2C_CTL1_DMAON);
     ctl |= dmastate;
     I2C_CTL1(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    configure whether next DMA EOT is DMA last transfer or not
+    \brief      configure whether next DMA EOT is DMA last transfer or not
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  dmalast:
                 only one parameter can be selected which is shown as below:
@@ -377,36 +383,36 @@ void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast)
 {
     /* configure DMA last transfer */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL1(i2c_periph);
-    ctl &= ~(I2C_CTL1_DMALST); 
+    ctl &= ~(I2C_CTL1_DMALST);
     ctl |= dmalast;
     I2C_CTL1(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    whether to stretch SCL low when data is not ready in slave mode 
+    \brief      whether to stretch SCL low when data is not ready in slave mode
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  stretchpara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SCLSTRETCH_ENABLE: SCL stretching is enabled
-      \arg        I2C_SCLSTRETCH_DISABLE: SCL stretching is disabled
+      \arg        I2C_SCLSTRETCH_ENABLE: enable SCL stretching
+      \arg        I2C_SCLSTRETCH_DISABLE: disable SCL stretching
     \param[out] none
     \retval     none
 */
 void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara)
 {
-    /* configure I2C SCL strerching enable or disable */
+    /* configure I2C SCL strerching */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SS); 
+    ctl &= ~(I2C_CTL0_SS);
     ctl |= stretchpara;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    whether or not to response to a general call 
+    \brief      whether or not to response to a general call
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  gcallpara:
                 only one parameter can be selected which is shown as below:
@@ -419,15 +425,15 @@ void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara)
 {
     /* configure slave response to a general call enable or disable */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_GCEN); 
+    ctl &= ~(I2C_CTL0_GCEN);
     ctl |= gcallpara;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    software reset I2C 
+    \brief      configure software reset of I2C
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  sreset:
                 only one parameter can be selected which is shown as below:
@@ -440,28 +446,28 @@ void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset)
 {
     /* modify CTL0 and configure software reset I2C state */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SRESET); 
+    ctl &= ~(I2C_CTL0_SRESET);
     ctl |= sreset;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief    I2C PEC calculation on or off
+    \brief      configure I2C PEC calculation
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  pecstate:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_PEC_ENABLE: PEC calculation on 
-      \arg        I2C_PEC_DISABLE: PEC calculation off 
+      \arg        I2C_PEC_ENABLE: PEC calculation on
+      \arg        I2C_PEC_DISABLE: PEC calculation off
     \param[out] none
     \retval     none
 */
-void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate)
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate)
 {
     /* on/off PEC calculation */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_PECEN);
     ctl |= pecstate;
@@ -469,20 +475,20 @@ void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate)
 }
 
 /*!
-    \brief    I2C whether to transfer PEC value
+    \brief      configure whether to transfer PEC value
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  pecpara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_PECTRANS_ENABLE: transfer PEC 
-      \arg        I2C_PECTRANS_DISABLE: not transfer PEC 
+      \arg        I2C_PECTRANS_ENABLE: transfer PEC value
+      \arg        I2C_PECTRANS_DISABLE: not transfer PEC value
     \param[out] none
     \retval     none
 */
-void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara)
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara)
 {
     /* whether to transfer PEC */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_PECTRANS);
     ctl |= pecpara;
@@ -490,31 +496,31 @@ void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara)
 }
 
 /*!
-    \brief    get packet error checking value 
+    \brief      get packet error checking value
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     PEC value
 */
 uint8_t i2c_pec_value_get(uint32_t i2c_periph)
 {
-    return (uint8_t)((I2C_STAT1(i2c_periph) & I2C_STAT1_PECV)>>STAT1_PECV_OFFSET);
+    return (uint8_t)((I2C_STAT1(i2c_periph) & I2C_STAT1_PECV) >> STAT1_PECV_OFFSET);
 }
 
 /*!
-    \brief    I2C issue alert through SMBA pin 
+    \brief      configure I2C alert through SMBA pin
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  smbuspara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SALTSEND_ENABLE: issue alert through SMBA pin 
-      \arg        I2C_SALTSEND_DISABLE: not issue alert through SMBA pin 
+      \arg        I2C_SALTSEND_ENABLE: issue alert through SMBA pin
+      \arg        I2C_SALTSEND_DISABLE: not issue alert through SMBA pin
     \param[out] none
     \retval     none
 */
-void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara)
 {
-    /* issue alert through SMBA pin configure*/
+    /* configure smubus alert through SMBA pin */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_SALT);
     ctl |= smbuspara;
@@ -522,7 +528,7 @@ void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
 }
 
 /*!
-    \brief    enable or disable I2C ARP protocol in SMBus switch
+    \brief      configure I2C ARP protocol in SMBus
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  arpstate:
                 only one parameter can be selected which is shown as below:
@@ -531,11 +537,11 @@ void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
     \param[out] none
     \retval     none
 */
-void i2c_smbus_arp_enable(uint32_t i2c_periph, uint32_t arpstate)
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate)
 {
     /* enable or disable I2C ARP protocol*/
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_ARPEN);
     ctl |= arpstate;
@@ -543,105 +549,122 @@ void i2c_smbus_arp_enable(uint32_t i2c_periph, uint32_t arpstate)
 }
 
 /*!
-    \brief    analog noise filter disable
+    \brief      disable analog noise filter
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_analog_noise_filter_disable(uint32_t i2c_periph)
 {
-    I2C_FCTL(i2c_periph) |= I2C_FCTL_AFD;  
+    I2C_FCTL(i2c_periph) |= I2C_FCTL_AFD;
 }
 
 /*!
-    \brief    analog noise filter enable
+    \brief      enable analog noise filter
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_analog_noise_filter_enable(uint32_t i2c_periph)
 {
-    I2C_FCTL(i2c_periph) &= ~(I2C_FCTL_AFD);  
+    I2C_FCTL(i2c_periph) &= ~(I2C_FCTL_AFD);
 }
 
 /*!
-    \brief    digital noise filter configuration
+    \brief      configure digital noise filter
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
-    \param[in]  dfilterpara: refer to enum i2c_digital_filter_enum
+    \param[in]  dfilterpara: refer to i2c_digital_filter_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_DF_DISABLE: disable digital noise filter
+      \arg        I2C_DF_1PCLK: enable digital noise filter and the maximum filtered spiker's length 1 PCLK1
+      \arg        I2C_DF_2PCLK: enable digital noise filter and the maximum filtered spiker's length 2 PCLK1
+      \arg        I2C_DF_3PCLK: enable digital noise filter and the maximum filtered spiker's length 3 PCLK1
+      \arg        I2C_DF_4PCLK: enable digital noise filter and the maximum filtered spiker's length 4 PCLK1
+      \arg        I2C_DF_5PCLK: enable digital noise filter and the maximum filtered spiker's length 5 PCLK1
+      \arg        I2C_DF_6PCLK: enable digital noise filter and the maximum filtered spiker's length 6 PCLK1
+      \arg        I2C_DF_7PCLK: enable digital noise filter and the maximum filtered spiker's length 7 PCLK1
+      \arg        I2C_DF_8PCLK: enable digital noise filter and the maximum filtered spiker's length 8 PCLK1
+      \arg        I2C_DF_9PCLK: enable digital noise filter and the maximum filtered spiker's length 9 PCLK1
+      \arg        I2C_DF_10PCLK: enable digital noise filter and the maximum filtered spiker's length 10 PCLK1
+      \arg        I2C_DF_11CLK: enable digital noise filter and the maximum filtered spiker's length 11 PCLK1
+      \arg        I2C_DF_12CLK: enable digital noise filter and the maximum filtered spiker's length 12 PCLK1
+      \arg        I2C_DF_13PCLK: enable digital noise filter and the maximum filtered spiker's length 13 PCLK1
+      \arg        I2C_DF_14PCLK: enable digital noise filter and the maximum filtered spiker's length 14 PCLK1
+      \arg        I2C_DF_15PCLK: enable digital noise filter and the maximum filtered spiker's length 15 PCLK1
     \param[out] none
     \retval     none
 */
-void i2c_digital_noise_filter_config(uint32_t i2c_periph,i2c_digital_filter_enum dfilterpara)
+void i2c_digital_noise_filter_config(uint32_t i2c_periph, i2c_digital_filter_enum dfilterpara)
 {
-    I2C_FCTL(i2c_periph) |= dfilterpara;  
+    I2C_FCTL(i2c_periph) |= dfilterpara;
 }
 
 /*!
-    \brief    enable SAM_V interface
+    \brief      enable SAM_V interface
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_sam_enable(uint32_t i2c_periph)
 {
-    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_SAMEN;  
+    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_SAMEN;
 }
 
 /*!
-    \brief    disable SAM_V interface
+    \brief      disable SAM_V interface
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_sam_disable(uint32_t i2c_periph)
 {
-    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_SAMEN);  
+    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_SAMEN);
 }
 
 /*!
-    \brief    enable SAM_V interface timeout detect
+    \brief      enable SAM_V interface timeout detect
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_sam_timeout_enable(uint32_t i2c_periph)
 {
-    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_STOEN;  
+    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_STOEN;
 }
 
 /*!
-    \brief    disable SAM_V interface timeout detect
+    \brief      disable SAM_V interface timeout detect
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[out] none
     \retval     none
 */
 void i2c_sam_timeout_disable(uint32_t i2c_periph)
 {
-    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_STOEN);  
+    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_STOEN);
 }
 
 /*!
-    \brief    check I2C flag is set or not
+    \brief      get I2C flag status
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  flag: I2C flags, refer to i2c_flag_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_FLAG_SBSEND: start condition send out 
+      \arg        I2C_FLAG_SBSEND: start condition sent out in master mode
       \arg        I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
       \arg        I2C_FLAG_BTC: byte transmission finishes
       \arg        I2C_FLAG_ADD10SEND: header of 10-bit address is sent in master mode
       \arg        I2C_FLAG_STPDET: stop condition detected in slave mode
-      \arg        I2C_FLAG_RBNE: I2C_DATA is not Empty during receiving
+      \arg        I2C_FLAG_RBNE: I2C_DATA is not empty during receiving
       \arg        I2C_FLAG_TBE: I2C_DATA is empty during transmitting
       \arg        I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
       \arg        I2C_FLAG_LOSTARB: arbitration lost in master mode
       \arg        I2C_FLAG_AERR: acknowledge error
-      \arg        I2C_FLAG_OUERR: overrun or underrun situation occurs in slave mode
+      \arg        I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
       \arg        I2C_FLAG_PECERR: PEC error when receiving data
       \arg        I2C_FLAG_SMBTO: timeout signal in SMBus mode
       \arg        I2C_FLAG_SMBALT: SMBus alert status
       \arg        I2C_FLAG_MASTER: a flag indicating whether I2C block is in master or slave mode
       \arg        I2C_FLAG_I2CBSY: busy flag
-      \arg        I2C_FLAG_TRS: whether the I2C is a transmitter or a receiver
+      \arg        I2C_FLAG_TR: whether the I2C is a transmitter or a receiver
       \arg        I2C_FLAG_RXGC: general call address (00h) received
       \arg        I2C_FLAG_DEFSMB: default address of SMBus device
       \arg        I2C_FLAG_HSTSMB: SMBus host header detected in slave mode
@@ -655,26 +678,26 @@ void i2c_sam_timeout_disable(uint32_t i2c_periph)
 */
 FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag)
 {
-    if(RESET != (I2C_REG_VAL(i2c_periph, flag) & BIT(I2C_BIT_POS(flag)))){
+    if(RESET != (I2C_REG_VAL(i2c_periph, flag) & BIT(I2C_BIT_POS(flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear I2C flag
+    \brief      clear I2C flag status
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  flag: I2C flags, refer to i2c_flag_enum
                 only one parameter can be selected which is shown as below:
-      \arg       I2C_FLAG_SMBALT: SMBus Alert status
+      \arg       I2C_FLAG_SMBALT: SMBus alert status
       \arg       I2C_FLAG_SMBTO: timeout signal in SMBus mode
       \arg       I2C_FLAG_PECERR: PEC error when receiving data
       \arg       I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
       \arg       I2C_FLAG_AERR: acknowledge error
-      \arg       I2C_FLAG_LOSTARB: arbitration lost in master mode   
-      \arg       I2C_FLAG_BERR: a bus error   
-      \arg       I2C_FLAG_ADDSEND: cleared by reading I2C_STAT0 and reading I2C_STAT1
+      \arg       I2C_FLAG_LOSTARB: arbitration lost in master mode
+      \arg       I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
+      \arg       I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
       \arg       I2C_FLAG_TFF: txframe fall flag
       \arg       I2C_FLAG_TFR: txframe rise flag
       \arg       I2C_FLAG_RFF: rxframe fall flag
@@ -684,27 +707,27 @@ FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag)
 */
 void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag)
 {
-    if(I2C_FLAG_ADDSEND == flag){
+    if(I2C_FLAG_ADDSEND == flag) {
         /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
         I2C_STAT0(i2c_periph);
         I2C_STAT1(i2c_periph);
-    }else{
+    } else {
         I2C_REG_VAL(i2c_periph, flag) &= ~BIT(I2C_BIT_POS(flag));
     }
 }
 
 /*!
-    \brief    enable I2C interrupt
+    \brief      enable I2C interrupt
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_INT_ERR: error interrupt enable 
-      \arg        I2C_INT_EV: event interrupt enable 
-      \arg        I2C_INT_BUF: buffer interrupt enable
-      \arg        I2C_INT_TFF: txframe fall interrupt enable
-      \arg        I2C_INT_TFR: txframe rise interrupt enable
-      \arg        I2C_INT_RFF: rxframe fall interrupt enable
-      \arg        I2C_INT_RFR: rxframe rise interrupt enable
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
     \param[out] none
     \retval     none
 */
@@ -714,17 +737,17 @@ void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 }
 
 /*!
-    \brief    disable I2C interrupt
+    \brief      disable I2C interrupt
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
-    \param[in]  interrupt: I2C interrupts, refer to i2c_flag_enum
+    \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_INT_ERR: error interrupt enable 
-      \arg        I2C_INT_EV: event interrupt enable 
-      \arg        I2C_INT_BUF: buffer interrupt enable
-      \arg        I2C_INT_TFF: txframe fall interrupt enable
-      \arg        I2C_INT_TFR: txframe rise interrupt enable
-      \arg        I2C_INT_RFF: rxframe fall interrupt enable
-      \arg        I2C_INT_RFR: rxframe rise interrupt enable
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
     \param[out] none
     \retval     none
 */
@@ -734,15 +757,15 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 }
 
 /*!
-    \brief    check I2C interrupt flag
+    \brief      get I2C interrupt flag status
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
                 only one parameter can be selected which is shown as below:
       \arg        I2C_INT_FLAG_SBSEND: start condition sent out in master mode interrupt flag
       \arg        I2C_INT_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode interrupt flag
-      \arg        I2C_INT_FLAG_BTC: byte transmission finishes
+      \arg        I2C_INT_FLAG_BTC: byte transmission finishes interrupt flag
       \arg        I2C_INT_FLAG_ADD10SEND: header of 10-bit address is sent in master mode interrupt flag
-      \arg        I2C_INT_FLAG_STPDET: etop condition detected in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_STPDET: stop condition detected in slave mode interrupt flag
       \arg        I2C_INT_FLAG_RBNE: I2C_DATA is not Empty during receiving interrupt flag
       \arg        I2C_INT_FLAG_TBE: I2C_DATA is empty during transmitting interrupt flag
       \arg        I2C_INT_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag
@@ -751,7 +774,7 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
       \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
       \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
       \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
-      \arg        I2C_INT_FLAG_SMBALT: SMBus Alert status interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
       \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
       \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
       \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag
@@ -762,31 +785,31 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
 {
     uint32_t intenable = 0U, flagstatus = 0U, bufie;
-    
+
     /* check BUFIE */
     bufie = I2C_CTL1(i2c_periph)&I2C_CTL1_BUFIE;
-    
+
     /* get the interrupt enable bit status */
     intenable = (I2C_REG_VAL(i2c_periph, int_flag) & BIT(I2C_BIT_POS(int_flag)));
     /* get the corresponding flag bit status */
     flagstatus = (I2C_REG_VAL2(i2c_periph, int_flag) & BIT(I2C_BIT_POS2(int_flag)));
 
-    if((I2C_INT_FLAG_RBNE == int_flag) || (I2C_INT_FLAG_TBE == int_flag)){
-        if(intenable && bufie){
-            intenable = 1U;                       
-        }else{
+    if((I2C_INT_FLAG_RBNE == int_flag) || (I2C_INT_FLAG_TBE == int_flag)) {
+        if(intenable && bufie) {
+            intenable = 1U;
+        } else {
             intenable = 0U;
         }
     }
-    if((0U != flagstatus) && (0U != intenable)){
+    if((0U != flagstatus) && (0U != intenable)) {
         return SET;
-    }else{
-        return RESET; 
+    } else {
+        return RESET;
     }
 }
 
 /*!
-    \brief    clear I2C interrupt flag
+    \brief      clear I2C interrupt flag status
     \param[in]  i2c_periph: I2Cx(x=0,1,2)
     \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
                 only one parameter can be selected which is shown as below:
@@ -797,7 +820,7 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
       \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
       \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
       \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
-      \arg        I2C_INT_FLAG_SMBALT: SMBus Alert status interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
       \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
       \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
       \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag
@@ -807,11 +830,11 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
 */
 void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
 {
-    if(I2C_INT_FLAG_ADDSEND == int_flag){
+    if(I2C_INT_FLAG_ADDSEND == int_flag) {
         /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
         I2C_STAT0(i2c_periph);
         I2C_STAT1(i2c_periph);
-    }else{
+    } else {
         I2C_REG_VAL2(i2c_periph, int_flag) &= ~BIT(I2C_BIT_POS2(int_flag));
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_i2c.c
@@ -39,8 +39,6 @@ OF SUCH DAMAGE.
 #include "gd32f4xx_i2c.h"
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x0000003CU)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_ipa.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_ipa.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_ipa.c
     \brief   IPA driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -130,8 +131,8 @@ void ipa_background_lut_loading_enable(void)
     \brief    set pixel format convert mode, the function is invalid when the IPA transfer is enabled
     \param[in]  pfcm: pixel format convert mode
                 only one parameter can be selected which is shown as below:
-      \arg        IPA_FGTODE: foreground memory to destination memory without pixel format convert 
-      \arg        IPA_FGTODE_PF_CONVERT: foreground memory to destination memory with pixel format convert 
+      \arg        IPA_FGTODE: foreground memory to destination memory without pixel format convert
+      \arg        IPA_FGTODE_PF_CONVERT: foreground memory to destination memory with pixel format convert
       \arg        IPA_FGBGTODE: blending foreground and background memory to destination memory
       \arg        IPA_FILL_UP_DE: fill up destination memory with specific color
     \param[out] none
@@ -139,27 +140,28 @@ void ipa_background_lut_loading_enable(void)
 */
 void ipa_pixel_format_convert_mode_set(uint32_t pfcm)
 {
+    IPA_CTL &= ~(IPA_CTL_PFCM);
     IPA_CTL |= pfcm;
 }
 
 /*!
-    \brief    initialize the structure of IPA foreground parameter struct with the default values, it is 
+    \brief    initialize the structure of IPA foreground parameter struct with the default values, it is
                 suggested that call this function after an ipa_foreground_parameter_struct structure is defined
     \param[in]  none
     \param[out] foreground_struct: the data needed to initialize foreground
                   foreground_memaddr: foreground memory base address
                   foreground_lineoff: foreground line offset
-                  foreground_prealpha: foreground pre-defined alpha value 
+                  foreground_prealpha: foreground pre-defined alpha value
                   foreground_alpha_algorithm: IPA_FG_ALPHA_MODE_0,IPA_FG_ALPHA_MODE_1,IPA_FG_ALPHA_MODE_2
                   foreground_pf: foreground pixel format(FOREGROUND_PPF_ARGB8888,FOREGROUND_PPF_RGB888,FOREGROUND_PPF_RGB565,
                             FOREGROUND_PPF_ARG1555,FOREGROUND_PPF_ARGB4444,FOREGROUND_PPF_L8,FOREGROUND_PPF_AL44,
                             FOREGROUND_PPF_AL88,FOREGROUND_PPF_L4,FOREGROUND_PPF_A8,FOREGROUND_PPF_A4)
                   foreground_prered: foreground pre-defined red value
-                  foreground_pregreen: foreground pre-defined green value 
+                  foreground_pregreen: foreground pre-defined green value
                   foreground_preblue: foreground pre-defined blue value
     \retval     none
 */
-void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct* foreground_struct)
+void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct *foreground_struct)
 {
     /* initialize the struct parameters with default values */
     foreground_struct->foreground_memaddr = IPA_DEFAULT_VALUE;
@@ -188,15 +190,15 @@ void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct* foreground
     \param[out] none
     \retval     none
 */
-void ipa_foreground_init(ipa_foreground_parameter_struct* foreground_struct)
+void ipa_foreground_init(ipa_foreground_parameter_struct *foreground_struct)
 {
     FlagStatus tempflag = RESET;
-    if(RESET != (IPA_CTL & IPA_CTL_TEN)){
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
         tempflag = SET;
         /* reset the TEN in order to configure the following bits */
         IPA_CTL &= ~IPA_CTL_TEN;
     }
-    
+
     /* foreground memory base address configuration */
     IPA_FMADDR &= ~(IPA_FMADDR_FMADDR);
     IPA_FMADDR = foreground_struct->foreground_memaddr;
@@ -204,23 +206,23 @@ void ipa_foreground_init(ipa_foreground_parameter_struct* foreground_struct)
     IPA_FLOFF &= ~(IPA_FLOFF_FLOFF);
     IPA_FLOFF = foreground_struct->foreground_lineoff;
     /* foreground pixel format pre-defined alpha, alpha calculation algorithm configuration */
-    IPA_FPCTL &= ~(IPA_FPCTL_FPDAV|IPA_FPCTL_FAVCA|IPA_FPCTL_FPF);
-    IPA_FPCTL |= (foreground_struct->foreground_prealpha<<24U);
+    IPA_FPCTL &= ~(IPA_FPCTL_FPDAV | IPA_FPCTL_FAVCA | IPA_FPCTL_FPF);
+    IPA_FPCTL |= (foreground_struct->foreground_prealpha << 24U);
     IPA_FPCTL |= foreground_struct->foreground_alpha_algorithm;
     IPA_FPCTL |= foreground_struct->foreground_pf;
     /* foreground pre-defined red green blue configuration */
-    IPA_FPV &= ~(IPA_FPV_FPDRV|IPA_FPV_FPDGV|IPA_FPV_FPDBV);
-    IPA_FPV |= ((foreground_struct->foreground_prered<<16U)|(foreground_struct->foreground_pregreen<<8U)
-                  |(foreground_struct->foreground_preblue));
-    
-    if(SET == tempflag){
+    IPA_FPV &= ~(IPA_FPV_FPDRV | IPA_FPV_FPDGV | IPA_FPV_FPDBV);
+    IPA_FPV |= ((foreground_struct->foreground_prered << 16U) | (foreground_struct->foreground_pregreen << 8U)
+                | (foreground_struct->foreground_preblue));
+
+    if(SET == tempflag) {
         /* restore the state of TEN */
         IPA_CTL |= IPA_CTL_TEN;
     }
 }
 
 /*!
-    \brief    initialize the structure of IPA background parameter struct with the default values, it is 
+    \brief    initialize the structure of IPA background parameter struct with the default values, it is
                 suggested that call this function after an ipa_background_parameter_struct structure is defined
     \param[in]  none
     \param[out] background_struct: the data needed to initialize background
@@ -236,7 +238,7 @@ void ipa_foreground_init(ipa_foreground_parameter_struct* foreground_struct)
                   background_preblue: background pre-defined blue value
     \retval     none
 */
-void ipa_background_struct_para_init(ipa_background_parameter_struct* background_struct)
+void ipa_background_struct_para_init(ipa_background_parameter_struct *background_struct)
 {
     /* initialize the struct parameters with default values */
     background_struct->background_memaddr = IPA_DEFAULT_VALUE;
@@ -265,15 +267,15 @@ void ipa_background_struct_para_init(ipa_background_parameter_struct* background
     \param[out] none
     \retval     none
 */
-void ipa_background_init(ipa_background_parameter_struct* background_struct)
+void ipa_background_init(ipa_background_parameter_struct *background_struct)
 {
     FlagStatus tempflag = RESET;
-    if(RESET != (IPA_CTL & IPA_CTL_TEN)){
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
         tempflag = SET;
         /* reset the TEN in order to configure the following bits */
         IPA_CTL &= ~IPA_CTL_TEN;
     }
-    
+
     /* background memory base address configuration */
     IPA_BMADDR &= ~(IPA_BMADDR_BMADDR);
     IPA_BMADDR = background_struct->background_memaddr;
@@ -281,23 +283,23 @@ void ipa_background_init(ipa_background_parameter_struct* background_struct)
     IPA_BLOFF &= ~(IPA_BLOFF_BLOFF);
     IPA_BLOFF = background_struct->background_lineoff;
     /* background pixel format pre-defined alpha, alpha calculation algorithm configuration */
-    IPA_BPCTL &= ~(IPA_BPCTL_BPDAV|IPA_BPCTL_BAVCA|IPA_BPCTL_BPF);
-    IPA_BPCTL |= (background_struct->background_prealpha<<24U);
+    IPA_BPCTL &= ~(IPA_BPCTL_BPDAV | IPA_BPCTL_BAVCA | IPA_BPCTL_BPF);
+    IPA_BPCTL |= (background_struct->background_prealpha << 24U);
     IPA_BPCTL |= background_struct->background_alpha_algorithm;
-    IPA_BPCTL |= background_struct->background_pf; 
+    IPA_BPCTL |= background_struct->background_pf;
     /* background pre-defined red green blue configuration */
-    IPA_BPV &= ~(IPA_BPV_BPDRV|IPA_BPV_BPDGV|IPA_BPV_BPDBV);
-    IPA_BPV |= ((background_struct->background_prered<<16U)|(background_struct->background_pregreen<<8U)
-                  |(background_struct->background_preblue));
-    
-    if(SET == tempflag){
+    IPA_BPV &= ~(IPA_BPV_BPDRV | IPA_BPV_BPDGV | IPA_BPV_BPDBV);
+    IPA_BPV |= ((background_struct->background_prered << 16U) | (background_struct->background_pregreen << 8U)
+                | (background_struct->background_preblue));
+
+    if(SET == tempflag) {
         /* restore the state of TEN */
         IPA_CTL |= IPA_CTL_TEN;
     }
 }
 
 /*!
-    \brief    initialize the structure of IPA destination parameter struct with the default values, it is 
+    \brief    initialize the structure of IPA destination parameter struct with the default values, it is
                 suggested that call this function after an ipa_destination_parameter_struct structure is defined
     \param[in]  none
     \param[out] destination_struct: the data needed to initialize destination parameter
@@ -313,7 +315,7 @@ void ipa_background_init(ipa_background_parameter_struct* background_struct)
                   image_height: height of the image to be processed
     \retval     none
 */
-void ipa_destination_struct_para_init(ipa_destination_parameter_struct* destination_struct)
+void ipa_destination_struct_para_init(ipa_destination_parameter_struct *destination_struct)
 {
     /* initialize the struct parameters with default values */
     destination_struct->destination_pf = IPA_DPF_ARGB8888;
@@ -343,53 +345,53 @@ void ipa_destination_struct_para_init(ipa_destination_parameter_struct* destinat
     \param[out] none
     \retval     none
 */
-void ipa_destination_init(ipa_destination_parameter_struct* destination_struct)
+void ipa_destination_init(ipa_destination_parameter_struct *destination_struct)
 {
     uint32_t destination_pixelformat;
     FlagStatus tempflag = RESET;
-    if(RESET != (IPA_CTL & IPA_CTL_TEN)){
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
         tempflag = SET;
         /* reset the TEN in order to configure the following bits */
         IPA_CTL &= ~IPA_CTL_TEN;
     }
-    
+
     /* destination pixel format configuration */
     IPA_DPCTL &= ~(IPA_DPCTL_DPF);
     IPA_DPCTL = destination_struct->destination_pf;
     destination_pixelformat = destination_struct->destination_pf;
     /* destination pixel format ARGB8888 */
-    switch(destination_pixelformat){
+    switch(destination_pixelformat) {
     case IPA_DPF_ARGB8888:
-        IPA_DPV &= ~(IPA_DPV_DPDBV_0|(IPA_DPV_DPDGV_0)|(IPA_DPV_DPDRV_0)|(IPA_DPV_DPDAV_0));
-        IPA_DPV = (destination_struct->destination_preblue|(destination_struct->destination_pregreen<<8U)
-                                                            |(destination_struct->destination_prered<<16U)
-                                                            |(destination_struct->destination_prealpha<<24U));
+        IPA_DPV &= ~(IPA_DPV_DPDBV_0 | (IPA_DPV_DPDGV_0) | (IPA_DPV_DPDRV_0) | (IPA_DPV_DPDAV_0));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 8U)
+                   | (destination_struct->destination_prered << 16U)
+                   | (destination_struct->destination_prealpha << 24U));
         break;
     /* destination pixel format RGB888 */
     case IPA_DPF_RGB888:
-        IPA_DPV &= ~(IPA_DPV_DPDBV_1|(IPA_DPV_DPDGV_1)|(IPA_DPV_DPDRV_1));
-        IPA_DPV = (destination_struct->destination_preblue|(destination_struct->destination_pregreen<<8U)
-                                                            |(destination_struct->destination_prered<<16U));
+        IPA_DPV &= ~(IPA_DPV_DPDBV_1 | (IPA_DPV_DPDGV_1) | (IPA_DPV_DPDRV_1));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 8U)
+                   | (destination_struct->destination_prered << 16U));
         break;
     /* destination pixel format RGB565 */
     case IPA_DPF_RGB565:
-        IPA_DPV &= ~(IPA_DPV_DPDBV_2|(IPA_DPV_DPDGV_2)|(IPA_DPV_DPDRV_2));
-        IPA_DPV = (destination_struct->destination_preblue|(destination_struct->destination_pregreen<<5U)
-                                                            |(destination_struct->destination_prered<<11U));
+        IPA_DPV &= ~(IPA_DPV_DPDBV_2 | (IPA_DPV_DPDGV_2) | (IPA_DPV_DPDRV_2));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 5U)
+                   | (destination_struct->destination_prered << 11U));
         break;
     /* destination pixel format ARGB1555 */
     case IPA_DPF_ARGB1555:
-        IPA_DPV &= ~(IPA_DPV_DPDBV_3|(IPA_DPV_DPDGV_3)|(IPA_DPV_DPDRV_3)|(IPA_DPV_DPDAV_3));
-        IPA_DPV = (destination_struct->destination_preblue|(destination_struct->destination_pregreen<<5U)
-                                                            |(destination_struct->destination_prered<<10U)
-                                                            |(destination_struct->destination_prealpha<<15U));
+        IPA_DPV &= ~(IPA_DPV_DPDBV_3 | (IPA_DPV_DPDGV_3) | (IPA_DPV_DPDRV_3) | (IPA_DPV_DPDAV_3));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 5U)
+                   | (destination_struct->destination_prered << 10U)
+                   | (destination_struct->destination_prealpha << 15U));
         break;
     /* destination pixel format ARGB4444 */
     case IPA_DPF_ARGB4444:
-        IPA_DPV &= ~(IPA_DPV_DPDBV_4|(IPA_DPV_DPDGV_4)|(IPA_DPV_DPDRV_4)|(IPA_DPV_DPDAV_4));
-        IPA_DPV = (destination_struct->destination_preblue|(destination_struct->destination_pregreen<<4U)
-                                                            |(destination_struct->destination_prered<<8U)
-                                                            |(destination_struct->destination_prealpha<<12U));
+        IPA_DPV &= ~(IPA_DPV_DPDBV_4 | (IPA_DPV_DPDGV_4) | (IPA_DPV_DPDRV_4) | (IPA_DPV_DPDAV_4));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 4U)
+                   | (destination_struct->destination_prered << 8U)
+                   | (destination_struct->destination_prealpha << 12U));
         break;
     default:
         break;
@@ -399,12 +401,12 @@ void ipa_destination_init(ipa_destination_parameter_struct* destination_struct)
     IPA_DMADDR = destination_struct->destination_memaddr;
     /* destination line offset configuration */
     IPA_DLOFF &= ~(IPA_DLOFF_DLOFF);
-    IPA_DLOFF =destination_struct->destination_lineoff;
+    IPA_DLOFF = destination_struct->destination_lineoff;
     /* image size configuration */
-    IPA_IMS &= ~(IPA_IMS_HEIGHT|IPA_IMS_WIDTH);
-    IPA_IMS |= ((destination_struct->image_width<<16U)|(destination_struct->image_height));
-    
-    if(SET == tempflag){
+    IPA_IMS &= ~(IPA_IMS_HEIGHT | IPA_IMS_WIDTH);
+    IPA_IMS |= ((destination_struct->image_width << 16U) | (destination_struct->image_height));
+
+    if(SET == tempflag) {
         /* restore the state of TEN */
         IPA_CTL |= IPA_CTL_TEN;
     }
@@ -421,25 +423,25 @@ void ipa_destination_init(ipa_destination_parameter_struct* destination_struct)
 void ipa_foreground_lut_init(uint8_t fg_lut_num, uint8_t fg_lut_pf, uint32_t fg_lut_addr)
 {
     FlagStatus tempflag = RESET;
-    if(RESET != (IPA_FPCTL & IPA_FPCTL_FLLEN)){
+    if(RESET != (IPA_FPCTL & IPA_FPCTL_FLLEN)) {
         tempflag = SET;
         /* reset the FLLEN in order to configure the following bits */
         IPA_FPCTL &= ~IPA_FPCTL_FLLEN;
     }
-    
+
     /* foreground LUT number of pixel configuration */
-    IPA_FPCTL |= ((uint32_t)fg_lut_num<<8U);
+    IPA_FPCTL |= ((uint32_t)fg_lut_num << 8U);
     /* foreground LUT pixel format configuration */
-    if(IPA_LUT_PF_RGB888 == fg_lut_pf){
+    if(IPA_LUT_PF_RGB888 == fg_lut_pf) {
         IPA_FPCTL |= IPA_FPCTL_FLPF;
-    }else{
+    } else {
         IPA_FPCTL &= ~(IPA_FPCTL_FLPF);
     }
     /* foreground LUT memory base address configuration */
     IPA_FLMADDR &= ~(IPA_FLMADDR_FLMADDR);
     IPA_FLMADDR = fg_lut_addr;
-    
-    if(SET == tempflag){
+
+    if(SET == tempflag) {
         /* restore the state of FLLEN */
         IPA_FPCTL |= IPA_FPCTL_FLLEN;
     }
@@ -456,25 +458,25 @@ void ipa_foreground_lut_init(uint8_t fg_lut_num, uint8_t fg_lut_pf, uint32_t fg_
 void ipa_background_lut_init(uint8_t bg_lut_num, uint8_t bg_lut_pf, uint32_t bg_lut_addr)
 {
     FlagStatus tempflag = RESET;
-    if(RESET != (IPA_BPCTL & IPA_BPCTL_BLLEN)){
+    if(RESET != (IPA_BPCTL & IPA_BPCTL_BLLEN)) {
         tempflag = SET;
         /* reset the BLLEN in order to configure the following bits */
         IPA_BPCTL &= ~IPA_BPCTL_BLLEN;
     }
-    
+
     /* background LUT number of pixel configuration */
-    IPA_BPCTL |= ((uint32_t)bg_lut_num<<8U);
+    IPA_BPCTL |= ((uint32_t)bg_lut_num << 8U);
     /* background LUT pixel format configuration */
-    if(IPA_LUT_PF_RGB888 == bg_lut_pf){
+    if(IPA_LUT_PF_RGB888 == bg_lut_pf) {
         IPA_BPCTL |= IPA_BPCTL_BLPF;
-    }else{
+    } else {
         IPA_BPCTL &= ~(IPA_BPCTL_BLPF);
     }
     /* background LUT memory base address configuration */
     IPA_BLMADDR &= ~(IPA_BLMADDR_BLMADDR);
     IPA_BLMADDR = bg_lut_addr;
-    
-    if(SET == tempflag){
+
+    if(SET == tempflag) {
         /* restore the state of BLLEN */
         IPA_BPCTL |= IPA_BPCTL_BLLEN;
     }
@@ -500,9 +502,9 @@ void ipa_line_mark_config(uint16_t line_num)
 */
 void ipa_inter_timer_config(uint8_t timer_cfg)
 {
-    if(IPA_INTER_TIMER_ENABLE == timer_cfg){
+    if(IPA_INTER_TIMER_ENABLE == timer_cfg) {
         IPA_ITCTL |= IPA_ITCTL_ITEN;
-    }else{
+    } else {
         IPA_ITCTL &= ~(IPA_ITCTL_ITEN);
     }
 }
@@ -517,7 +519,7 @@ void ipa_interval_clock_num_config(uint8_t clk_num)
 {
     /* NCCI[7:0] bits have no meaning if ITEN is '0' */
     IPA_ITCTL &= ~(IPA_ITCTL_NCCI);
-    IPA_ITCTL |= ((uint32_t)clk_num<<8U);
+    IPA_ITCTL |= ((uint32_t)clk_num << 8U);
 }
 
 /*!
@@ -535,9 +537,9 @@ void ipa_interval_clock_num_config(uint8_t clk_num)
 */
 FlagStatus ipa_flag_get(uint32_t flag)
 {
-    if(RESET != (IPA_INTF & flag)){
+    if(RESET != (IPA_INTF & flag)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -611,9 +613,9 @@ void ipa_interrupt_disable(uint32_t int_flag)
 */
 FlagStatus ipa_interrupt_flag_get(uint32_t int_flag)
 {
-    if(0U != (IPA_INTF & int_flag)){
+    if(0U != (IPA_INTF & int_flag)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_iref.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_iref.c
@@ -5,39 +5,40 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_iref.h"
 
 /*!
-    \brief    deinit IREF
+    \brief      deinitialize IREF
     \param[in]  none
     \param[out] none
     \retval     none
@@ -60,7 +61,7 @@ void iref_enable(void)
 }
 
 /*!
-    \brief    disable IREF
+    \brief      disable IREF
     \param[in]  none
     \param[out] none
     \retval     none
@@ -71,7 +72,7 @@ void iref_disable(void)
 }
 
 /*!
-    \brief    set IREF mode
+    \brief      set IREF mode
     \param[in]  step
       \arg        IREF_MODE_LOW_POWER: 1uA step
       \arg        IREF_MODE_HIGH_CURRENT: 8uA step
@@ -85,7 +86,7 @@ void iref_mode_set(uint32_t step)
 }
 
 /*!
-    \brief    set IREF precision_trim_value
+    \brief      set IREF precision_trim_value
     \param[in]  precisiontrim
       \arg        IREF_CUR_PRECISION_TRIM_X(x=0..31): (-15+ x)%
     \param[out] none
@@ -98,7 +99,7 @@ void iref_precision_trim_value_set(uint32_t precisiontrim)
 }
 
 /*!
-    \brief    set IREF sink mode
+    \brief      set IREF sink mode
     \param[in]  sinkmode
       \arg        IREF_SOURCE_CURRENT : source current.
       \arg        IREF_SINK_CURRENT: sink current
@@ -112,7 +113,7 @@ void iref_sink_set(uint32_t sinkmode)
 }
 
 /*!
-    \brief    set IREF step data 
+    \brief      set IREF step data
     \param[in]  stepdata
       \arg        IREF_CUR_STEP_DATA_X:(x=0..63): step*x
     \param[out] none

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_misc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_misc.c
@@ -1,36 +1,36 @@
 /*!
     \file    gd32f4xx_misc.c
     \brief   MISC driver
-    
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -61,34 +61,34 @@ void nvic_priority_group_set(uint32_t nvic_prigroup)
     \param[out] none
     \retval     none
 */
-void nvic_irq_enable(uint8_t nvic_irq, uint8_t nvic_irq_pre_priority, 
+void nvic_irq_enable(uint8_t nvic_irq, uint8_t nvic_irq_pre_priority,
                      uint8_t nvic_irq_sub_priority)
 {
     uint32_t temp_priority = 0x00U, temp_pre = 0x00U, temp_sub = 0x00U;
     /* use the priority group value to get the temp_pre and the temp_sub */
-    if(((SCB->AIRCR) & (uint32_t)0x700U)==NVIC_PRIGROUP_PRE0_SUB4){
-        temp_pre=0U;
-        temp_sub=0x4U;
-    }else if(((SCB->AIRCR) & (uint32_t)0x700U)==NVIC_PRIGROUP_PRE1_SUB3){
-        temp_pre=1U;
-        temp_sub=0x3U;
-    }else if(((SCB->AIRCR) & (uint32_t)0x700U)==NVIC_PRIGROUP_PRE2_SUB2){
-        temp_pre=2U;
-        temp_sub=0x2U;
-    }else if(((SCB->AIRCR) & (uint32_t)0x700U)==NVIC_PRIGROUP_PRE3_SUB1){
-        temp_pre=3U;
-        temp_sub=0x1U;
-    }else if(((SCB->AIRCR) & (uint32_t)0x700U)==NVIC_PRIGROUP_PRE4_SUB0){
-        temp_pre=4U;
-        temp_sub=0x0U;
-    }else{
+    if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE0_SUB4) {
+        temp_pre = 0U;
+        temp_sub = 0x4U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE1_SUB3) {
+        temp_pre = 1U;
+        temp_sub = 0x3U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE2_SUB2) {
+        temp_pre = 2U;
+        temp_sub = 0x2U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE3_SUB1) {
+        temp_pre = 3U;
+        temp_sub = 0x1U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE4_SUB0) {
+        temp_pre = 4U;
+        temp_sub = 0x0U;
+    } else {
         nvic_priority_group_set(NVIC_PRIGROUP_PRE2_SUB2);
-        temp_pre=2U;
-        temp_sub=0x2U;
+        temp_pre = 2U;
+        temp_sub = 0x2U;
     }
     /* get the temp_priority to fill the NVIC->IP register */
     temp_priority = (uint32_t)nvic_irq_pre_priority << (0x4U - temp_pre);
-    temp_priority |= nvic_irq_sub_priority &(0x0FU >> (0x4U - temp_sub));
+    temp_priority |= nvic_irq_sub_priority & (0x0FU >> (0x4U - temp_sub));
     temp_priority = temp_priority << 0x04U;
     NVIC->IP[nvic_irq] = (uint8_t)temp_priority;
     /* enable the selected IRQ */
@@ -119,15 +119,16 @@ void nvic_irq_disable(uint8_t nvic_irq)
 void nvic_vector_table_set(uint32_t nvic_vict_tab, uint32_t offset)
 {
     SCB->VTOR = nvic_vict_tab | (offset & NVIC_VECTTAB_OFFSET_MASK);
+    __DSB();
 }
 
 /*!
     \brief    set the state of the low power mode
     \param[in]  lowpower_mode: the low power mode state
-      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system always enter low power 
+      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system always enter low power
                     mode by exiting from ISR
       \arg        SCB_LPM_DEEPSLEEP: if chose this para, the system will enter the DEEPSLEEP mode
-      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode can be woke up 
+      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode can be woke up
                     by all the enable and disable interrupts
     \param[out] none
     \retval     none
@@ -140,10 +141,10 @@ void system_lowpower_set(uint8_t lowpower_mode)
 /*!
     \brief    reset the state of the low power mode
     \param[in]  lowpower_mode: the low power mode state
-      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system will exit low power 
+      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system will exit low power
                     mode by exiting from ISR
       \arg        SCB_LPM_DEEPSLEEP: if chose this para, the system will enter the SLEEP mode
-      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode only can be 
+      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode only can be
                     woke up by the enable interrupts
     \param[out] none
     \retval     none
@@ -164,10 +165,10 @@ void system_lowpower_reset(uint8_t lowpower_mode)
 
 void systick_clksource_set(uint32_t systick_clksource)
 {
-    if(SYSTICK_CLKSOURCE_HCLK == systick_clksource ){
+    if(SYSTICK_CLKSOURCE_HCLK == systick_clksource) {
         /* set the systick clock source from HCLK */
         SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
-    }else{
+    } else {
         /* set the systick clock source from HCLK/8 */
         SysTick->CTRL &= SYSTICK_CLKSOURCE_HCLK_DIV8;
     }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_pmu.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_pmu.c
@@ -5,39 +5,41 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32f4xx_pmu.h"
 #include "core_cm4.h"
+
 /*!
-    \brief    reset PMU register
+    \brief      reset PMU registers
     \param[in]  none
     \param[out] none
     \retval     none
@@ -50,7 +52,7 @@ void pmu_deinit(void)
 }
 
 /*!
-    \brief    select low voltage detector threshold
+    \brief      select low voltage detector threshold
     \param[in]  lvdt_n:
       \arg        PMU_LVDT_0: voltage threshold is 2.1V
       \arg        PMU_LVDT_1: voltage threshold is 2.3V
@@ -76,7 +78,19 @@ void pmu_lvd_select(uint32_t lvdt_n)
 }
 
 /*!
-    \brief    select LDO output voltage
+    \brief      disable PMU lvd
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_lvd_disable(void)
+{
+    /* disable LVD */
+    PMU_CTL &= ~PMU_CTL_LVDEN;
+}
+
+/*!
+    \brief      select LDO output voltage
                 this bit set by software when the main PLL closed, before closing PLL, change the system clock to IRC16M or HXTAL
     \param[in]  ldo_output:
       \arg        PMU_LDOVS_LOW: low-driver mode enable in deep-sleep mode
@@ -92,39 +106,7 @@ void pmu_ldo_output_select(uint32_t ldo_output)
 }
 
 /*!
-    \brief    enable low-driver mode in deep-sleep mode
-    \param[in]  lowdr_mode:
-      \arg        PMU_LOWDRIVER_ENABLE: enable low-driver mode in deep-sleep mode
-      \arg        PMU_LOWDRIVER_DISABLE: disable low-driver mode in deep-sleep mode
-    \param[out] none
-    \retval     none
-*/
-void pmu_low_driver_mode_enable(uint32_t lowdr_mode)
-{
-    PMU_CTL &= ~PMU_CTL_LDEN;
-    PMU_CTL |= lowdr_mode;
-}
-
-/*!
-    \brief    switch high-driver mode
-                this bit set by software only when IRC16M or HXTAL used as system clock
-    \param[in]  highdr_switch:
-      \arg        PMU_HIGHDR_SWITCH_NONE: disable high-driver mode switch
-      \arg        PMU_HIGHDR_SWITCH_EN: enable high-driver mode switch
-    \param[out] none
-    \retval     none
-*/
-void pmu_highdriver_switch_select(uint32_t highdr_switch)
-{
-    /* wait for HDRF flag set */
-    while(SET != pmu_flag_get(PMU_FLAG_HDRF)){
-    }
-    PMU_CTL &= ~PMU_CTL_HDS;
-    PMU_CTL |= highdr_switch;
-}
-
-/*!
-    \brief    enable high-driver mode
+    \brief      enable high-driver mode
                 this bit set by software only when IRC16M or HXTAL used as system clock
     \param[in]  none
     \param[out] none
@@ -136,7 +118,7 @@ void pmu_highdriver_mode_enable(void)
 }
 
 /*!
-    \brief    disable high-driver mode
+    \brief      disable high-driver mode
     \param[in]  none
     \param[out] none
     \retval     none
@@ -147,47 +129,75 @@ void pmu_highdriver_mode_disable(void)
 }
 
 /*!
-    \brief    disable PMU lvd
+    \brief      switch high-driver mode
+                this bit set by software only when IRC16M or HXTAL used as system clock
+    \param[in]  highdr_switch:
+      \arg        PMU_HIGHDR_SWITCH_NONE: disable high-driver mode switch
+      \arg        PMU_HIGHDR_SWITCH_EN: enable high-driver mode switch
+    \param[out] none
+    \retval     none
+*/
+void pmu_highdriver_switch_select(uint32_t highdr_switch)
+{
+    /* wait for HDRF flag set */
+    while(SET != pmu_flag_get(PMU_FLAG_HDRF)) {
+    }
+    PMU_CTL &= ~PMU_CTL_HDS;
+    PMU_CTL |= highdr_switch;
+}
+
+/*!
+    \brief      enable low-driver mode in deep-sleep
     \param[in]  none
     \param[out] none
     \retval     none
 */
-void pmu_lvd_disable(void)
+void pmu_lowdriver_mode_enable(void)
 {
-    /* disable LVD */
-    PMU_CTL &= ~PMU_CTL_LVDEN;
+    PMU_CTL |= PMU_CTL_LDEN;
 }
 
 /*!
-    \brief    low-driver mode when use low power LDO
+    \brief      disable low-driver mode in deep-sleep
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_lowdriver_mode_disable(void)
+{
+    PMU_CTL &= ~PMU_CTL_LDEN;
+}
+
+/*!
+    \brief      in deep-sleep mode, driver mode when use low power LDO
     \param[in]  mode:
       \arg        PMU_NORMALDR_LOWPWR:  normal driver when use low power LDO
       \arg        PMU_LOWDR_LOWPWR:  low-driver mode enabled when LDEN is 11 and use low power LDO
     \param[out] none
     \retval     none
 */
-void pmu_lowdriver_lowpower_config(uint32_t mode)
+void pmu_lowpower_driver_config(uint32_t mode)
 {
     PMU_CTL &= ~PMU_CTL_LDLP;
     PMU_CTL |= mode;
 }
 
 /*!
-    \brief    low-driver mode when use normal power LDO
+    \brief      in deep-sleep mode, driver mode when use normal power LDO
     \param[in]  mode:
       \arg        PMU_NORMALDR_NORMALPWR: normal driver when use normal power LDO
       \arg        PMU_LOWDR_NORMALPWR: low-driver mode enabled when LDEN is 11 and use normal power LDO
     \param[out] none
     \retval     none
 */
-void pmu_lowdriver_normalpower_config(uint32_t mode)
+void pmu_normalpower_driver_config(uint32_t mode)
 {
     PMU_CTL &= ~PMU_CTL_LDNP;
     PMU_CTL |= mode;
 }
 
 /*!
-    \brief    PMU work at sleep mode
+    \brief      PMU work in sleep mode
     \param[in]  sleepmodecmd:
       \arg        WFI_CMD: use WFI command
       \arg        WFE_CMD: use WFE command
@@ -198,68 +208,80 @@ void pmu_to_sleepmode(uint8_t sleepmodecmd)
 {
     /* clear sleepdeep bit of Cortex-M4 system control register */
     SCB->SCR &= ~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
-    
+
     /* select WFI or WFE command to enter sleep mode */
-    if(WFI_CMD == sleepmodecmd){
+    if(WFI_CMD == sleepmodecmd) {
         __WFI();
-    }else{
+    } else {
         __WFE();
     }
 }
 
 /*!
-    \brief    PMU work at deepsleep mode
+    \brief      PMU work in deep-sleep mode
     \param[in]  ldo
-      \arg        PMU_LDO_NORMAL: LDO normal work when pmu enter deepsleep mode
-      \arg        PMU_LDO_LOWPOWER: LDO work at low power mode when pmu enter deepsleep mode
-    \param[in]  deepsleepmodecmd: 
+      \arg        PMU_LDO_NORMAL: LDO normal work when pmu enter deep-sleep mode
+      \arg        PMU_LDO_LOWPOWER: LDO work at low power mode when pmu enter deep-sleep mode
+    \param[in]  lowdrive:
+                only one parameter can be selected which is shown as below:
+      \arg        PMU_LOWDRIVER_DISABLE: Low-driver mode disable in deep-sleep mode
+      \arg        PMU_LOWDRIVER_ENABLE: Low-driver mode enable in deep-sleep mode
+    \param[in]  deepsleepmodecmd:
       \arg        WFI_CMD: use WFI command
       \arg        WFE_CMD: use WFE command
     \param[out] none
     \retval     none
 */
-void pmu_to_deepsleepmode(uint32_t ldo,uint8_t deepsleepmodecmd)
+void pmu_to_deepsleepmode(uint32_t ldo, uint32_t lowdrive, uint8_t deepsleepmodecmd)
 {
-    static uint32_t reg_snap[ 4 ];      
+    static uint32_t reg_snap[4];
     /* clear stbmod and ldolp bits */
-    PMU_CTL &= ~((uint32_t)(PMU_CTL_STBMOD | PMU_CTL_LDOLP));
-    
+    PMU_CTL &= ~((uint32_t)(PMU_CTL_STBMOD | PMU_CTL_LDOLP | PMU_CTL_LDEN | PMU_CTL_LDNP | PMU_CTL_LDLP));
+
     /* set ldolp bit according to pmu_ldo */
     PMU_CTL |= ldo;
-    
+
+    /* configure low drive mode in deep-sleep mode */
+    if(PMU_LOWDRIVER_ENABLE == lowdrive) {
+        if(PMU_LDO_NORMAL == ldo) {
+            PMU_CTL |= (uint32_t)(PMU_CTL_LDEN | PMU_CTL_LDNP);
+        } else {
+            PMU_CTL |= (uint32_t)(PMU_CTL_LDEN | PMU_CTL_LDLP);
+        }
+    }
     /* set sleepdeep bit of Cortex-M4 system control register */
     SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
 
-    reg_snap[ 0 ] = REG32( 0xE000E010U );
-    reg_snap[ 1 ] = REG32( 0xE000E100U );
-    reg_snap[ 2 ] = REG32( 0xE000E104U );
-    reg_snap[ 3 ] = REG32( 0xE000E108U );
-    
-    REG32( 0xE000E010U ) &= 0x00010004U;
-    REG32( 0xE000E180U )  = 0XFF7FF831U;
-    REG32( 0xE000E184U )  = 0XBFFFF8FFU;
-    REG32( 0xE000E188U )  = 0xFFFFEFFFU; 
-    
-    /* select WFI or WFE command to enter deepsleep mode */
-    if(WFI_CMD == deepsleepmodecmd){
+    reg_snap[0] = REG32(0xE000E010U);
+    reg_snap[1] = REG32(0xE000E100U);
+    reg_snap[2] = REG32(0xE000E104U);
+    reg_snap[3] = REG32(0xE000E108U);
+
+    REG32(0xE000E010U) &= 0x00010004U;
+    REG32(0xE000E180U)  = 0XFF7FF831U;
+    REG32(0xE000E184U)  = 0XBFFFF8FFU;
+    REG32(0xE000E188U)  = 0xFFFFEFFFU;
+
+    /* select WFI or WFE command to enter deep-sleep mode */
+    if(WFI_CMD == deepsleepmodecmd) {
         __WFI();
-    }else{
+    } else {
         __SEV();
         __WFE();
         __WFE();
     }
-    
-    REG32( 0xE000E010U ) = reg_snap[ 0 ] ; 
-    REG32( 0xE000E100U ) = reg_snap[ 1 ] ;
-    REG32( 0xE000E104U ) = reg_snap[ 2 ] ;
-    REG32( 0xE000E108U ) = reg_snap[ 3 ] ;  
-    
+
+    REG32(0xE000E010U) = reg_snap[0];
+    REG32(0xE000E100U) = reg_snap[1];
+    REG32(0xE000E104U) = reg_snap[2];
+    REG32(0xE000E108U) = reg_snap[3];
+
     /* reset sleepdeep bit of Cortex-M4 system control register */
     SCB->SCR &= ~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
 }
 
 /*!
-    \brief    pmu work at standby mode
+    \brief      pmu work in standby mode
     \param[in]  standbymodecmd:
       \arg        WFI_CMD: use WFI command
       \arg        WFE_CMD: use WFE command
@@ -273,21 +295,43 @@ void pmu_to_standbymode(uint8_t standbymodecmd)
 
     /* set stbmod bit */
     PMU_CTL |= PMU_CTL_STBMOD;
-        
+
     /* reset wakeup flag */
     PMU_CTL |= PMU_CTL_WURST;
-    
+
     /* select WFI or WFE command to enter standby mode */
-    if(WFI_CMD == standbymodecmd){
+    if(WFI_CMD == standbymodecmd) {
         __WFI();
-    }else{
+    } else {
         __WFE();
         __WFE();
     }
 }
 
 /*!
-    \brief    backup SRAM LDO on
+    \brief      enable PMU wakeup pin
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_wakeup_pin_enable(void)
+{
+    PMU_CS |= PMU_CS_WUPEN;
+}
+
+/*!
+    \brief      disable PMU wakeup pin
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_wakeup_pin_disable(void)
+{
+    PMU_CS &= ~PMU_CS_WUPEN;
+}
+
+/*!
+    \brief      backup SRAM LDO on
     \param[in]  bkp_ldo:
       \arg        PMU_BLDOON_OFF: backup SRAM LDO closed
       \arg        PMU_BLDOON_ON: open the backup SRAM LDO
@@ -301,16 +345,61 @@ void pmu_backup_ldo_config(uint32_t bkp_ldo)
 }
 
 /*!
-    \brief    reset flag bit
-    \param[in]  flag_reset:
+    \brief      enable write access to the registers in backup domain
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_backup_write_enable(void)
+{
+    PMU_CTL |= PMU_CTL_BKPWEN;
+}
+
+/*!
+    \brief      disable write access to the registers in backup domain
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_backup_write_disable(void)
+{
+    PMU_CTL &= ~PMU_CTL_BKPWEN;
+}
+
+/*!
+    \brief      get flag state
+    \param[in]  flag:
+      \arg        PMU_FLAG_WAKEUP: wakeup flag
+      \arg        PMU_FLAG_STANDBY: standby flag
+      \arg        PMU_FLAG_LVD: lvd flag
+      \arg        PMU_FLAG_BLDORF: backup SRAM LDO ready flag
+      \arg        PMU_FLAG_LDOVSRF: LDO voltage select ready flag
+      \arg        PMU_FLAG_HDRF: high-driver ready flag
+      \arg        PMU_FLAG_HDSRF: high-driver switch ready flag
+      \arg        PMU_FLAG_LDRF: low-driver mode ready flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus pmu_flag_get(uint32_t flag)
+{
+    if(PMU_CS & flag) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear flag bit
+    \param[in]  flag:
       \arg        PMU_FLAG_RESET_WAKEUP: reset wakeup flag
       \arg        PMU_FLAG_RESET_STANDBY: reset standby flag
     \param[out] none
     \retval     none
 */
-void pmu_flag_reset(uint32_t flag_reset)
+void pmu_flag_clear(uint32_t flag)
 {
-    switch(flag_reset){
+    switch(flag) {
     case PMU_FLAG_RESET_WAKEUP:
         /* reset wakeup flag */
         PMU_CTL |= PMU_CTL_WURST;
@@ -322,71 +411,4 @@ void pmu_flag_reset(uint32_t flag_reset)
     default :
         break;
     }
-}
-
-/*!
-    \brief    get flag state
-    \param[in]  pmu_flag:
-      \arg        PMU_FLAG_WAKEUP: wakeup flag
-      \arg        PMU_FLAG_STANDBY: standby flag
-      \arg        PMU_FLAG_LVD: lvd flag
-      \arg        PMU_FLAG_BLDORF: backup SRAM LDO ready flag
-      \arg        PMU_FLAG_LDOVSRF: LDO voltage select ready flag
-      \arg        PMU_FLAG_HDRF: high-driver ready flag
-      \arg        PMU_FLAG_HDSRF: high-driver switch ready flag
-      \arg        PMU_FLAG_LDRF: low-driver mode ready flag 
-    \param[out] none
-    \retval     FlagStatus: SET or RESET
-*/
-FlagStatus pmu_flag_get(uint32_t pmu_flag)
-{
-    if(PMU_CS & pmu_flag){
-        return  SET;
-    }else{
-        return  RESET;
-    }
-}
-
-/*!
-    \brief    enable backup domain write
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void pmu_backup_write_enable(void)
-{
-    PMU_CTL |= PMU_CTL_BKPWEN;
-}
-
-/*!
-    \brief    disable backup domain write
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void pmu_backup_write_disable(void)
-{
-    PMU_CTL &= ~PMU_CTL_BKPWEN;
-}
-
-/*!
-    \brief    enable wakeup pin
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void pmu_wakeup_pin_enable(void)
-{
-    PMU_CS |= PMU_CS_WUPEN;
-}
-
-/*!
-    \brief    disable wakeup pin
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void pmu_wakeup_pin_disable(void)
-{
-    PMU_CS &= ~PMU_CS_WUPEN;
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_rcu.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_rcu.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_rcu.c
     \brief   RCU driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -59,14 +60,16 @@ void rcu_deinit(void)
     /* enable IRC16M */
     RCU_CTL |= RCU_CTL_IRC16MEN;
     rcu_osci_stab_wait(RCU_IRC16M);
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+
+    /* reset CTL register */
+    RCU_CTL &= ~(RCU_CTL_HXTALEN | RCU_CTL_CKMEN | RCU_CTL_PLLEN | RCU_CTL_PLLI2SEN
+                 | RCU_CTL_PLLSAIEN);
+    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
     /* reset CFG0 register */
     RCU_CFG0 &= ~(RCU_CFG0_SCS | RCU_CFG0_AHBPSC | RCU_CFG0_APB1PSC | RCU_CFG0_APB2PSC |
                   RCU_CFG0_RTCDIV | RCU_CFG0_CKOUT0SEL | RCU_CFG0_I2SSEL | RCU_CFG0_CKOUT0DIV |
                   RCU_CFG0_CKOUT1DIV | RCU_CFG0_CKOUT1SEL);
-    /* reset CTL register */
-    RCU_CTL &= ~(RCU_CTL_HXTALEN | RCU_CTL_CKMEN | RCU_CTL_PLLEN | RCU_CTL_PLLI2SEN 
-                 | RCU_CTL_PLLSAIEN);
-    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
     /* reset PLL register */
     RCU_PLL = 0x24003010U;
     /* reset PLLI2S register */
@@ -76,7 +79,7 @@ void rcu_deinit(void)
     /* reset INT register */
     RCU_INT = 0x00000000U;
     /* reset CFG1 register */
-    RCU_CFG1 &= ~(RCU_CFG1_PLLSAIRDIV | RCU_CFG1_TIMERSEL);                
+    RCU_CFG1 &= ~(RCU_CFG1_PLLSAIRDIV | RCU_CFG1_TIMERSEL);
 }
 
 /*!
@@ -370,7 +373,7 @@ void rcu_bkp_reset_disable(void)
 void rcu_system_clock_source_config(uint32_t ck_sys)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the SCS bits and set according to ck_sys */
     reg &= ~RCU_CFG0_SCS;
@@ -402,7 +405,7 @@ uint32_t rcu_system_clock_source_get(void)
 void rcu_ahb_clock_config(uint32_t ck_ahb)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the AHBPSC bits and set according to ck_ahb */
     reg &= ~RCU_CFG0_AHBPSC;
@@ -424,7 +427,7 @@ void rcu_ahb_clock_config(uint32_t ck_ahb)
 void rcu_apb1_clock_config(uint32_t ck_apb1)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the APB1PSC and set according to ck_apb1 */
     reg &= ~RCU_CFG0_APB1PSC;
@@ -446,7 +449,7 @@ void rcu_apb1_clock_config(uint32_t ck_apb1)
 void rcu_apb2_clock_config(uint32_t ck_apb2)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the APB2PSC and set according to ck_apb2 */
     reg &= ~RCU_CFG0_APB2PSC;
@@ -461,7 +464,7 @@ void rcu_apb2_clock_config(uint32_t ck_apb2)
       \arg        RCU_CKOUT0SRC_LXTAL: LXTAL selected
       \arg        RCU_CKOUT0SRC_HXTAL: HXTAL selected
       \arg        RCU_CKOUT0SRC_PLLP: PLLP selected
-    \param[in]  ckout0_div: CK_OUT0 divider 
+    \param[in]  ckout0_div: CK_OUT0 divider
       \arg        RCU_CKOUT0_DIVx(x=1,2,3,4,5): CK_OUT0 is divided by x
     \param[out] none
     \retval     none
@@ -469,10 +472,10 @@ void rcu_apb2_clock_config(uint32_t ck_apb2)
 void rcu_ckout0_config(uint32_t ckout0_src, uint32_t ckout0_div)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the CKOUT0SRC, CKOUT0DIV and set according to ckout0_src and ckout0_div */
-    reg &= ~(RCU_CFG0_CKOUT0SEL | RCU_CFG0_CKOUT0DIV );
+    reg &= ~(RCU_CFG0_CKOUT0SEL | RCU_CFG0_CKOUT0DIV);
     RCU_CFG0 = (reg | ckout0_src | ckout0_div);
 }
 
@@ -483,8 +486,8 @@ void rcu_ckout0_config(uint32_t ckout0_src, uint32_t ckout0_div)
       \arg        RCU_CKOUT1SRC_SYSTEMCLOCK: system clock selected
       \arg        RCU_CKOUT1SRC_PLLI2SR: PLLI2SR selected
       \arg        RCU_CKOUT1SRC_HXTAL: HXTAL selected
-      \arg        RCU_CKOUT1SRC_PLLP: PLLP selected           
-    \param[in]  ckout1_div: CK_OUT1 divider 
+      \arg        RCU_CKOUT1SRC_PLLP: PLLP selected
+    \param[in]  ckout1_div: CK_OUT1 divider
       \arg        RCU_CKOUT1_DIVx(x=1,2,3,4,5): CK_OUT1 is divided by x
     \param[out] none
     \retval     none
@@ -492,7 +495,7 @@ void rcu_ckout0_config(uint32_t ckout0_src, uint32_t ckout0_div)
 void rcu_ckout1_config(uint32_t ckout1_src, uint32_t ckout1_div)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG0;
     /* reset the CKOUT1SRC, CKOUT1DIV and set according to ckout1_src and ckout1_div */
     reg &= ~(RCU_CFG0_CKOUT1SEL | RCU_CFG0_CKOUT1DIV);
@@ -500,7 +503,7 @@ void rcu_ckout1_config(uint32_t ckout1_src, uint32_t ckout1_div)
 }
 
 /*!
-    \brief    configure the main PLL clock 
+    \brief    configure the main PLL clock
     \param[in]  pll_src: PLL clock source selection
       \arg        RCU_PLLSRC_IRC16M: select IRC16M as PLL source clock
       \arg        RCU_PLLSRC_HXTAL: select HXTAL as PLL source clock
@@ -519,35 +522,35 @@ ErrStatus rcu_pll_config(uint32_t pll_src, uint32_t pll_psc, uint32_t pll_n, uin
 {
     uint32_t ss_modulation_inc;
     uint32_t ss_modulation_reg;
-    
+
     ss_modulation_inc = 0U;
     ss_modulation_reg = RCU_PLLSSCTL;
 
     /* calculate the minimum factor of PLLN */
-    if((ss_modulation_reg & RCU_PLLSSCTL_SSCGON) == RCU_PLLSSCTL_SSCGON){
-        if((ss_modulation_reg & RCU_SS_TYPE_DOWN) == RCU_SS_TYPE_DOWN){
+    if((ss_modulation_reg & RCU_PLLSSCTL_SSCGON) == RCU_PLLSSCTL_SSCGON) {
+        if((ss_modulation_reg & RCU_SS_TYPE_DOWN) == RCU_SS_TYPE_DOWN) {
             ss_modulation_inc += RCU_SS_MODULATION_DOWN_INC;
-        }else{
+        } else {
             ss_modulation_inc += RCU_SS_MODULATION_CENTER_INC;
         }
     }
-    
+
     /* check the function parameter */
-    if(CHECK_PLL_PSC_VALID(pll_psc) && CHECK_PLL_N_VALID(pll_n,ss_modulation_inc) && 
-       CHECK_PLL_P_VALID(pll_p) && CHECK_PLL_Q_VALID(pll_q)){
-         RCU_PLL = pll_psc | (pll_n << 6) | (((pll_p >> 1) - 1U) << 16) |
-                   (pll_src) | (pll_q << 24);
-    }else{
+    if(CHECK_PLL_PSC_VALID(pll_psc) && CHECK_PLL_N_VALID(pll_n, ss_modulation_inc) &&
+            CHECK_PLL_P_VALID(pll_p) && CHECK_PLL_Q_VALID(pll_q)) {
+        RCU_PLL = pll_psc | (pll_n << 6) | (((pll_p >> 1) - 1U) << 16) |
+                  (pll_src) | (pll_q << 24);
+    } else {
         /* return status */
         return ERROR;
     }
-    
+
     /* return status */
     return SUCCESS;
 }
 
 /*!
-    \brief    configure the PLLI2S clock 
+    \brief    configure the PLLI2S clock
     \param[in]  plli2s_n: the PLLI2S VCO clock multi factor
       \arg        this parameter should be selected between 50 and 500
     \param[in]  plli2s_r: the PLLI2S R output frequency division factor from PLLI2S VCO clock
@@ -558,19 +561,19 @@ ErrStatus rcu_pll_config(uint32_t pll_src, uint32_t pll_psc, uint32_t pll_n, uin
 ErrStatus rcu_plli2s_config(uint32_t plli2s_n, uint32_t plli2s_r)
 {
     /* check the function parameter */
-    if(CHECK_PLLI2S_N_VALID(plli2s_n) && CHECK_PLLI2S_R_VALID(plli2s_r)){
+    if(CHECK_PLLI2S_N_VALID(plli2s_n) && CHECK_PLLI2S_R_VALID(plli2s_r)) {
         RCU_PLLI2S = (plli2s_n << 6) | (plli2s_r << 28);
-    }else{
+    } else {
         /* return status */
         return ERROR;
     }
-    
+
     /* return status */
-    return SUCCESS;  
+    return SUCCESS;
 }
 
 /*!
-    \brief    configure the PLLSAI clock 
+    \brief    configure the PLLSAI clock
     \param[in]  pllsai_n: the PLLSAI VCO clock multi factor
       \arg        this parameter should be selected between 50 and 500
     \param[in]  pllsai_p: the PLLSAI P output frequency division factor from PLL VCO clock
@@ -583,13 +586,13 @@ ErrStatus rcu_plli2s_config(uint32_t plli2s_n, uint32_t plli2s_r)
 ErrStatus rcu_pllsai_config(uint32_t pllsai_n, uint32_t pllsai_p, uint32_t pllsai_r)
 {
     /* check the function parameter */
-    if(CHECK_PLLSAI_N_VALID(pllsai_n) && CHECK_PLLSAI_P_VALID(pllsai_p) && CHECK_PLLSAI_R_VALID(pllsai_r)){
+    if(CHECK_PLLSAI_N_VALID(pllsai_n) && CHECK_PLLSAI_P_VALID(pllsai_p) && CHECK_PLLSAI_R_VALID(pllsai_r)) {
         RCU_PLLSAI = (pllsai_n << 6U) | (((pllsai_p >> 1U) - 1U) << 16U) | (pllsai_r << 28U);
-    }else{
+    } else {
         /* return status */
         return ERROR;
     }
-    
+
     /* return status */
     return SUCCESS;
 }
@@ -608,15 +611,15 @@ ErrStatus rcu_pllsai_config(uint32_t pllsai_n, uint32_t pllsai_p, uint32_t pllsa
 void rcu_rtc_clock_config(uint32_t rtc_clock_source)
 {
     uint32_t reg;
-    
-    reg = RCU_BDCTL; 
+
+    reg = RCU_BDCTL;
     /* reset the RTCSRC bits and set according to rtc_clock_source */
     reg &= ~RCU_BDCTL_RTCSRC;
     RCU_BDCTL = (reg | rtc_clock_source);
 }
 
 /*!
-    \brief    configure the frequency division of RTC clock when HXTAL was selected as its clock source 
+    \brief    configure the frequency division of RTC clock when HXTAL was selected as its clock source
     \param[in]  rtc_div: RTC clock frequency division
                 only one parameter can be selected which is shown as below:
       \arg        RCU_RTC_HXTAL_NONE: no clock for RTC
@@ -627,8 +630,8 @@ void rcu_rtc_clock_config(uint32_t rtc_clock_source)
 void rcu_rtc_div_config(uint32_t rtc_div)
 {
     uint32_t reg;
-    
-    reg = RCU_CFG0; 
+
+    reg = RCU_CFG0;
     /* reset the RTCDIV bits and set according to rtc_div value */
     reg &= ~RCU_CFG0_RTCDIV;
     RCU_CFG0 = (reg | rtc_div);
@@ -647,8 +650,8 @@ void rcu_rtc_div_config(uint32_t rtc_div)
 void rcu_i2s_clock_config(uint32_t i2s_clock_source)
 {
     uint32_t reg;
-    
-    reg = RCU_CFG0; 
+
+    reg = RCU_CFG0;
     /* reset the I2SSEL bit and set according to i2s_clock_source */
     reg &= ~RCU_CFG0_I2SSEL;
     RCU_CFG0 = (reg | i2s_clock_source);
@@ -666,7 +669,7 @@ void rcu_i2s_clock_config(uint32_t i2s_clock_source)
 void rcu_ck48m_clock_config(uint32_t ck48m_clock_source)
 {
     uint32_t reg;
-    
+
     reg = RCU_ADDCTL;
     /* reset the CK48MSEL bit and set according to i2s_clock_source */
     reg &= ~RCU_ADDCTL_CK48MSEL;
@@ -685,7 +688,7 @@ void rcu_ck48m_clock_config(uint32_t ck48m_clock_source)
 void rcu_pll48m_clock_config(uint32_t pll48m_clock_source)
 {
     uint32_t reg;
-    
+
     reg = RCU_ADDCTL;
     /* reset the PLL48MSEL bit and set according to pll48m_clock_source */
     reg &= ~RCU_ADDCTL_PLL48MSEL;
@@ -696,13 +699,13 @@ void rcu_pll48m_clock_config(uint32_t pll48m_clock_source)
     \brief    configure the TIMER clock prescaler selection
     \param[in]  timer_clock_prescaler: TIMER clock selection
                 only one parameter can be selected which is shown as below:
-      \arg        RCU_TIMER_PSC_MUL2: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB) 
+      \arg        RCU_TIMER_PSC_MUL2: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB)
                                       or 0b100(CK_APBx = CK_AHB/2), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB).
-                                      or else, the TIMER clock is twice the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 2 x CK_APB1; 
+                                      or else, the TIMER clock is twice the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 2 x CK_APB1;
                                       TIMER in APB2 domain: CK_TIMERx = 2 x CK_APB2)
-      \arg        RCU_TIMER_PSC_MUL4: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB), 
-                                      0b100(CK_APBx = CK_AHB/2), or 0b101(CK_APBx = CK_AHB/4), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB). 
-                                      or else, the TIMER clock is four timers the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 4 x CK_APB1;  
+      \arg        RCU_TIMER_PSC_MUL4: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB),
+                                      0b100(CK_APBx = CK_AHB/2), or 0b101(CK_APBx = CK_AHB/4), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB).
+                                      or else, the TIMER clock is four timers the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 4 x CK_APB1;
                                       TIMER in APB2 domain: CK_TIMERx = 4 x CK_APB2)
     \param[out] none
     \retval     none
@@ -710,9 +713,9 @@ void rcu_pll48m_clock_config(uint32_t pll48m_clock_source)
 void rcu_timer_clock_prescaler_config(uint32_t timer_clock_prescaler)
 {
     /* configure the TIMERSEL bit and select the TIMER clock prescaler */
-    if(timer_clock_prescaler == RCU_TIMER_PSC_MUL2){
+    if(timer_clock_prescaler == RCU_TIMER_PSC_MUL2) {
         RCU_CFG1 &= timer_clock_prescaler;
-    }else{
+    } else {
         RCU_CFG1 |= timer_clock_prescaler;
     }
 }
@@ -728,7 +731,7 @@ void rcu_timer_clock_prescaler_config(uint32_t timer_clock_prescaler)
 void rcu_tli_clock_div_config(uint32_t pllsai_r_div)
 {
     uint32_t reg;
-    
+
     reg = RCU_CFG1;
     /* reset the PLLSAIRDIV bit and set according to pllsai_r_div */
     reg &= ~RCU_CFG1_PLLSAIRDIV;
@@ -760,9 +763,9 @@ void rcu_tli_clock_div_config(uint32_t pllsai_r_div)
 FlagStatus rcu_flag_get(rcu_flag_enum flag)
 {
     /* get the rcu flag */
-    if(RESET != (RCU_REG_VAL(flag) & BIT(RCU_BIT_POS(flag)))){
+    if(RESET != (RCU_REG_VAL(flag) & BIT(RCU_BIT_POS(flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -797,9 +800,9 @@ void rcu_all_reset_flag_clear(void)
 FlagStatus rcu_interrupt_flag_get(rcu_int_flag_enum int_flag)
 {
     /* get the rcu interrupt flag */
-    if(RESET != (RCU_REG_VAL(int_flag) & BIT(RCU_BIT_POS(int_flag)))){
+    if(RESET != (RCU_REG_VAL(int_flag) & BIT(RCU_BIT_POS(int_flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -878,9 +881,9 @@ void rcu_interrupt_disable(rcu_int_enum interrupt)
 void rcu_lxtal_drive_capability_config(uint32_t lxtal_dricap)
 {
     uint32_t reg;
-    
+
     reg = RCU_BDCTL;
-    
+
     /* reset the LXTALDRI bits and set according to lxtal_dricap */
     reg &= ~RCU_BDCTL_LXTALDRI;
     RCU_BDCTL = (reg | lxtal_dricap);
@@ -906,109 +909,109 @@ ErrStatus rcu_osci_stab_wait(rcu_osci_type_enum osci)
     uint32_t stb_cnt = 0U;
     ErrStatus reval = ERROR;
     FlagStatus osci_stat = RESET;
-    
-    switch(osci){
+
+    switch(osci) {
     /* wait HXTAL stable */
     case RCU_HXTAL:
-        while((RESET == osci_stat) && (HXTAL_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (HXTAL_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_HXTALSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_HXTALSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_HXTALSTB)) {
             reval = SUCCESS;
         }
         break;
     /* wait LXTAL stable */
     case RCU_LXTAL:
-        while((RESET == osci_stat) && (LXTAL_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (LXTAL_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_LXTALSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_LXTALSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_LXTALSTB)) {
             reval = SUCCESS;
         }
         break;
-    /* wait IRC16M stable */    
+    /* wait IRC16M stable */
     case RCU_IRC16M:
-        while((RESET == osci_stat) && (IRC16M_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (IRC16M_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_IRC16MSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_IRC16MSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC16MSTB)) {
             reval = SUCCESS;
         }
         break;
-    /* wait IRC48M stable */    
+    /* wait IRC48M stable */
     case RCU_IRC48M:
-        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_IRC48MSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if (RESET != rcu_flag_get(RCU_FLAG_IRC48MSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC48MSTB)) {
             reval = SUCCESS;
         }
         break;
     /* wait IRC32K stable */
     case RCU_IRC32K:
-        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_IRC32KSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_IRC32KSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC32KSTB)) {
             reval = SUCCESS;
         }
         break;
-    /* wait PLL stable */    
+    /* wait PLL stable */
     case RCU_PLL_CK:
-        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_PLLSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_PLLSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLSTB)) {
             reval = SUCCESS;
         }
         break;
     /* wait PLLI2S stable */
     case RCU_PLLI2S_CK:
-        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_PLLI2SSTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_PLLI2SSTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLI2SSTB)) {
             reval = SUCCESS;
         }
         break;
-    /* wait PLLSAI stable */    
+    /* wait PLLSAI stable */
     case RCU_PLLSAI_CK:
-        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)){
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
             osci_stat = rcu_flag_get(RCU_FLAG_PLLSAISTB);
             stb_cnt++;
         }
-        
+
         /* check whether flag is set */
-        if(RESET != rcu_flag_get(RCU_FLAG_PLLSAISTB)){
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLSAISTB)) {
             reval = SUCCESS;
         }
         break;
-    
+
     default:
         break;
     }
-    
+
     /* return value */
     return reval;
 }
@@ -1066,8 +1069,8 @@ void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci)
 {
     uint32_t reg;
 
-    switch(osci){
-    /* enable HXTAL to bypass mode */    
+    switch(osci) {
+    /* enable HXTAL to bypass mode */
     case RCU_HXTAL:
         reg = RCU_CTL;
         RCU_CTL &= ~RCU_CTL_HXTALEN;
@@ -1084,7 +1087,7 @@ void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci)
     case RCU_IRC32K:
     case RCU_PLL_CK:
     case RCU_PLLI2S_CK:
-    case RCU_PLLSAI_CK:    
+    case RCU_PLLSAI_CK:
         break;
     default:
         break;
@@ -1103,9 +1106,9 @@ void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci)
 void rcu_osci_bypass_mode_disable(rcu_osci_type_enum osci)
 {
     uint32_t reg;
-    
-    switch(osci){
-    /* disable HXTAL to bypass mode */    
+
+    switch(osci) {
+    /* disable HXTAL to bypass mode */
     case RCU_HXTAL:
         reg = RCU_CTL;
         RCU_CTL &= ~RCU_CTL_HXTALEN;
@@ -1122,7 +1125,7 @@ void rcu_osci_bypass_mode_disable(rcu_osci_type_enum osci)
     case RCU_IRC32K:
     case RCU_PLL_CK:
     case RCU_PLLI2S_CK:
-    case RCU_PLLSAI_CK:    
+    case RCU_PLLSAI_CK:
         break;
     default:
         break;
@@ -1162,7 +1165,7 @@ void rcu_hxtal_clock_monitor_disable(void)
 void rcu_irc16m_adjust_value_set(uint32_t irc16m_adjval)
 {
     uint32_t reg;
-    
+
     reg = RCU_CTL;
     /* reset the IRC16MADJ bits and set according to irc16m_adjval */
     reg &= ~RCU_CTL_IRC16MADJ;
@@ -1184,15 +1187,15 @@ void rcu_voltage_key_unlock(void)
     \brief    deep-sleep mode voltage select
     \param[in]  dsvol: deep sleep mode voltage
                 only one parameter can be selected which is shown as below:
-      \arg        RCU_DEEPSLEEP_V_1_2: the core voltage is 1.2V
-      \arg        RCU_DEEPSLEEP_V_1_1: the core voltage is 1.1V
-      \arg        RCU_DEEPSLEEP_V_1_0: the core voltage is 1.0V
-      \arg        RCU_DEEPSLEEP_V_0_9: the core voltage is 0.9V
+      \arg        RCU_DEEPSLEEP_V_0: the core voltage is default value
+      \arg        RCU_DEEPSLEEP_V_1: the core voltage is (default value-0.1)V(customers are not recommended to use it)
+      \arg        RCU_DEEPSLEEP_V_2: the core voltage is (default value-0.2)V(customers are not recommended to use it)
+      \arg        RCU_DEEPSLEEP_V_3: the core voltage is (default value-0.3)V(customers are not recommended to use it)
     \param[out] none
     \retval     none
 */
 void rcu_deepsleep_voltage_set(uint32_t dsvol)
-{    
+{
     dsvol &= RCU_DSV_DSLPVS;
     RCU_DSV = dsvol;
 }
@@ -1212,7 +1215,7 @@ void rcu_deepsleep_voltage_set(uint32_t dsvol)
 void rcu_spread_spectrum_config(uint32_t spread_spectrum_type, uint32_t modstep, uint32_t modcnt)
 {
     uint32_t reg;
-    
+
     reg = RCU_PLLSSCTL;
     /* reset the RCU_PLLSSCTL register bits */
     reg &= ~(RCU_PLLSSCTL_MODCNT | RCU_PLLSSCTL_MODSTEP | RCU_PLLSSCTL_SS_TYPE);
@@ -1257,14 +1260,14 @@ uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock)
     uint32_t sws, ck_freq = 0U;
     uint32_t cksys_freq, ahb_freq, apb1_freq, apb2_freq;
     uint32_t pllpsc, plln, pllsel, pllp, ck_src, idx, clk_exp;
-    
+
     /* exponent of AHB, APB1 and APB2 clock divider */
     const uint8_t ahb_exp[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
     const uint8_t apb1_exp[8] = {0, 0, 0, 0, 1, 2, 3, 4};
     const uint8_t apb2_exp[8] = {0, 0, 0, 0, 1, 2, 3, 4};
 
     sws = GET_BITS(RCU_CFG0, 2, 3);
-    switch(sws){
+    switch(sws) {
     /* IRC16M is selected as CK_SYS */
     case SEL_IRC16M:
         cksys_freq = IRC16M_VALUE;
@@ -1281,12 +1284,12 @@ uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock)
         pllp = (GET_BITS(RCU_PLL, 16U, 17U) + 1U) * 2U;
         /* PLL clock source selection, HXTAL or IRC16M/2 */
         pllsel = (RCU_PLL & RCU_PLL_PLLSEL);
-        if (RCU_PLLSRC_HXTAL == pllsel) {
+        if(RCU_PLLSRC_HXTAL == pllsel) {
             ck_src = HXTAL_VALUE;
         } else {
             ck_src = IRC16M_VALUE;
         }
-        cksys_freq = ((ck_src / pllpsc) * plln)/pllp;
+        cksys_freq = ((ck_src / pllpsc) * plln) / pllp;
         break;
     /* IRC16M is selected as CK_SYS */
     default:
@@ -1297,19 +1300,19 @@ uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock)
     idx = GET_BITS(RCU_CFG0, 4, 7);
     clk_exp = ahb_exp[idx];
     ahb_freq = cksys_freq >> clk_exp;
-    
+
     /* calculate APB1 clock frequency */
     idx = GET_BITS(RCU_CFG0, 10, 12);
     clk_exp = apb1_exp[idx];
     apb1_freq = ahb_freq >> clk_exp;
-    
+
     /* calculate APB2 clock frequency */
     idx = GET_BITS(RCU_CFG0, 13, 15);
     clk_exp = apb2_exp[idx];
     apb2_freq = ahb_freq >> clk_exp;
-    
+
     /* return the clocks frequency */
-    switch(clock){
+    switch(clock) {
     case CK_SYS:
         ck_freq = cksys_freq;
         break;

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_rtc.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_rtc.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -44,7 +45,6 @@ OF SUCH DAMAGE.
 #define RTC_HRFC_TIMEOUT                   ((uint32_t)0x20000000U)                    /*!< recalibration pending flag timeout */
 #define RTC_SHIFTCTL_TIMEOUT               ((uint32_t)0x00001000U)                    /*!< shift function operation pending flag timeout */
 #define RTC_ALRMXWF_TIMEOUT                ((uint32_t)0x00008000U)                    /*!< alarm configuration can be write flag timeout */
-
 
 /*!
     \brief    reset most of the RTC registers
@@ -67,7 +67,7 @@ ErrStatus rtc_deinit(void)
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){
+    if(ERROR != error_status) {
         /* reset RTC_CTL register, but RTC_CTL[2��0] */
         RTC_CTL &= (RTC_REGISTER_RESET | RTC_CTL_WTCS);
         /* before reset RTC_TIME and RTC_DATE, BPSHAD bit in RTC_CTL should be reset as the condition.
@@ -78,18 +78,18 @@ ErrStatus rtc_deinit(void)
         RTC_PSC = RTC_PSC_RESET;
         /* only when RTC_CTL_WTEN=0 and RTC_STAT_WTWF=1 can write RTC_CTL[2��0] */
         /* wait until the WTWF flag to be set */
-        do{
-           flag_status = RTC_STAT & RTC_STAT_WTWF;
-        }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+        do {
+            flag_status = RTC_STAT & RTC_STAT_WTWF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-        if ((uint32_t)RESET == flag_status){
+        if((uint32_t)RESET == flag_status) {
             error_status = ERROR;
-        }else{
+        } else {
             RTC_CTL &= RTC_REGISTER_RESET;
             RTC_WUT = RTC_WUT_RESET;
             RTC_COSC = RTC_REGISTER_RESET;
             /* to write RTC_ALRMxSS register, ALRMxEN bit in RTC_CTL register should be reset as the condition */
-            RTC_ALRM0TD = RTC_REGISTER_RESET;        
+            RTC_ALRM0TD = RTC_REGISTER_RESET;
             RTC_ALRM1TD = RTC_REGISTER_RESET;
             RTC_ALRM0SS = RTC_REGISTER_RESET;
             RTC_ALRM1SS = RTC_REGISTER_RESET;
@@ -97,9 +97,9 @@ ErrStatus rtc_deinit(void)
                at the same time, RTC_STAT_SOPF bit is reset, as the condition to reset RTC_SHIFTCTL register later */
             RTC_STAT = RTC_STAT_RESET;
             /* reset RTC_SHIFTCTL and RTC_HRFC register, this can be done without the init mode */
-            RTC_SHIFTCTL   = RTC_REGISTER_RESET;       
+            RTC_SHIFTCTL   = RTC_REGISTER_RESET;
             RTC_HRFC       = RTC_REGISTER_RESET;
-            error_status = rtc_register_sync_wait(); 
+            error_status = rtc_register_sync_wait();
         }
     }
 
@@ -111,7 +111,7 @@ ErrStatus rtc_deinit(void)
 
 /*!
     \brief    initialize RTC registers
-    \param[in]  rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains 
+    \param[in]  rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains
                 parameters for initialization of the rtc peripheral
                 members of the structure and the member values are shown as below:
                   year: 0x0 - 0x99(BCD format)
@@ -130,7 +130,7 @@ ErrStatus rtc_deinit(void)
     \param[out] none
     \retval     ErrStatus: ERROR or SUCCESS
 */
-ErrStatus rtc_init(rtc_parameter_struct* rtc_initpara_struct)
+ErrStatus rtc_init(rtc_parameter_struct *rtc_initpara_struct)
 {
     ErrStatus error_status = ERROR;
     uint32_t reg_time = 0U, reg_date = 0U;
@@ -138,13 +138,13 @@ ErrStatus rtc_init(rtc_parameter_struct* rtc_initpara_struct)
     reg_date = (DATE_YR(rtc_initpara_struct->year) | \
                 DATE_DOW(rtc_initpara_struct->day_of_week) | \
                 DATE_MON(rtc_initpara_struct->month) | \
-                DATE_DAY(rtc_initpara_struct->date)); 
-    
-    reg_time = (rtc_initpara_struct->am_pm| \
+                DATE_DAY(rtc_initpara_struct->date));
+
+    reg_time = (rtc_initpara_struct->am_pm | \
                 TIME_HR(rtc_initpara_struct->hour)  | \
                 TIME_MN(rtc_initpara_struct->minute) | \
-                TIME_SC(rtc_initpara_struct->second)); 
-              
+                TIME_SC(rtc_initpara_struct->second));
+
     /* 1st: disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -152,8 +152,8 @@ ErrStatus rtc_init(rtc_parameter_struct* rtc_initpara_struct)
     /* 2nd: enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){    
-        RTC_PSC = (uint32_t)(PSC_FACTOR_A(rtc_initpara_struct->factor_asyn)| \
+    if(ERROR != error_status) {
+        RTC_PSC = (uint32_t)(PSC_FACTOR_A(rtc_initpara_struct->factor_asyn) | \
                              PSC_FACTOR_S(rtc_initpara_struct->factor_syn));
 
         RTC_TIME = (uint32_t)reg_time;
@@ -161,10 +161,10 @@ ErrStatus rtc_init(rtc_parameter_struct* rtc_initpara_struct)
 
         RTC_CTL &= (uint32_t)(~RTC_CTL_CS);
         RTC_CTL |=  rtc_initpara_struct->display_format;
-        
-        /* 3rd: exit init mode */  
+
+        /* 3rd: exit init mode */
         rtc_init_mode_exit();
-        
+
         /* 4th: wait the RSYNF flag to set */
         error_status = rtc_register_sync_wait();
     }
@@ -188,18 +188,18 @@ ErrStatus rtc_init_mode_enter(void)
     ErrStatus error_status = ERROR;
 
     /* check whether it has been in init mode */
-    if ((uint32_t)RESET == (RTC_STAT & RTC_STAT_INITF)){   
+    if((uint32_t)RESET == (RTC_STAT & RTC_STAT_INITF)) {
         RTC_STAT |= RTC_STAT_INITM;
-        
-        /* wait until the INITF flag to be set */
-        do{
-           flag_status = RTC_STAT & RTC_STAT_INITF;
-        }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-        if ((uint32_t)RESET != flag_status){        
+        /* wait until the INITF flag to be set */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_INITF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+        if((uint32_t)RESET != flag_status) {
             error_status = SUCCESS;
         }
-    }else{
+    } else {
         error_status = SUCCESS;
     }
     return error_status;
@@ -217,7 +217,7 @@ void rtc_init_mode_exit(void)
 }
 
 /*!
-    \brief    wait until RTC_TIME and RTC_DATE registers are synchronized with APB clock, and the shadow 
+    \brief    wait until RTC_TIME and RTC_DATE registers are synchronized with APB clock, and the shadow
                 registers are updated
     \param[in]  none
     \param[out] none
@@ -229,7 +229,7 @@ ErrStatus rtc_register_sync_wait(void)
     uint32_t flag_status = RESET;
     ErrStatus error_status = ERROR;
 
-    if ((uint32_t)RESET == (RTC_CTL & RTC_CTL_BPSHAD)){
+    if((uint32_t)RESET == (RTC_CTL & RTC_CTL_BPSHAD)) {
         /* disable the write protection */
         RTC_WPK = RTC_UNLOCK_KEY1;
         RTC_WPK = RTC_UNLOCK_KEY2;
@@ -238,17 +238,17 @@ ErrStatus rtc_register_sync_wait(void)
         RTC_STAT &= (uint32_t)(~RTC_STAT_RSYNF);
 
         /* wait until RSYNF flag to be set */
-        do{
+        do {
             flag_status = RTC_STAT & RTC_STAT_RSYNF;
-        }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-        if ((uint32_t)RESET != flag_status){  
+        if((uint32_t)RESET != flag_status) {
             error_status = SUCCESS;
         }
-        
+
         /* enable the write protection */
         RTC_WPK = RTC_LOCK_KEY;
-    }else{ 
+    } else {
         error_status = SUCCESS;
     }
 
@@ -258,7 +258,7 @@ ErrStatus rtc_register_sync_wait(void)
 /*!
     \brief    get current time and date
     \param[in]  none
-    \param[out] rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains 
+    \param[out] rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains
                 parameters for initialization of the rtc peripheral
                 members of the structure and the member values are shown as below:
                   year: 0x0 - 0x99(BCD format)
@@ -276,26 +276,26 @@ ErrStatus rtc_register_sync_wait(void)
                   display_format: RTC_24HOUR, RTC_12HOUR
     \retval     none
 */
-void rtc_current_time_get(rtc_parameter_struct* rtc_initpara_struct)
+void rtc_current_time_get(rtc_parameter_struct *rtc_initpara_struct)
 {
     uint32_t temp_tr = 0U, temp_dr = 0U, temp_pscr = 0U, temp_ctlr = 0U;
 
-    temp_tr = (uint32_t)RTC_TIME;   
+    temp_tr = (uint32_t)RTC_TIME;
     temp_dr = (uint32_t)RTC_DATE;
     temp_pscr = (uint32_t)RTC_PSC;
     temp_ctlr = (uint32_t)RTC_CTL;
-  
+
     /* get current time and construct rtc_parameter_struct structure */
     rtc_initpara_struct->year = (uint8_t)GET_DATE_YR(temp_dr);
     rtc_initpara_struct->month = (uint8_t)GET_DATE_MON(temp_dr);
     rtc_initpara_struct->date = (uint8_t)GET_DATE_DAY(temp_dr);
-    rtc_initpara_struct->day_of_week = (uint8_t)GET_DATE_DOW(temp_dr);  
+    rtc_initpara_struct->day_of_week = (uint8_t)GET_DATE_DOW(temp_dr);
     rtc_initpara_struct->hour = (uint8_t)GET_TIME_HR(temp_tr);
     rtc_initpara_struct->minute = (uint8_t)GET_TIME_MN(temp_tr);
     rtc_initpara_struct->second = (uint8_t)GET_TIME_SC(temp_tr);
     rtc_initpara_struct->factor_asyn = (uint16_t)GET_PSC_FACTOR_A(temp_pscr);
     rtc_initpara_struct->factor_syn = (uint16_t)GET_PSC_FACTOR_S(temp_pscr);
-    rtc_initpara_struct->am_pm = (uint32_t)(temp_pscr & RTC_TIME_PM); 
+    rtc_initpara_struct->am_pm = (uint32_t)(temp_pscr & RTC_TIME_PM);
     rtc_initpara_struct->display_format = (uint32_t)(temp_ctlr & RTC_CTL_CS);
 }
 
@@ -311,7 +311,7 @@ uint32_t rtc_subsecond_get(void)
     /* if BPSHAD bit is reset, reading RTC_SS will lock RTC_TIME and RTC_DATE automatically */
     reg = (uint32_t)RTC_SS;
     /* read RTC_DATE to unlock the 3 shadow registers */
-    (void) (RTC_DATE);
+    (void)(RTC_DATE);
 
     return reg;
 }
@@ -319,7 +319,7 @@ uint32_t rtc_subsecond_get(void)
 /*!
     \brief    configure RTC alarm
     \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
-    \param[in]  rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains 
+    \param[in]  rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains
                 parameters for RTC alarm configuration
                 members of the structure and the member values are shown as below:
                   alarm_mask: RTC_ALARM_NONE_MASK, RTC_ALARM_DATE_MASK, RTC_ALARM_HOUR_MASK
@@ -335,26 +335,26 @@ uint32_t rtc_subsecond_get(void)
     \param[out] none
     \retval     none
 */
-void rtc_alarm_config(uint8_t rtc_alarm, rtc_alarm_struct* rtc_alarm_time)
+void rtc_alarm_config(uint8_t rtc_alarm, rtc_alarm_struct *rtc_alarm_time)
 {
     uint32_t reg_alrmtd = 0U;
 
-    reg_alrmtd =(rtc_alarm_time->alarm_mask | \
-                 rtc_alarm_time->weekday_or_date | \
-                 rtc_alarm_time->am_pm | \
-                 ALRMTD_DAY(rtc_alarm_time->alarm_day) | \
-                 ALRMTD_HR(rtc_alarm_time->alarm_hour) | \
-                 ALRMTD_MN(rtc_alarm_time->alarm_minute) | \
-                 ALRMTD_SC(rtc_alarm_time->alarm_second));
+    reg_alrmtd = (rtc_alarm_time->alarm_mask | \
+                  rtc_alarm_time->weekday_or_date | \
+                  rtc_alarm_time->am_pm | \
+                  ALRMTD_DAY(rtc_alarm_time->alarm_day) | \
+                  ALRMTD_HR(rtc_alarm_time->alarm_hour) | \
+                  ALRMTD_MN(rtc_alarm_time->alarm_minute) | \
+                  ALRMTD_SC(rtc_alarm_time->alarm_second));
 
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
 
-    if(RTC_ALARM0 == rtc_alarm){
+    if(RTC_ALARM0 == rtc_alarm) {
         RTC_ALRM0TD = (uint32_t)reg_alrmtd;
-    
-    }else{
+
+    } else {
         RTC_ALRM1TD = (uint32_t)reg_alrmtd;
     }
     /* enable the write protection */
@@ -389,12 +389,12 @@ void rtc_alarm_subsecond_config(uint8_t rtc_alarm, uint32_t mask_subsecond, uint
 {
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
-    RTC_WPK = RTC_UNLOCK_KEY2;  
+    RTC_WPK = RTC_UNLOCK_KEY2;
 
-    if(RTC_ALARM0 == rtc_alarm){
-        RTC_ALRM0SS = mask_subsecond | subsecond;  
-    }else{
-        RTC_ALRM1SS = mask_subsecond | subsecond; 
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_ALRM0SS = mask_subsecond | subsecond;
+    } else {
+        RTC_ALRM1SS = mask_subsecond | subsecond;
     }
     /* enable the write protection */
     RTC_WPK = RTC_LOCK_KEY;
@@ -403,7 +403,7 @@ void rtc_alarm_subsecond_config(uint8_t rtc_alarm, uint32_t mask_subsecond, uint
 /*!
     \brief    get RTC alarm
     \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
-    \param[out] rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains 
+    \param[out] rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains
                 parameters for RTC alarm configuration
                 members of the structure and the member values are shown as below:
                   alarm_mask: RTC_ALARM_NONE_MASK, RTC_ALARM_DATE_MASK, RTC_ALARM_HOUR_MASK
@@ -418,24 +418,24 @@ void rtc_alarm_subsecond_config(uint8_t rtc_alarm, uint32_t mask_subsecond, uint
                   am_pm: RTC_AM, RTC_PM
     \retval     none
 */
-void rtc_alarm_get(uint8_t rtc_alarm, rtc_alarm_struct* rtc_alarm_time)
+void rtc_alarm_get(uint8_t rtc_alarm, rtc_alarm_struct *rtc_alarm_time)
 {
     uint32_t reg_alrmtd = 0U;
 
     /* get the value of RTC_ALRM0TD register */
-    if(RTC_ALARM0 == rtc_alarm){
+    if(RTC_ALARM0 == rtc_alarm) {
         reg_alrmtd = RTC_ALRM0TD;
-    }else{
+    } else {
         reg_alrmtd = RTC_ALRM1TD;
     }
     /* get alarm parameters and construct the rtc_alarm_struct structure */
-    rtc_alarm_time->alarm_mask = reg_alrmtd & RTC_ALARM_ALL_MASK; 
+    rtc_alarm_time->alarm_mask = reg_alrmtd & RTC_ALARM_ALL_MASK;
     rtc_alarm_time->am_pm = (uint32_t)(reg_alrmtd & RTC_ALRMXTD_PM);
     rtc_alarm_time->weekday_or_date = (uint32_t)(reg_alrmtd & RTC_ALRMXTD_DOWS);
     rtc_alarm_time->alarm_day = (uint8_t)GET_ALRMTD_DAY(reg_alrmtd);
     rtc_alarm_time->alarm_hour = (uint8_t)GET_ALRMTD_HR(reg_alrmtd);
     rtc_alarm_time->alarm_minute = (uint8_t)GET_ALRMTD_MN(reg_alrmtd);
-    rtc_alarm_time->alarm_second = (uint8_t)GET_ALRMTD_SC(reg_alrmtd);  
+    rtc_alarm_time->alarm_second = (uint8_t)GET_ALRMTD_SC(reg_alrmtd);
 }
 
 /*!
@@ -446,9 +446,9 @@ void rtc_alarm_get(uint8_t rtc_alarm, rtc_alarm_struct* rtc_alarm_time)
 */
 uint32_t rtc_alarm_subsecond_get(uint8_t rtc_alarm)
 {
-    if(RTC_ALARM0 == rtc_alarm){
+    if(RTC_ALARM0 == rtc_alarm) {
         return ((uint32_t)(RTC_ALRM0SS & RTC_ALRM0SS_SSC));
-    }else{
+    } else {
         return ((uint32_t)(RTC_ALRM1SS & RTC_ALRM1SS_SSC));
     }
 }
@@ -465,9 +465,9 @@ void rtc_alarm_enable(uint8_t rtc_alarm)
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
 
-    if(RTC_ALARM0 == rtc_alarm){
+    if(RTC_ALARM0 == rtc_alarm) {
         RTC_CTL |= RTC_CTL_ALRM0EN;
-    }else{
+    } else {
         RTC_CTL |= RTC_CTL_ALRM1EN;
     }
     /* enable the write protection */
@@ -489,23 +489,23 @@ ErrStatus rtc_alarm_disable(uint8_t rtc_alarm)
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
-    
+
     /* clear the state of alarm */
-    if(RTC_ALARM0 == rtc_alarm){
-        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM0EN); 
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM0EN);
         /* wait until ALRM0WF flag to be set after the alarm is disabled */
-        do{
+        do {
             flag_status = RTC_STAT & RTC_STAT_ALRM0WF;
-        }while((--time_index > 0U) && ((uint32_t)RESET == flag_status)); 
-    }else{
-        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM1EN);  
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    } else {
+        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM1EN);
         /* wait until ALRM1WF flag to be set after the alarm is disabled */
-        do{
+        do {
             flag_status = RTC_STAT & RTC_STAT_ALRM1WF;
-        }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
     }
-  
-    if ((uint32_t)RESET != flag_status){     
+
+    if((uint32_t)RESET != flag_status) {
         error_status = SUCCESS;
     }
 
@@ -532,7 +532,7 @@ void rtc_timestamp_enable(uint32_t edge)
 
     /* new configuration */
     reg_ctl |= (uint32_t)(edge | RTC_CTL_TSEN);
-   
+
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -554,7 +554,7 @@ void rtc_timestamp_disable(void)
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
-    
+
     /* clear the TSEN bit */
     RTC_CTL &= (uint32_t)(~ RTC_CTL_TSEN);
 
@@ -565,7 +565,7 @@ void rtc_timestamp_disable(void)
 /*!
     \brief    get RTC timestamp time and date
     \param[in]  none
-    \param[out] rtc_timestamp: pointer to a rtc_timestamp_struct structure which contains 
+    \param[out] rtc_timestamp: pointer to a rtc_timestamp_struct structure which contains
                 parameters for RTC time-stamp configuration
                 members of the structure and the member values are shown as below:
                   timestamp_month: RTC_JAN, RTC_FEB, RTC_MAR, RTC_APR, RTC_MAY, RTC_JUN,
@@ -579,14 +579,14 @@ void rtc_timestamp_disable(void)
                   am_pm: RTC_AM, RTC_PM
     \retval     none
 */
-void rtc_timestamp_get(rtc_timestamp_struct* rtc_timestamp)
+void rtc_timestamp_get(rtc_timestamp_struct *rtc_timestamp)
 {
     uint32_t temp_tts = 0U, temp_dts = 0U;
 
     /* get the value of time_stamp registers */
     temp_tts = (uint32_t)RTC_TTS;
     temp_dts = (uint32_t)RTC_DTS;
-  
+
     /* get timestamp time and construct the rtc_timestamp_struct structure */
     rtc_timestamp->am_pm = (uint32_t)(temp_tts & RTC_TTS_PM);
     rtc_timestamp->timestamp_month = (uint8_t)GET_DTS_MON(temp_dts);
@@ -609,7 +609,7 @@ uint32_t rtc_timestamp_subsecond_get(void)
 }
 
 /*!
-    \brief    RTC time-stamp mapping 
+    \brief    RTC time-stamp mapping
     \param[in]  rtc_af:
       \arg        RTC_AF0_TIMESTAMP: RTC_AF0 use for timestamp
       \arg        RTC_AF1_TIMESTAMP: RTC_AF1 use for timestamp
@@ -624,7 +624,7 @@ void rtc_timestamp_pin_map(uint32_t rtc_af)
 
 /*!
     \brief    enable RTC tamper
-    \param[in]  rtc_tamper: pointer to a rtc_tamper_struct structure which contains 
+    \param[in]  rtc_tamper: pointer to a rtc_tamper_struct structure which contains
                 parameters for RTC tamper configuration
                 members of the structure and the member values are shown as below:
                   detecting tamper event can using edge mode or level mode
@@ -646,49 +646,49 @@ void rtc_timestamp_pin_map(uint32_t rtc_af)
     \param[out] none
     \retval     none
 */
-void rtc_tamper_enable(rtc_tamper_struct* rtc_tamper)
+void rtc_tamper_enable(rtc_tamper_struct *rtc_tamper)
 {
     /* disable tamper */
-    RTC_TAMP &= (uint32_t)~(rtc_tamper->tamper_source); 
+    RTC_TAMP &= (uint32_t)~(rtc_tamper->tamper_source);
 
     /* tamper filter must be used when the tamper source is voltage level detection */
     RTC_TAMP &= (uint32_t)~RTC_TAMP_FLT;
-    
+
     /* the tamper source is voltage level detection */
-    if((uint32_t)(rtc_tamper->tamper_filter) != RTC_FLT_EDGE ){ 
+    if((uint32_t)(rtc_tamper->tamper_filter) != RTC_FLT_EDGE) {
         RTC_TAMP &= (uint32_t)~(RTC_TAMP_DISPU | RTC_TAMP_PRCH | RTC_TAMP_FREQ | RTC_TAMP_FLT);
 
         /* check if the tamper pin need precharge, if need, then configure the precharge time */
-        if(DISABLE == rtc_tamper->tamper_precharge_enable){
-            RTC_TAMP |=  (uint32_t)RTC_TAMP_DISPU;    
-        }else{
+        if(DISABLE == rtc_tamper->tamper_precharge_enable) {
+            RTC_TAMP |= (uint32_t)RTC_TAMP_DISPU;
+        } else {
             RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_precharge_time);
         }
 
         RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_sample_frequency);
         RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_filter);
-        
+
         /* configure the tamper trigger */
-        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));    
-        if(RTC_TAMPER_TRIGGER_LEVEL_LOW != rtc_tamper->tamper_trigger){
-            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source)<< RTC_TAMPER_TRIGGER_POS);
+        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));
+        if(RTC_TAMPER_TRIGGER_LEVEL_LOW != rtc_tamper->tamper_trigger) {
+            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS);
         }
-    }else{
- 
+    } else {
+
         /* configure the tamper trigger */
-        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));    
-        if(RTC_TAMPER_TRIGGER_EDGE_RISING != rtc_tamper->tamper_trigger){
-            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source)<< RTC_TAMPER_TRIGGER_POS);  
+        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));
+        if(RTC_TAMPER_TRIGGER_EDGE_RISING != rtc_tamper->tamper_trigger) {
+            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS);
         }
     }
-    
-    RTC_TAMP &= (uint32_t)~RTC_TAMP_TPTS;      
-    if(DISABLE != rtc_tamper->tamper_with_timestamp){           
+
+    RTC_TAMP &= (uint32_t)~RTC_TAMP_TPTS;
+    if(DISABLE != rtc_tamper->tamper_with_timestamp) {
         /* the tamper event also cause a time-stamp event */
         RTC_TAMP |= (uint32_t)RTC_TAMP_TPTS;
-    }    
+    }
     /* enable tamper */
-    RTC_TAMP |=  (uint32_t)(rtc_tamper->tamper_source); 
+    RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_source);
 }
 
 /*!
@@ -702,12 +702,12 @@ void rtc_tamper_enable(rtc_tamper_struct* rtc_tamper)
 void rtc_tamper_disable(uint32_t source)
 {
     /* disable tamper */
-    RTC_TAMP &= (uint32_t)~source; 
+    RTC_TAMP &= (uint32_t)~source;
 
 }
 
 /*!
-    \brief    RTC tamper0 mapping 
+    \brief    RTC tamper0 mapping
     \param[in]  rtc_af:
       \arg        RTC_AF0_TAMPER0: RTC_AF0 use for tamper0
       \arg        RTC_AF1_TAMPER0: RTC_AF1 use for tamper0
@@ -732,18 +732,18 @@ void rtc_tamper0_pin_map(uint32_t rtc_af)
     \retval     none
 */
 void rtc_interrupt_enable(uint32_t interrupt)
-{  
+{
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
- 
+
     /* enable the interrupts in RTC_CTL register */
     RTC_CTL |= (uint32_t)(interrupt & (uint32_t)~RTC_TAMP_TPIE);
     /* enable the interrupts in RTC_TAMP register */
     RTC_TAMP |= (uint32_t)(interrupt & RTC_TAMP_TPIE);
-    
+
     /* enable the write protection */
-    RTC_WPK = RTC_LOCK_KEY; 
+    RTC_WPK = RTC_LOCK_KEY;
 }
 
 /*!
@@ -758,11 +758,11 @@ void rtc_interrupt_enable(uint32_t interrupt)
     \retval     none
 */
 void rtc_interrupt_disable(uint32_t interrupt)
-{  
+{
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
- 
+
     /* disable the interrupts in RTC_CTL register */
     RTC_CTL &= (uint32_t)~(interrupt & (uint32_t)~RTC_TAMP_TPIE);
     /* disable the interrupts in RTC_TAMP register */
@@ -779,9 +779,9 @@ void rtc_interrupt_disable(uint32_t interrupt)
       \arg        RTC_FLAG_TP1: RTC tamper 1 detected flag
       \arg        RTC_FLAG_TP0: RTC tamper 0 detected flag
       \arg        RTC_FLAG_TSOVR: time-stamp overflow flag
-      \arg        RTC_FLAG_TS: time-stamp flag 
-      \arg        RTC_FLAG_ALARM0: alarm0 occurs flag
-      \arg        RTC_FLAG_ALARM1: alarm1 occurs flag
+      \arg        RTC_FLAG_TS: time-stamp flag
+      \arg        RTC_FLAG_ALRM0: alarm0 occurs flag
+      \arg        RTC_FLAG_ALRM1: alarm1 occurs flag
       \arg        RTC_FLAG_WT: wakeup timer occurs flag
       \arg        RTC_FLAG_INIT: initialization state flag
       \arg        RTC_FLAG_RSYN: register synchronization flag
@@ -796,8 +796,8 @@ void rtc_interrupt_disable(uint32_t interrupt)
 FlagStatus rtc_flag_get(uint32_t flag)
 {
     FlagStatus flag_state = RESET;
-    
-    if ((uint32_t)RESET != (RTC_STAT & flag)){
+
+    if((uint32_t)RESET != (RTC_STAT & flag)) {
         flag_state = SET;
     }
     return flag_state;
@@ -818,7 +818,7 @@ FlagStatus rtc_flag_get(uint32_t flag)
 */
 void rtc_flag_clear(uint32_t flag)
 {
-    RTC_STAT &= (uint32_t)(~flag);  
+    RTC_STAT &= (uint32_t)(~flag);
 }
 
 /*!
@@ -856,9 +856,9 @@ void rtc_alarm_output_config(uint32_t source, uint32_t mode)
 /*!
     \brief    configure rtc calibration output source
     \param[in]  source: specify signal to output
-      \arg        RTC_CALIBRATION_512HZ: when the LSE freqency is 32768Hz and the RTC_PSC 
+      \arg        RTC_CALIBRATION_512HZ: when the LSE freqency is 32768Hz and the RTC_PSC
                                          is the default value, output 512Hz signal
-      \arg        RTC_CALIBRATION_1HZ: when the LSE freqency is 32768Hz and the RTC_PSC 
+      \arg        RTC_CALIBRATION_1HZ: when the LSE freqency is 32768Hz and the RTC_PSC
                                        is the default value, output 1Hz signal
     \param[out] none
     \retval     none
@@ -876,7 +876,6 @@ void rtc_calibration_output_config(uint32_t source)
     RTC_WPK = RTC_LOCK_KEY;
 }
 
-
 /*!
     \brief    adjust the daylight saving time by adding or substracting one hour from the current time
     \param[in]  operation: hour adjustment operation
@@ -890,7 +889,7 @@ void rtc_hour_adjust(uint32_t operation)
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
-    
+
     RTC_CTL |= (uint32_t)(operation);
 
     /* enable the write protection */
@@ -911,21 +910,21 @@ ErrStatus rtc_second_adjust(uint32_t add, uint32_t minus)
     volatile uint32_t time_index = RTC_SHIFTCTL_TIMEOUT;
     ErrStatus error_status = ERROR;
     uint32_t flag_status = RESET;
-    uint32_t temp=0U;
+    uint32_t temp = 0U;
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
-    
-    /* check if a shift operation is ongoing */    
-    do{
+
+    /* check if a shift operation is ongoing */
+    do {
         flag_status = RTC_STAT & RTC_STAT_SOPF;
-    }while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
-    
+    } while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
+
     /* check if the function of reference clock detection is disabled */
     temp = RTC_CTL & RTC_CTL_REFEN;
-    if((RESET == flag_status) && (RESET == temp)){  
+    if((RESET == flag_status) && (RESET == temp)) {
         RTC_SHIFTCTL = (uint32_t)(add | SHIFTCTL_SFS(minus));
-        error_status = rtc_register_sync_wait();        
+        error_status = rtc_register_sync_wait();
     }
 
     /* enable the write protection */
@@ -941,7 +940,7 @@ ErrStatus rtc_second_adjust(uint32_t add, uint32_t minus)
     \retval     none
 */
 void rtc_bypass_shadow_enable(void)
-{ 
+{
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -959,7 +958,7 @@ void rtc_bypass_shadow_enable(void)
     \retval     none
 */
 void rtc_bypass_shadow_disable(void)
-{ 
+{
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -979,7 +978,7 @@ void rtc_bypass_shadow_disable(void)
 ErrStatus rtc_refclock_detection_enable(void)
 {
     ErrStatus error_status = ERROR;
-    
+
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -987,7 +986,7 @@ ErrStatus rtc_refclock_detection_enable(void)
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){
+    if(ERROR != error_status) {
         RTC_CTL |= (uint32_t)RTC_CTL_REFEN;
         /* exit init mode */
         rtc_init_mode_exit();
@@ -1008,7 +1007,7 @@ ErrStatus rtc_refclock_detection_enable(void)
 ErrStatus rtc_refclock_detection_disable(void)
 {
     ErrStatus error_status = ERROR;
-    
+
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
@@ -1016,7 +1015,7 @@ ErrStatus rtc_refclock_detection_disable(void)
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){ 
+    if(ERROR != error_status) {
         RTC_CTL &= (uint32_t)~RTC_CTL_REFEN;
         /* exit init mode */
         rtc_init_mode_exit();
@@ -1038,7 +1037,7 @@ void rtc_wakeup_enable(void)
 {
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
-    RTC_WPK = RTC_UNLOCK_KEY2; 
+    RTC_WPK = RTC_UNLOCK_KEY2;
 
     RTC_CTL |= RTC_CTL_WTEN;
 
@@ -1062,13 +1061,13 @@ ErrStatus rtc_wakeup_disable(void)
     RTC_WPK = RTC_UNLOCK_KEY2;
     RTC_CTL &= ~RTC_CTL_WTEN;
     /* wait until the WTWF flag to be set */
-    do{
+    do {
         flag_status = RTC_STAT & RTC_STAT_WTWF;
-    }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-    if ((uint32_t)RESET == flag_status){
+    if((uint32_t)RESET == flag_status) {
         error_status = ERROR;
-    }else{
+    } else {
         error_status = SUCCESS;
     }
     /* enable the write protection */
@@ -1079,12 +1078,12 @@ ErrStatus rtc_wakeup_disable(void)
 /*!
     \brief    set RTC auto wakeup timer clock
     \param[in]  wakeup_clock:
-      \arg        WAKEUP_RTCCK_DIV16: RTC auto wakeup timer clock is RTC clock divided by 16 
-      \arg        WAKEUP_RTCCK_DIV8: RTC auto wakeup timer clock is RTC clock divided by 8 
-      \arg        WAKEUP_RTCCK_DIV4: RTC auto wakeup timer clock is RTC clock divided by 4 
-      \arg        WAKEUP_RTCCK_DIV2: RTC auto wakeup timer clock is RTC clock divided by 2 
+      \arg        WAKEUP_RTCCK_DIV16: RTC auto wakeup timer clock is RTC clock divided by 16
+      \arg        WAKEUP_RTCCK_DIV8: RTC auto wakeup timer clock is RTC clock divided by 8
+      \arg        WAKEUP_RTCCK_DIV4: RTC auto wakeup timer clock is RTC clock divided by 4
+      \arg        WAKEUP_RTCCK_DIV2: RTC auto wakeup timer clock is RTC clock divided by 2
       \arg        WAKEUP_CKSPRE: RTC auto wakeup timer clock is ckspre
-      \arg        WAKEUP_CKSPRE_2EXP16: RTC auto wakeup timer clock is ckspre and wakeup timer add 2exp16 
+      \arg        WAKEUP_CKSPRE_2EXP16: RTC auto wakeup timer clock is ckspre and wakeup timer add 2exp16
     \param[out] none
     \retval     ErrStatus: ERROR or SUCCESS
 */
@@ -1095,23 +1094,23 @@ ErrStatus rtc_wakeup_clock_set(uint8_t wakeup_clock)
     uint32_t flag_status = RESET;
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
-    RTC_WPK = RTC_UNLOCK_KEY2; 
+    RTC_WPK = RTC_UNLOCK_KEY2;
     /* only when RTC_CTL_WTEN=0 and RTC_STAT_WTWF=1 can write RTC_CTL[2��0] */
     /* wait until the WTWF flag to be set */
-    do{
+    do {
         flag_status = RTC_STAT & RTC_STAT_WTWF;
-    }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-    if ((uint32_t)RESET == flag_status){
+    if((uint32_t)RESET == flag_status) {
         error_status = ERROR;
-    }else{
+    } else {
         RTC_CTL &= (uint32_t)~ RTC_CTL_WTCS;
         RTC_CTL |= (uint32_t)wakeup_clock;
         error_status = SUCCESS;
     }
     /* enable the write protection */
     RTC_WPK = RTC_LOCK_KEY;
-    
+
     return error_status;
 }
 
@@ -1130,13 +1129,13 @@ ErrStatus rtc_wakeup_timer_set(uint16_t wakeup_timer)
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
     /* wait until the WTWF flag to be set */
-    do{
+    do {
         flag_status = RTC_STAT & RTC_STAT_WTWF;
-    }while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
 
-    if ((uint32_t)RESET == flag_status){
+    if((uint32_t)RESET == flag_status) {
         error_status = ERROR;
-    }else{
+    } else {
         RTC_WUT = (uint32_t)wakeup_timer;
         error_status = SUCCESS;
     }
@@ -1151,7 +1150,7 @@ ErrStatus rtc_wakeup_timer_set(uint16_t wakeup_timer)
     \param[out] none
     \retval     wakeup timer value
 */
- uint16_t rtc_wakeup_timer_get(void)
+uint16_t rtc_wakeup_timer_get(void)
 {
     return (uint16_t)RTC_WUT;
 }
@@ -1174,17 +1173,17 @@ ErrStatus rtc_smooth_calibration_config(uint32_t window, uint32_t plus, uint32_t
     volatile uint32_t time_index = RTC_HRFC_TIMEOUT;
     ErrStatus error_status = ERROR;
     uint32_t flag_status = RESET;
-    
+
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
-    RTC_WPK = RTC_UNLOCK_KEY2;    
-    
-    /* check if a smooth calibration operation is ongoing */        
-    do{
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* check if a smooth calibration operation is ongoing */
+    do {
         flag_status = RTC_STAT & RTC_STAT_SCPF;
-    }while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
-    
-    if((uint32_t)RESET == flag_status){
+    } while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET == flag_status) {
         RTC_HRFC = (uint32_t)(window | plus | HRFC_CMSK(minus));
         error_status = SUCCESS;
     }
@@ -1210,12 +1209,12 @@ ErrStatus rtc_coarse_calibration_enable(void)
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){ 
+    if(ERROR != error_status) {
         RTC_CTL |= (uint32_t)RTC_CTL_CCEN;
         /* exit init mode */
         rtc_init_mode_exit();
     }
-    
+
     /* enable the write protection */
     RTC_WPK = RTC_LOCK_KEY;
     return error_status;
@@ -1232,24 +1231,24 @@ ErrStatus rtc_coarse_calibration_disable(void)
     ErrStatus error_status = ERROR;
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
-    RTC_WPK = RTC_UNLOCK_KEY2;    
+    RTC_WPK = RTC_UNLOCK_KEY2;
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){ 
+    if(ERROR != error_status) {
         RTC_CTL &= (uint32_t)~RTC_CTL_CCEN;
         /* exit init mode */
         rtc_init_mode_exit();
     }
-    
+
     /* enable the write protection */
-    RTC_WPK = RTC_LOCK_KEY;	
+    RTC_WPK = RTC_LOCK_KEY;
     return error_status;
 }
 
 /*!
     \brief    config coarse calibration direction and step
-    \param[in]  direction: CALIB_INCREASE or CALIB_DECREASE      
+    \param[in]  direction: CALIB_INCREASE or CALIB_DECREASE
     \param[in]  step: 0x00-0x1F
                 COSD=0:
                   0x00:+0 PPM
@@ -1272,14 +1271,14 @@ ErrStatus rtc_coarse_calibration_config(uint8_t direction, uint8_t step)
     /* disable the write protection */
     RTC_WPK = RTC_UNLOCK_KEY1;
     RTC_WPK = RTC_UNLOCK_KEY2;
-    
+
     /* enter init mode */
     error_status = rtc_init_mode_enter();
 
-    if(ERROR != error_status){ 
-        if(CALIB_DECREASE == direction){
+    if(ERROR != error_status) {
+        if(CALIB_DECREASE == direction) {
             RTC_COSC |= (uint32_t)RTC_COSC_COSD;
-        }else{
+        } else {
             RTC_COSC &= (uint32_t)~RTC_COSC_COSD;
         }
         RTC_COSC &= ~RTC_COSC_COSS;
@@ -1287,9 +1286,9 @@ ErrStatus rtc_coarse_calibration_config(uint8_t direction, uint8_t step)
         /* exit init mode */
         rtc_init_mode_exit();
     }
-    
+
     /* enable the write protection */
     RTC_WPK = RTC_LOCK_KEY;
-    
+
     return error_status;
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_sdio.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_sdio.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_sdio.c
     \brief   SDIO driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.1, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -73,7 +74,7 @@ void sdio_clock_config(uint32_t clock_edge, uint32_t clock_bypass, uint32_t cloc
     /* reset the CLKEDGE, CLKBYP, CLKPWRSAV, DIV */
     clock_config &= ~(SDIO_CLKCTL_CLKEDGE | SDIO_CLKCTL_CLKBYP | SDIO_CLKCTL_CLKPWRSAV | SDIO_CLKCTL_DIV8 | SDIO_CLKCTL_DIV);
     /* if the clock division is greater or equal to 256, set the DIV[8] */
-    if(clock_division >= 256U){
+    if(clock_division >= 256U) {
         clock_config |= SDIO_CLKCTL_DIV8;
         clock_division -= 256U;
     }
@@ -262,7 +263,7 @@ uint8_t sdio_command_index_get(void)
 uint32_t sdio_response_get(uint32_t sdio_responsex)
 {
     uint32_t resp_content = 0U;
-    switch(sdio_responsex){
+    switch(sdio_responsex) {
     case SDIO_RESPONSE0:
         resp_content = SDIO_RESP0;
         break;
@@ -462,7 +463,7 @@ void sdio_dma_disable(void)
 FlagStatus sdio_flag_get(uint32_t flag)
 {
     FlagStatus temp_flag = RESET;
-    if(RESET != (SDIO_STAT & flag)){
+    if(RESET != (SDIO_STAT & flag)) {
         temp_flag = SET;
     }
     return temp_flag;
@@ -599,7 +600,7 @@ void sdio_interrupt_disable(uint32_t int_flag)
 FlagStatus sdio_interrupt_flag_get(uint32_t int_flag)
 {
     FlagStatus temp_flag = RESET;
-    if(RESET != (SDIO_STAT & int_flag)){
+    if(RESET != (SDIO_STAT & int_flag)) {
         temp_flag = SET;
     }
     return temp_flag;
@@ -685,9 +686,9 @@ void sdio_stop_readwait_disable(void)
 */
 void sdio_readwait_type_set(uint32_t readwait_type)
 {
-    if(SDIO_READWAITTYPE_CLK == readwait_type){
+    if(SDIO_READWAITTYPE_CLK == readwait_type) {
         SDIO_DATACTL |= SDIO_DATACTL_RWTYPE;
-    }else{
+    } else {
         SDIO_DATACTL &= ~SDIO_DATACTL_RWTYPE;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_spi.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_spi.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -47,14 +48,14 @@ OF SUCH DAMAGE.
 #define SPI_I2SPSC_DEFAULT_VALUE        ((uint32_t)0x00000002U)  /*!< default value of SPI_I2SPSC register */
 
 /*!
-    \brief    deinitialize SPI and I2S 
+    \brief      deinitialize SPI and I2S
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5),include I2S1_ADD and I2S2_ADD
     \param[out] none
     \retval     none
 */
 void spi_i2s_deinit(uint32_t spi_periph)
 {
-    switch(spi_periph){
+    switch(spi_periph) {
     case SPI0:
         /* reset SPI0 */
         rcu_periph_reset_enable(RCU_SPI0RST);
@@ -91,7 +92,7 @@ void spi_i2s_deinit(uint32_t spi_periph)
 }
 
 /*!
-    \brief    initialize the parameters of SPI struct with default values
+    \brief      initialize the parameters of SPI struct with default values
     \param[in]  none
     \param[out] spi_parameter_struct: the initialized struct spi_parameter_struct pointer
     \retval     none
@@ -108,7 +109,7 @@ void spi_struct_para_init(spi_parameter_struct *spi_struct)
     spi_struct->endian               = SPI_ENDIAN_MSB;
 }
 /*!
-    \brief    initialize SPI parameter
+    \brief      initialize SPI parameter
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_struct: SPI parameter initialization stuct members of the structure
                 and the member values are shown as below:
@@ -124,8 +125,8 @@ void spi_struct_para_init(spi_parameter_struct *spi_struct)
     \param[out] none
     \retval     none
 */
-void spi_init(uint32_t spi_periph, spi_parameter_struct* spi_struct)
-{   
+void spi_init(uint32_t spi_periph, spi_parameter_struct *spi_struct)
+{
     uint32_t reg = 0U;
     reg = SPI_CTL0(spi_periph);
     reg &= SPI_INIT_MASK;
@@ -152,7 +153,7 @@ void spi_init(uint32_t spi_periph, spi_parameter_struct* spi_struct)
 }
 
 /*!
-    \brief    enable SPI 
+    \brief      enable SPI
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -163,7 +164,7 @@ void spi_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    disable SPI 
+    \brief      disable SPI
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -174,7 +175,7 @@ void spi_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    initialize I2S parameter 
+    \brief      initialize I2S parameter
     \param[in]  spi_periph: SPIx(x=1,2)
     \param[in]  i2s_mode: I2S operation mode
                 only one parameter can be selected which is shown as below:
@@ -198,12 +199,12 @@ void spi_disable(uint32_t spi_periph)
 */
 void i2s_init(uint32_t spi_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl)
 {
-    uint32_t reg= 0U;
+    uint32_t reg = 0U;
     reg = SPI_I2SCTL(spi_periph);
     reg &= I2S_INIT_MASK;
 
     /* enable I2S mode */
-    reg |= (uint32_t)SPI_I2SCTL_I2SSEL; 
+    reg |= (uint32_t)SPI_I2SCTL_I2SSEL;
     /* select I2S mode */
     reg |= (uint32_t)i2s_mode;
     /* select I2S standard */
@@ -216,7 +217,7 @@ void i2s_init(uint32_t spi_periph, uint32_t i2s_mode, uint32_t i2s_standard, uin
 }
 
 /*!
-    \brief    configure I2S prescale
+    \brief      configure I2S prescale
     \param[in]  spi_periph: SPIx(x=1,2)
     \param[in]  i2s_audiosample: I2S audio sample rate
                 only one parameter can be selected which is shown as below:
@@ -249,7 +250,7 @@ void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_
     uint32_t i2sclock = 0U;
 
 #ifndef I2S_EXTERNAL_CLOCK_IN
-  uint32_t plli2sm = 0U, plli2sn = 0U, plli2sr = 0U;
+    uint32_t plli2sm = 0U, plli2sn = 0U, plli2sr = 0U;
 #endif /* I2S_EXTERNAL_CLOCK_IN */
 
     /* deinit SPI_I2SPSC register */
@@ -280,25 +281,23 @@ void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_
     /* get the RCU_PLLI2S_PLLI2SR value */
     plli2sr = (uint32_t)((RCU_PLLI2S & RCU_PLLI2S_PLLI2SR) >> 28);
 
-    if((RCU_PLL & RCU_PLL_PLLSEL) == RCU_PLLSRC_HXTAL)
-    {
-      /* get the I2S source clock value */
-      i2sclock = (uint32_t)(((HXTAL_VALUE / plli2sm) * plli2sn) / plli2sr);
-    }
-    else
-    { /* get the I2S source clock value */
-      i2sclock = (uint32_t)(((IRC16M_VALUE / plli2sm) * plli2sn) / plli2sr);
+    if((RCU_PLL & RCU_PLL_PLLSEL) == RCU_PLLSRC_HXTAL) {
+        /* get the I2S source clock value */
+        i2sclock = (uint32_t)(((HXTAL_VALUE / plli2sm) * plli2sn) / plli2sr);
+    } else {
+        /* get the I2S source clock value */
+        i2sclock = (uint32_t)(((IRC16M_VALUE / plli2sm) * plli2sn) / plli2sr);
     }
 #endif /* I2S_EXTERNAL_CLOCK_IN */
 
     /* config the prescaler depending on the mclk output state, the frame format and audio sample rate */
-    if(I2S_MCKOUT_ENABLE == i2s_mckout){
+    if(I2S_MCKOUT_ENABLE == i2s_mckout) {
         clks = (uint32_t)(((i2sclock / 256U) * 10U) / i2s_audiosample);
-    }else{
-        if(I2S_FRAMEFORMAT_DT16B_CH16B == i2s_frameformat){
-            clks = (uint32_t)(((i2sclock / 32U) *10U ) / i2s_audiosample);
-        }else{
-            clks = (uint32_t)(((i2sclock / 64U) *10U ) / i2s_audiosample);
+    } else {
+        if(I2S_FRAMEFORMAT_DT16B_CH16B == i2s_frameformat) {
+            clks = (uint32_t)(((i2sclock / 32U) * 10U) / i2s_audiosample);
+        } else {
+            clks = (uint32_t)(((i2sclock / 64U) * 10U) / i2s_audiosample);
         }
     }
     /* remove the floating point */
@@ -308,7 +307,7 @@ void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_
     i2sof = (i2sof << 8U);
 
     /* set the default values */
-    if((i2sdiv< 2U) || (i2sdiv > 255U)){
+    if((i2sdiv < 2U) || (i2sdiv > 255U)) {
         i2sdiv = 2U;
         i2sof = 0U;
     }
@@ -317,13 +316,13 @@ void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_
     SPI_I2SPSC(spi_periph) = (uint32_t)(i2sdiv | i2sof | i2s_mckout);
 
     /* clear SPI_I2SCTL_DTLEN and SPI_I2SCTL_CHLEN bits */
-    SPI_I2SCTL(spi_periph) &= (uint32_t)(~(SPI_I2SCTL_DTLEN|SPI_I2SCTL_CHLEN));
+    SPI_I2SCTL(spi_periph) &= (uint32_t)(~(SPI_I2SCTL_DTLEN | SPI_I2SCTL_CHLEN));
     /* configure data frame format */
     SPI_I2SCTL(spi_periph) |= (uint32_t)i2s_frameformat;
 }
 
 /*!
-    \brief    enable I2S 
+    \brief      enable I2S
     \param[in]  spi_periph: SPIx(x=1,2)
     \param[out] none
     \retval     none
@@ -334,7 +333,7 @@ void i2s_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    disable I2S 
+    \brief      disable I2S
     \param[in]  spi_periph: SPIx(x=1,2)
     \param[out] none
     \retval     none
@@ -345,7 +344,7 @@ void i2s_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    enable SPI nss output 
+    \brief      enable SPI nss output
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -356,7 +355,7 @@ void spi_nss_output_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    disable SPI nss output 
+    \brief      disable SPI nss output
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -367,7 +366,7 @@ void spi_nss_output_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    SPI nss pin high level in software mode
+    \brief      SPI nss pin high level in software mode
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -378,7 +377,7 @@ void spi_nss_internal_high(uint32_t spi_periph)
 }
 
 /*!
-    \brief    SPI nss pin low level in software mode
+    \brief      SPI nss pin low level in software mode
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -389,7 +388,7 @@ void spi_nss_internal_low(uint32_t spi_periph)
 }
 
 /*!
-    \brief    enable SPI DMA send or receive
+    \brief      enable SPI DMA send or receive
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_dma: SPI DMA mode
                 only one parameter can be selected which is shown as below:
@@ -400,15 +399,15 @@ void spi_nss_internal_low(uint32_t spi_periph)
 */
 void spi_dma_enable(uint32_t spi_periph, uint8_t spi_dma)
 {
-    if(SPI_DMA_TRANSMIT == spi_dma){
+    if(SPI_DMA_TRANSMIT == spi_dma) {
         SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_DMATEN;
-    }else{
+    } else {
         SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_DMAREN;
     }
 }
 
 /*!
-    \brief    diable SPI DMA send or receive 
+    \brief      diable SPI DMA send or receive
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_dma: SPI DMA mode
                 only one parameter can be selected which is shown as below:
@@ -419,15 +418,15 @@ void spi_dma_enable(uint32_t spi_periph, uint8_t spi_dma)
 */
 void spi_dma_disable(uint32_t spi_periph, uint8_t spi_dma)
 {
-    if(SPI_DMA_TRANSMIT == spi_dma){
+    if(SPI_DMA_TRANSMIT == spi_dma) {
         SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_DMATEN);
-    }else{
+    } else {
         SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_DMAREN);
     }
 }
 
 /*!
-    \brief    configure SPI/I2S data frame format
+    \brief      configure SPI/I2S data frame format
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  frame_format: SPI frame size
                 only one parameter can be selected which is shown as below:
@@ -445,7 +444,7 @@ void spi_i2s_data_frame_format_config(uint32_t spi_periph, uint16_t frame_format
 }
 
 /*!
-    \brief    SPI transmit data
+    \brief      SPI transmit data
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  data: 16-bit data
     \param[out] none
@@ -457,7 +456,7 @@ void spi_i2s_data_transmit(uint32_t spi_periph, uint16_t data)
 }
 
 /*!
-    \brief    SPI receive data
+    \brief      SPI receive data
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     16-bit data
@@ -468,7 +467,7 @@ uint16_t spi_i2s_data_receive(uint32_t spi_periph)
 }
 
 /*!
-    \brief    configure SPI bidirectional transfer direction
+    \brief      configure SPI bidirectional transfer direction
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  transfer_direction: SPI transfer direction
                 only one parameter can be selected which is shown as below:
@@ -478,30 +477,30 @@ uint16_t spi_i2s_data_receive(uint32_t spi_periph)
 */
 void spi_bidirectional_transfer_config(uint32_t spi_periph, uint32_t transfer_direction)
 {
-    if(SPI_BIDIRECTIONAL_TRANSMIT == transfer_direction){
+    if(SPI_BIDIRECTIONAL_TRANSMIT == transfer_direction) {
         /* set the transmit only mode */
         SPI_CTL0(spi_periph) |= (uint32_t)SPI_BIDIRECTIONAL_TRANSMIT;
-    }else{
+    } else {
         /* set the receive only mode */
         SPI_CTL0(spi_periph) &= SPI_BIDIRECTIONAL_RECEIVE;
     }
 }
 
 /*!
-    \brief    set SPI CRC polynomial 
+    \brief      set SPI CRC polynomial
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  crc_poly: CRC polynomial value
     \param[out] none
     \retval     none
 */
-void spi_crc_polynomial_set(uint32_t spi_periph,uint16_t crc_poly)
+void spi_crc_polynomial_set(uint32_t spi_periph, uint16_t crc_poly)
 {
     /* set SPI CRC polynomial */
     SPI_CRCPOLY(spi_periph) = (uint32_t)crc_poly;
 }
 
 /*!
-    \brief    get SPI CRC polynomial 
+    \brief      get SPI CRC polynomial
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     16-bit CRC polynomial
@@ -512,7 +511,7 @@ uint16_t spi_crc_polynomial_get(uint32_t spi_periph)
 }
 
 /*!
-    \brief    turn on CRC function 
+    \brief      turn on SPI CRC function
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -523,7 +522,7 @@ void spi_crc_on(uint32_t spi_periph)
 }
 
 /*!
-    \brief    turn off CRC function 
+    \brief      turn off SPI CRC function
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -534,7 +533,7 @@ void spi_crc_off(uint32_t spi_periph)
 }
 
 /*!
-    \brief    SPI next data is CRC value
+    \brief      SPI next data is CRC value
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -545,7 +544,7 @@ void spi_crc_next(uint32_t spi_periph)
 }
 
 /*!
-    \brief    get SPI CRC send value or receive value
+    \brief      get SPI CRC send value or receive value
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_crc: SPI crc value
                 only one parameter can be selected which is shown as below:
@@ -554,17 +553,17 @@ void spi_crc_next(uint32_t spi_periph)
     \param[out] none
     \retval     16-bit CRC value
 */
-uint16_t spi_crc_get(uint32_t spi_periph,uint8_t spi_crc)
+uint16_t spi_crc_get(uint32_t spi_periph, uint8_t spi_crc)
 {
-    if(SPI_CRC_TX == spi_crc){
+    if(SPI_CRC_TX == spi_crc) {
         return ((uint16_t)(SPI_TCRC(spi_periph)));
-    }else{
+    } else {
         return ((uint16_t)(SPI_RCRC(spi_periph)));
     }
 }
 
 /*!
-    \brief    enable SPI TI mode
+    \brief      enable SPI TI mode
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -575,7 +574,7 @@ void spi_ti_mode_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    disable SPI TI mode
+    \brief      disable SPI TI mode
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none
@@ -586,20 +585,20 @@ void spi_ti_mode_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    configure i2s full duplex mode
+    \brief      configure i2s full duplex mode
     \param[in]  i2s_add_periph: I2Sx_ADD(x=1,2)
-    \param[in]  i2s_mode: 
+    \param[in]  i2s_mode:
       \arg        I2S_MODE_SLAVETX : I2S slave transmit mode
       \arg        I2S_MODE_SLAVERX : I2S slave receive mode
       \arg        I2S_MODE_MASTERTX : I2S master transmit mode
       \arg        I2S_MODE_MASTERRX : I2S master receive mode
-    \param[in]  i2s_standard: 
+    \param[in]  i2s_standard:
       \arg        I2S_STD_PHILLIPS : I2S phillips standard
       \arg        I2S_STD_MSB : I2S MSB standard
       \arg        I2S_STD_LSB : I2S LSB standard
       \arg        I2S_STD_PCMSHORT : I2S PCM short standard
       \arg        I2S_STD_PCMLONG : I2S PCM long standard
-    \param[in]  i2s_ckpl: 
+    \param[in]  i2s_ckpl:
       \arg        I2S_CKPL_LOW : I2S clock polarity low level
       \arg        I2S_CKPL_HIGH : I2S clock polarity high level
     \param[in]  i2s_frameformat:
@@ -616,17 +615,17 @@ void i2s_full_duplex_mode_config(uint32_t i2s_add_periph, uint32_t i2s_mode, uin
     uint32_t reg = 0U, tmp = 0U;
 
     reg = I2S_ADD_I2SCTL(i2s_add_periph);
-    reg &= I2S_FULL_DUPLEX_MASK;  
+    reg &= I2S_FULL_DUPLEX_MASK;
 
     /* get the mode of the extra I2S module I2Sx_ADD */
-    if((I2S_MODE_MASTERTX == i2s_mode) || (I2S_MODE_SLAVETX == i2s_mode)){
+    if((I2S_MODE_MASTERTX == i2s_mode) || (I2S_MODE_SLAVETX == i2s_mode)) {
         tmp = I2S_MODE_SLAVERX;
-    }else{
+    } else {
         tmp = I2S_MODE_SLAVETX;
     }
 
     /* enable I2S mode */
-    reg |= (uint32_t)SPI_I2SCTL_I2SSEL; 
+    reg |= (uint32_t)SPI_I2SCTL_I2SSEL;
     /* select I2S mode */
     reg |= (uint32_t)tmp;
     /* select I2S standard */
@@ -641,7 +640,7 @@ void i2s_full_duplex_mode_config(uint32_t i2s_add_periph, uint32_t i2s_mode, uin
 }
 
 /*!
-    \brief    enable quad wire SPI  
+    \brief      enable quad wire SPI
     \param[in]  spi_periph: SPIx(only x=5)
     \param[out] none
     \retval     none
@@ -652,7 +651,7 @@ void qspi_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    disable quad wire SPI 
+    \brief      disable quad wire SPI
     \param[in]  spi_periph: SPIx(only x=5)
     \param[out] none
     \retval     none
@@ -663,7 +662,7 @@ void qspi_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    enable quad wire SPI write 
+    \brief      enable quad wire SPI write
     \param[in]  spi_periph: SPIx(only x=5)
     \param[out] none
     \retval     none
@@ -674,7 +673,7 @@ void qspi_write_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    enable quad wire SPI read 
+    \brief      enable quad wire SPI read
     \param[in]  spi_periph: SPIx(only x=5)
     \param[out] none
     \retval     none
@@ -685,7 +684,7 @@ void qspi_read_enable(uint32_t spi_periph)
 }
 
 /*!
-    \brief    enable SPI_IO2 and SPI_IO3 pin output 
+    \brief      enable SPI_IO2 and SPI_IO3 pin output
     \param[in]  spi_periph: SPIx(only x=5)
     \param[out] none
     \retval     none
@@ -695,19 +694,19 @@ void qspi_io23_output_enable(uint32_t spi_periph)
     SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_IO23_DRV;
 }
 
- /*!
-    \brief    disable SPI_IO2 and SPI_IO3 pin output 
-    \param[in]  spi_periph: SPIx(only x=5)
-    \param[out] none
-    \retval     none
+/*!
+   \brief      disable SPI_IO2 and SPI_IO3 pin output
+   \param[in]  spi_periph: SPIx(only x=5)
+   \param[out] none
+   \retval     none
 */
- void qspi_io23_output_disable(uint32_t spi_periph)
+void qspi_io23_output_disable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_IO23_DRV);
 }
 
 /*!
-    \brief    enable SPI and I2S interrupt 
+    \brief      enable SPI and I2S interrupt
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_i2s_int: SPI/I2S interrupt
                 only one parameter can be selected which is shown as below:
@@ -720,7 +719,7 @@ void qspi_io23_output_enable(uint32_t spi_periph)
 */
 void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int)
 {
-    switch(spi_i2s_int){
+    switch(spi_i2s_int) {
     /* SPI/I2S transmit buffer empty interrupt */
     case SPI_I2S_INT_TBE:
         SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_TBEIE;
@@ -739,7 +738,7 @@ void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int)
 }
 
 /*!
-    \brief    disable SPI and I2S interrupt 
+    \brief      disable SPI and I2S interrupt
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_i2s_int: SPI/I2S interrupt
                 only one parameter can be selected which is shown as below:
@@ -752,7 +751,7 @@ void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int)
 */
 void spi_i2s_interrupt_disable(uint32_t spi_periph, uint8_t spi_i2s_int)
 {
-    switch(spi_i2s_int){
+    switch(spi_i2s_int) {
     /* SPI/I2S transmit buffer empty interrupt */
     case SPI_I2S_INT_TBE :
         SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_TBEIE);
@@ -771,9 +770,10 @@ void spi_i2s_interrupt_disable(uint32_t spi_periph, uint8_t spi_i2s_int)
 }
 
 /*!
-    \brief    get SPI and I2S interrupt flag status
+    \brief      get SPI and I2S interrupt flag status
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_i2s_int: SPI/I2S interrupt flag status
+                only one parameter can be selected which are shown as below:
       \arg        SPI_I2S_INT_FLAG_TBE: transmit buffer empty interrupt flag
       \arg        SPI_I2S_INT_FLAG_RBNE: receive buffer not empty interrupt flag
       \arg        SPI_I2S_INT_FLAG_RXORERR: overrun interrupt flag
@@ -789,7 +789,7 @@ FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int)
     uint32_t reg1 = SPI_STAT(spi_periph);
     uint32_t reg2 = SPI_CTL1(spi_periph);
 
-    switch(spi_i2s_int){
+    switch(spi_i2s_int) {
     /* SPI/I2S transmit buffer empty interrupt */
     case SPI_I2S_INT_FLAG_TBE :
         reg1 = reg1 & SPI_STAT_TBE;
@@ -829,17 +829,18 @@ FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int)
         break;
     }
     /*get SPI/I2S interrupt flag status */
-    if(reg1 && reg2){
+    if(reg1 && reg2) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    get SPI and I2S flag status
+    \brief      get SPI and I2S flag status
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[in]  spi_i2s_flag: SPI/I2S flag status
+                only one parameter can be selected which are shown as below:
       \arg        SPI_FLAG_TBE: transmit buffer empty flag
       \arg        SPI_FLAG_RBNE: receive buffer not empty flag
       \arg        SPI_FLAG_TRANS: transmit on-going flag
@@ -859,15 +860,15 @@ FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int)
 */
 FlagStatus spi_i2s_flag_get(uint32_t spi_periph, uint32_t spi_i2s_flag)
 {
-    if(SPI_STAT(spi_periph) & spi_i2s_flag){
+    if(SPI_STAT(spi_periph) & spi_i2s_flag) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
 
 /*!
-    \brief    clear SPI CRC error flag status
+    \brief      clear SPI CRC error flag status
     \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
     \param[out] none
     \retval     none

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_syscfg.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_syscfg.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_syscfg.c
     \brief   SYSCFG driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -49,7 +50,7 @@ void syscfg_deinit(void)
 }
 
 /*!
-    \brief    configure the boot mode 
+    \brief    configure the boot mode
     \param[in]  syscfg_bootmode: selects the memory remapping
                 only one parameter can be selected which is shown as below:
       \arg        SYSCFG_BOOTMODE_FLASH: main flash memory (0x08000000~0x083BFFFF) is mapped at address 0x00000000
@@ -120,7 +121,7 @@ void syscfg_exti_line_config(uint8_t exti_port, uint8_t exti_pin)
     uint32_t clear_exti_mask = ~((uint32_t)EXTI_SS_MASK << (EXTI_SS_MSTEP(exti_pin)));
     uint32_t config_exti_mask = ((uint32_t)exti_port) << (EXTI_SS_MSTEP(exti_pin));
 
-    switch(exti_pin/EXTI_SS_JSTEP){
+    switch(exti_pin / EXTI_SS_JSTEP) {
     case EXTISS0:
         /* clear EXTI source line(0..3) */
         SYSCFG_EXTISS0 &= clear_exti_mask;
@@ -155,14 +156,14 @@ void syscfg_exti_line_config(uint8_t exti_port, uint8_t exti_pin)
     \param[in]  syscfg_enet_phy_interface: specifies the media interface mode.
                 only one parameter can be selected which is shown as below:
       \arg        SYSCFG_ENET_PHY_MII: MII mode is selected
-      \arg        SYSCFG_ENET_PHY_RMII: RMII mode is selected 
+      \arg        SYSCFG_ENET_PHY_RMII: RMII mode is selected
     \param[out] none
     \retval     none
 */
 void syscfg_enet_phy_interface_config(uint32_t syscfg_enet_phy_interface)
-{ 
+{
     uint32_t reg;
-    
+
     reg = SYSCFG_CFG1;
     /* reset the ENET_PHY_SEL bit and set according to syscfg_enet_phy_interface */
     reg &= ~SYSCFG_CFG1_ENET_PHY_SEL;
@@ -178,7 +179,7 @@ void syscfg_enet_phy_interface_config(uint32_t syscfg_enet_phy_interface)
     \param[out] none
     \retval     none
 */
-void syscfg_compensation_config(uint32_t syscfg_compensation) 
+void syscfg_compensation_config(uint32_t syscfg_compensation)
 {
     uint32_t reg;
 
@@ -196,9 +197,9 @@ void syscfg_compensation_config(uint32_t syscfg_compensation)
   */
 FlagStatus syscfg_flag_get(void)
 {
-    if(((uint32_t)RESET) != (SYSCFG_CPSCTL & SYSCFG_CPSCTL_CPS_RDY)){
+    if(((uint32_t)RESET) != (SYSCFG_CPSCTL & SYSCFG_CPSCTL_CPS_RDY)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_timer.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_timer.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -38,14 +39,14 @@ OF SUCH DAMAGE.
 #include "gd32f4xx_timer.h"
 
 /*!
-    \brief    deinit a TIMER
+    \brief      deinit a TIMER
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
 */
 void timer_deinit(uint32_t timer_periph)
 {
-    switch(timer_periph){
+    switch(timer_periph) {
     case TIMER0:
         /* reset TIMER0 */
         rcu_periph_reset_enable(RCU_TIMER0RST);
@@ -122,12 +123,12 @@ void timer_deinit(uint32_t timer_periph)
 }
 
 /*!
-    \brief    initialize TIMER init parameter struct with a default value
+    \brief      initialize TIMER init parameter struct with a default value
     \param[in]  initpara: init parameter struct
     \param[out] none
     \retval     none
 */
-void timer_struct_para_init(timer_parameter_struct* initpara)
+void timer_struct_para_init(timer_parameter_struct *initpara)
 {
     /* initialize the init parameter struct member with the default value */
     initpara->prescaler         = 0U;
@@ -139,7 +140,7 @@ void timer_struct_para_init(timer_parameter_struct* initpara)
 }
 
 /*!
-    \brief    initialize TIMER counter
+    \brief      initialize TIMER counter
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[in]  initpara: init parameter struct
                 prescaler: prescaler value of the counter clock,0~65535
@@ -151,15 +152,15 @@ void timer_struct_para_init(timer_parameter_struct* initpara)
     \param[out] none
     \retval     none
 */
-void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
+void timer_init(uint32_t timer_periph, timer_parameter_struct *initpara)
 {
     /* configure the counter prescaler value */
     TIMER_PSC(timer_periph) = (uint16_t)initpara->prescaler;
 
     /* configure the counter direction and aligned mode */
     if((TIMER0 == timer_periph) || (TIMER1 == timer_periph) || (TIMER2 == timer_periph)
-        || (TIMER3 == timer_periph) || (TIMER4 == timer_periph) || (TIMER7 == timer_periph)){
-        TIMER_CTL0(timer_periph) &= ~(uint32_t)(TIMER_CTL0_DIR|TIMER_CTL0_CAM);
+            || (TIMER3 == timer_periph) || (TIMER4 == timer_periph) || (TIMER7 == timer_periph)) {
+        TIMER_CTL0(timer_periph) &= ~(uint32_t)(TIMER_CTL0_DIR | TIMER_CTL0_CAM);
         TIMER_CTL0(timer_periph) |= (uint32_t)initpara->alignedmode;
         TIMER_CTL0(timer_periph) |= (uint32_t)initpara->counterdirection;
     }
@@ -167,13 +168,13 @@ void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
     /* configure the autoreload value */
     TIMER_CAR(timer_periph) = (uint32_t)initpara->period;
 
-    if((TIMER5 != timer_periph) && (TIMER6 != timer_periph)){
+    if((TIMER5 != timer_periph) && (TIMER6 != timer_periph)) {
         /* reset the CKDIV bit */
         TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_CKDIV;
         TIMER_CTL0(timer_periph) |= (uint32_t)initpara->clockdivision;
     }
 
-    if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)){
+    if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
         /* configure the repetition counter value */
         TIMER_CREP(timer_periph) = (uint32_t)initpara->repetitioncounter;
     }
@@ -183,7 +184,7 @@ void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
 }
 
 /*!
-    \brief    enable a TIMER
+    \brief      enable a TIMER
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -194,7 +195,7 @@ void timer_enable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    disable a TIMER
+    \brief      disable a TIMER
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -205,7 +206,7 @@ void timer_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    enable the auto reload shadow function
+    \brief      enable the auto reload shadow function
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -216,7 +217,7 @@ void timer_auto_reload_shadow_enable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    disable the auto reload shadow function
+    \brief      disable the auto reload shadow function
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -227,7 +228,7 @@ void timer_auto_reload_shadow_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    enable the update event
+    \brief      enable the update event
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -238,7 +239,7 @@ void timer_update_event_enable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    disable the update event
+    \brief      disable the update event
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     none
@@ -249,7 +250,7 @@ void timer_update_event_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    set TIMER counter alignment mode
+    \brief      set TIMER counter alignment mode
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[in]  aligned:
                 only one parameter can be selected which is shown as below:
@@ -267,7 +268,7 @@ void timer_counter_alignment(uint32_t timer_periph, uint16_t aligned)
 }
 
 /*!
-    \brief    set TIMER counter up direction
+    \brief      set TIMER counter up direction
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[out] none
     \retval     none
@@ -278,7 +279,7 @@ void timer_counter_up_direction(uint32_t timer_periph)
 }
 
 /*!
-    \brief    set TIMER counter down direction
+    \brief      set TIMER counter down direction
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[out] none
     \retval     none
@@ -289,7 +290,7 @@ void timer_counter_down_direction(uint32_t timer_periph)
 }
 
 /*!
-    \brief    configure TIMER prescaler
+    \brief      configure TIMER prescaler
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[in]  prescaler: prescaler value,0~65535
     \param[in]  pscreload: prescaler reload mode
@@ -302,14 +303,14 @@ void timer_counter_down_direction(uint32_t timer_periph)
 void timer_prescaler_config(uint32_t timer_periph, uint16_t prescaler, uint8_t pscreload)
 {
     TIMER_PSC(timer_periph) = (uint32_t)prescaler;
-    
-    if(TIMER_PSC_RELOAD_NOW == pscreload){
+
+    if(TIMER_PSC_RELOAD_NOW == pscreload) {
         TIMER_SWEVG(timer_periph) |= (uint32_t)TIMER_SWEVG_UPG;
     }
 }
 
 /*!
-    \brief    configure TIMER repetition register value
+    \brief      configure TIMER repetition register value
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[in]  repetition: the counter repetition value,0~255
     \param[out] none
@@ -318,38 +319,38 @@ void timer_prescaler_config(uint32_t timer_periph, uint16_t prescaler, uint8_t p
 void timer_repetition_value_config(uint32_t timer_periph, uint16_t repetition)
 {
     TIMER_CREP(timer_periph) = (uint32_t)repetition;
-} 
- 
+}
+
 /*!
-    \brief    configure TIMER autoreload register value
+    \brief      configure TIMER autoreload register value
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[in]  autoreload: the counter auto-reload value
     \param[out] none
     \retval     none
-*/         
-void timer_autoreload_value_config(uint32_t timer_periph,uint32_t autoreload)
+*/
+void timer_autoreload_value_config(uint32_t timer_periph, uint32_t autoreload)
 {
     TIMER_CAR(timer_periph) = (uint32_t)autoreload;
 }
 
 /*!
-    \brief    configure TIMER counter register value
+    \brief      configure TIMER counter register value
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[in]  counter: the counter value,0~65535
     \param[out] none
     \retval     none
-*/         
-void timer_counter_value_config(uint32_t timer_periph , uint32_t counter)
+*/
+void timer_counter_value_config(uint32_t timer_periph, uint32_t counter)
 {
     TIMER_CNT(timer_periph) = (uint32_t)counter;
 }
 
 /*!
-    \brief    read TIMER counter value
+    \brief      read TIMER counter value
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     counter value
-*/         
+*/
 uint32_t timer_counter_read(uint32_t timer_periph)
 {
     uint32_t count_value = 0U;
@@ -358,11 +359,11 @@ uint32_t timer_counter_read(uint32_t timer_periph)
 }
 
 /*!
-    \brief    read TIMER prescaler value
+    \brief      read TIMER prescaler value
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[out] none
     \retval     prescaler register value
-*/         
+*/
 uint16_t timer_prescaler_read(uint32_t timer_periph)
 {
     uint16_t prescaler_value = 0U;
@@ -371,7 +372,7 @@ uint16_t timer_prescaler_read(uint32_t timer_periph)
 }
 
 /*!
-    \brief    configure TIMER single pulse mode
+    \brief      configure TIMER single pulse mode
     \param[in]  timer_periph: TIMERx(x=0..8,11)
     \param[in]  spmode:
                 only one parameter can be selected which is shown as below:
@@ -382,17 +383,17 @@ uint16_t timer_prescaler_read(uint32_t timer_periph)
 */
 void timer_single_pulse_mode_config(uint32_t timer_periph, uint32_t spmode)
 {
-    if(TIMER_SP_MODE_SINGLE == spmode){
+    if(TIMER_SP_MODE_SINGLE == spmode) {
         TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_SPM;
-    }else if(TIMER_SP_MODE_REPETITIVE == spmode){
+    } else if(TIMER_SP_MODE_REPETITIVE == spmode) {
         TIMER_CTL0(timer_periph) &= ~((uint32_t)TIMER_CTL0_SPM);
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    configure TIMER update source 
+    \brief      configure TIMER update source
     \param[in]  timer_periph: TIMERx(x=0..13)
     \param[in]  update:
                 only one parameter can be selected which is shown as below:
@@ -403,161 +404,17 @@ void timer_single_pulse_mode_config(uint32_t timer_periph, uint32_t spmode)
 */
 void timer_update_source_config(uint32_t timer_periph, uint32_t update)
 {
-    if(TIMER_UPDATE_SRC_REGULAR == update){
+    if(TIMER_UPDATE_SRC_REGULAR == update) {
         TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_UPS;
-    }else if(TIMER_UPDATE_SRC_GLOBAL == update){
+    } else if(TIMER_UPDATE_SRC_GLOBAL == update) {
         TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_UPS;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    enable the TIMER interrupt
-    \param[in]  timer_periph: please refer to the following parameters 
-    \param[in]  interrupt: timer interrupt enable source
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
-      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
-      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
-      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
-      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
-      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
-    \param[out] none
-    \retval     none
-*/
-void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt)
-{
-    TIMER_DMAINTEN(timer_periph) |= (uint32_t) interrupt; 
-}
-
-/*!
-    \brief    disable the TIMER interrupt
-    \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  interrupt: timer interrupt source enable
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
-      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
-      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
-      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
-      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
-      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
-    \param[out] none
-    \retval     none
-*/
-void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt)
-{
-    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)interrupt); 
-}
-
-/*!
-    \brief    get timer interrupt flag
-    \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  interrupt: the timer interrupt bits
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
-      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
-      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
-      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
-      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7) 
-      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
-      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
-    \param[out] none
-    \retval     FlagStatus: SET or RESET
-*/
-FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt)
-{
-    uint32_t val;
-    val = (TIMER_DMAINTEN(timer_periph) & interrupt);
-    if((RESET != (TIMER_INTF(timer_periph) & interrupt) ) && (RESET != val)){
-        return SET;
-    }else{
-        return RESET;
-    }
-}
-
-/*!
-    \brief    clear TIMER interrupt flag
-    \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  interrupt: the timer interrupt bits
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
-      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
-      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
-      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
-      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7) 
-      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
-      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
-    \param[out] none
-    \retval     none
-*/
-void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt)
-{
-    TIMER_INTF(timer_periph) = (~(uint32_t)interrupt);
-}
-
-/*!
-    \brief    get TIMER flags
-    \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  flag: the timer interrupt flags
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
-      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
-      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7) 
-      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11) 
-      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
-      \arg        TIMER_FLAG_CH0OF: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
-      \arg        TIMER_FLAG_CH1OF: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_FLAG_CH2OF: channel 2 overcapture flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CH3OF: channel 3 overcapture flag,TIMERx(x=0..4,7)
-    \param[out] none
-    \retval     FlagStatus: SET or RESET
-*/
-FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag)
-{
-    if(RESET != (TIMER_INTF(timer_periph) & flag)){
-        return SET;
-    }else{
-        return RESET;
-    }
-}
-
-/*!
-    \brief    clear TIMER flags
-    \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  flag: the timer interrupt flags
-                only one parameter can be selected which is shown as below:
-      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
-      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
-      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7) 
-      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11) 
-      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
-      \arg        TIMER_FLAG_CH0OF: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
-      \arg        TIMER_FLAG_CH1OF: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_FLAG_CH2OF: channel 2 overcapture flag,TIMERx(x=0..4,7)
-      \arg        TIMER_FLAG_CH3OF: channel 3 overcapture flag,TIMERx(x=0..4,7)
-    \param[out] none
-    \retval     none
-*/
-void timer_flag_clear(uint32_t timer_periph, uint32_t flag)
-{
-    TIMER_INTF(timer_periph) = (~(uint32_t)flag);
-}
-
-/*!
-    \brief    enable the TIMER DMA
+    \brief      enable the TIMER DMA
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  dma: specify which DMA to enable
                 one or more parameters can be selected which is shown as below:
@@ -573,11 +430,11 @@ void timer_flag_clear(uint32_t timer_periph, uint32_t flag)
 */
 void timer_dma_enable(uint32_t timer_periph, uint16_t dma)
 {
-    TIMER_DMAINTEN(timer_periph) |= (uint32_t) dma; 
+    TIMER_DMAINTEN(timer_periph) |= (uint32_t) dma;
 }
 
 /*!
-    \brief    disable the TIMER DMA
+    \brief      disable the TIMER DMA
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  dma: specify which DMA to disable
                 one or more parameters can be selected which are shown as below:
@@ -593,32 +450,32 @@ void timer_dma_enable(uint32_t timer_periph, uint16_t dma)
 */
 void timer_dma_disable(uint32_t timer_periph, uint16_t dma)
 {
-    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)(dma)); 
+    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)(dma));
 }
 
 /*!
-    \brief    channel DMA request source selection
+    \brief      channel DMA request source selection
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[in]  dma_request: channel DMA request source selection
                 only one parameter can be selected which is shown as below:
        \arg        TIMER_DMAREQUEST_CHANNELEVENT: DMA request of channel y is sent when channel y event occurs
-       \arg        TIMER_DMAREQUEST_UPDATEEVENT: DMA request of channel y is sent when update event occurs 
+       \arg        TIMER_DMAREQUEST_UPDATEEVENT: DMA request of channel y is sent when update event occurs
     \param[out] none
     \retval     none
 */
 void timer_channel_dma_request_source_select(uint32_t timer_periph, uint8_t dma_request)
 {
-    if(TIMER_DMAREQUEST_UPDATEEVENT == dma_request){
+    if(TIMER_DMAREQUEST_UPDATEEVENT == dma_request) {
         TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_DMAS;
-    }else if(TIMER_DMAREQUEST_CHANNELEVENT == dma_request){
+    } else if(TIMER_DMAREQUEST_CHANNELEVENT == dma_request) {
         TIMER_CTL1(timer_periph) &= ~(uint32_t)TIMER_CTL1_DMAS;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    configure the TIMER DMA transfer
+    \brief      configure the TIMER DMA transfer
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  dma_baseaddr:
                 only one parameter can be selected which is shown as below:
@@ -655,16 +512,16 @@ void timer_dma_transfer_config(uint32_t timer_periph, uint32_t dma_baseaddr, uin
 }
 
 /*!
-    \brief    software generate events 
+    \brief      software generate events
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  event: the timer software event generation sources
                 one or more parameters can be selected which are shown as below:
       \arg        TIMER_EVENT_SRC_UPG: update event,TIMERx(x=0..13)
-      \arg        TIMER_EVENT_SRC_CH0G: channel 0 capture or compare event generation,TIMERx(x=0..4,7..13) 
+      \arg        TIMER_EVENT_SRC_CH0G: channel 0 capture or compare event generation,TIMERx(x=0..4,7..13)
       \arg        TIMER_EVENT_SRC_CH1G: channel 1 capture or compare event generation,TIMERx(x=0..4,7,8,11)
-      \arg        TIMER_EVENT_SRC_CH2G: channel 2 capture or compare event generation,TIMERx(x=0..4,7) 
-      \arg        TIMER_EVENT_SRC_CH3G: channel 3 capture or compare event generation,TIMERx(x=0..4,7) 
-      \arg        TIMER_EVENT_SRC_CMTG: channel commutation event generation,TIMERx(x=0,7) 
+      \arg        TIMER_EVENT_SRC_CH2G: channel 2 capture or compare event generation,TIMERx(x=0..4,7)
+      \arg        TIMER_EVENT_SRC_CH3G: channel 3 capture or compare event generation,TIMERx(x=0..4,7)
+      \arg        TIMER_EVENT_SRC_CMTG: channel commutation event generation,TIMERx(x=0,7)
       \arg        TIMER_EVENT_SRC_TRGG: trigger event generation,TIMERx(x=0..4,7,8,11)
       \arg        TIMER_EVENT_SRC_BRKG:  break event generation,TIMERx(x=0,7)
     \param[out] none
@@ -676,12 +533,12 @@ void timer_event_software_generate(uint32_t timer_periph, uint16_t event)
 }
 
 /*!
-    \brief    initialize TIMER break parameter struct with a default value
+    \brief      initialize TIMER break parameter struct
     \param[in]  breakpara: TIMER break parameter struct
     \param[out] none
     \retval     none
 */
-void timer_break_struct_para_init(timer_break_parameter_struct* breakpara)
+void timer_break_struct_para_init(timer_break_parameter_struct *breakpara)
 {
     /* initialize the break parameter struct member with the default value */
     breakpara->runoffstate     = TIMER_ROS_STATE_DISABLE;
@@ -694,7 +551,7 @@ void timer_break_struct_para_init(timer_break_parameter_struct* breakpara)
 }
 
 /*!
-    \brief    configure TIMER break function 
+    \brief      configure TIMER break function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[in]  breakpara: TIMER break parameter struct
                 runoffstate: TIMER_ROS_STATE_ENABLE,TIMER_ROS_STATE_DISABLE
@@ -707,19 +564,19 @@ void timer_break_struct_para_init(timer_break_parameter_struct* breakpara)
     \param[out] none
     \retval     none
 */
-void timer_break_config(uint32_t timer_periph, timer_break_parameter_struct* breakpara)
+void timer_break_config(uint32_t timer_periph, timer_break_parameter_struct *breakpara)
 {
-    TIMER_CCHP(timer_periph) = (uint32_t)(((uint32_t)(breakpara->runoffstate))|
-                                          ((uint32_t)(breakpara->ideloffstate))|
-                                          ((uint32_t)(breakpara->deadtime))|
-                                          ((uint32_t)(breakpara->breakpolarity))|
+    TIMER_CCHP(timer_periph) = (uint32_t)(((uint32_t)(breakpara->runoffstate)) |
+                                          ((uint32_t)(breakpara->ideloffstate)) |
+                                          ((uint32_t)(breakpara->deadtime)) |
+                                          ((uint32_t)(breakpara->breakpolarity)) |
                                           ((uint32_t)(breakpara->outputautostate)) |
-                                          ((uint32_t)(breakpara->protectmode))|
+                                          ((uint32_t)(breakpara->protectmode)) |
                                           ((uint32_t)(breakpara->breakstate))) ;
 }
 
 /*!
-    \brief    enable TIMER break function
+    \brief      enable TIMER break function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[out] none
     \retval     none
@@ -730,7 +587,7 @@ void timer_break_enable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    disable TIMER break function
+    \brief      disable TIMER break function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[out] none
     \retval     none
@@ -741,7 +598,7 @@ void timer_break_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    enable TIMER output automatic function
+    \brief      enable TIMER output automatic function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[out] none
     \retval     none
@@ -752,7 +609,7 @@ void timer_automatic_output_enable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    disable TIMER output automatic function
+    \brief      disable TIMER output automatic function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[out] none
     \retval     none
@@ -763,7 +620,7 @@ void timer_automatic_output_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    configure TIMER primary output function
+    \brief      configure TIMER primary output function
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[in]  newvalue: ENABLE or DISABLE
     \param[out] none
@@ -771,57 +628,57 @@ void timer_automatic_output_disable(uint32_t timer_periph)
 */
 void timer_primary_output_config(uint32_t timer_periph, ControlStatus newvalue)
 {
-    if(ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         TIMER_CCHP(timer_periph) |= (uint32_t)TIMER_CCHP_POEN;
-    }else{
+    } else {
         TIMER_CCHP(timer_periph) &= (~(uint32_t)TIMER_CCHP_POEN);
     }
 }
 
 /*!
-    \brief    enable or disable channel capture/compare control shadow register
+    \brief      enable or disable channel capture/compare control shadow register
     \param[in]  timer_periph: TIMERx(x=0,7)
-    \param[in]  newvalue: ENABLE or DISABLE 
+    \param[in]  newvalue: ENABLE or DISABLE
     \param[out] none
     \retval     none
 */
 void timer_channel_control_shadow_config(uint32_t timer_periph, ControlStatus newvalue)
 {
-     if(ENABLE == newvalue){
+    if(ENABLE == newvalue) {
         TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_CCSE;
-    }else{
+    } else {
         TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_CCSE);
     }
 }
 
 /*!
-    \brief    configure TIMER channel control shadow register update control
+    \brief      configure TIMER channel control shadow register update control
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[in]  ccuctl: channel control shadow register update control
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_UPDATECTL_CCU: the shadow registers update by when CMTG bit is set
-      \arg        TIMER_UPDATECTL_CCUTRI: the shadow registers update by when CMTG bit is set or an rising edge of TRGI occurs 
+      \arg        TIMER_UPDATECTL_CCUTRI: the shadow registers update by when CMTG bit is set or an rising edge of TRGI occurs
     \param[out] none
     \retval     none
-*/              
+*/
 void timer_channel_control_shadow_update_config(uint32_t timer_periph, uint8_t ccuctl)
 {
-    if(TIMER_UPDATECTL_CCU == ccuctl){
+    if(TIMER_UPDATECTL_CCU == ccuctl) {
         TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_CCUC);
-    }else if(TIMER_UPDATECTL_CCUTRI == ccuctl){
+    } else if(TIMER_UPDATECTL_CCUTRI == ccuctl) {
         TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_CCUC;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    initialize TIMER channel output parameter struct with a default value
+    \brief      initialize TIMER channel output parameter struct with a default value
     \param[in]  ocpara: TIMER channel n output parameter struct
     \param[out] none
     \retval     none
 */
-void timer_channel_output_struct_para_init(timer_oc_parameter_struct* ocpara)
+void timer_channel_output_struct_para_init(timer_oc_parameter_struct *ocpara)
 {
     /* initialize the channel output parameter struct member with the default value */
     ocpara->outputstate  = (uint16_t)TIMER_CCX_DISABLE;
@@ -833,7 +690,7 @@ void timer_channel_output_struct_para_init(timer_oc_parameter_struct* ocpara)
 }
 
 /*!
-    \brief    configure TIMER channel output function
+    \brief      configure TIMER channel output function
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
@@ -851,9 +708,9 @@ void timer_channel_output_struct_para_init(timer_oc_parameter_struct* ocpara)
     \param[out] none
     \retval     none
 */
-void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_oc_parameter_struct* ocpara)
+void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_oc_parameter_struct *ocpara)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         /* reset the CH0EN bit */
@@ -866,7 +723,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
         /* set the CH0P bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpara->ocpolarity;
 
-        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)){
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
             /* reset the CH0NEN bit */
             TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NEN);
             /* set the CH0NEN bit */
@@ -897,7 +754,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
         /* set the CH1P bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 4U);
 
-        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)){
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
             /* reset the CH1NEN bit */
             TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1NEN);
             /* set the CH1NEN bit */
@@ -928,7 +785,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
         /* set the CH2P bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 8U);
 
-        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)){
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
             /* reset the CH2NEN bit */
             TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2NEN);
             /* set the CH2NEN bit */
@@ -950,7 +807,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
     /* configure TIMER_CH_3 */
     case TIMER_CH_3:
         /* reset the CH3EN bit */
-        TIMER_CHCTL2(timer_periph) &=(~(uint32_t)TIMER_CHCTL2_CH3EN);
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3EN);
         TIMER_CHCTL1(timer_periph) &= ~(uint32_t)TIMER_CHCTL1_CH3MS;
         /* set the CH3EN bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpara->outputstate << 12U);
@@ -959,7 +816,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
         /* set the CH3P bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 12U);
 
-        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)){
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
             /* reset the ISO3 bit */
             TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO3);
             /* set the ISO3 bit */
@@ -972,7 +829,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
 }
 
 /*!
-    \brief    configure TIMER channel output compare mode
+    \brief      configure TIMER channel output compare mode
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
@@ -995,7 +852,7 @@ void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_
 */
 void timer_channel_output_mode_config(uint32_t timer_periph, uint16_t channel, uint16_t ocmode)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMCTL);
@@ -1022,7 +879,7 @@ void timer_channel_output_mode_config(uint32_t timer_periph, uint16_t channel, u
 }
 
 /*!
-    \brief    configure TIMER channel output pulse value
+    \brief      configure TIMER channel output pulse value
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
@@ -1036,7 +893,7 @@ void timer_channel_output_mode_config(uint32_t timer_periph, uint16_t channel, u
 */
 void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t channel, uint32_t pulse)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CH0CV(timer_periph) = (uint32_t)pulse;
@@ -1051,7 +908,7 @@ void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t cha
         break;
     /* configure TIMER_CH_3 */
     case TIMER_CH_3:
-         TIMER_CH3CV(timer_periph) = (uint32_t)pulse;
+        TIMER_CH3CV(timer_periph) = (uint32_t)pulse;
         break;
     default:
         break;
@@ -1059,7 +916,7 @@ void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t cha
 }
 
 /*!
-    \brief    configure TIMER channel output shadow function
+    \brief      configure TIMER channel output shadow function
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
@@ -1076,7 +933,7 @@ void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t cha
 */
 void timer_channel_output_shadow_config(uint32_t timer_periph, uint16_t channel, uint16_t ocshadow)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMSEN);
@@ -1103,7 +960,7 @@ void timer_channel_output_shadow_config(uint32_t timer_periph, uint16_t channel,
 }
 
 /*!
-    \brief    configure TIMER channel output fast function
+    \brief      configure TIMER channel output fast function
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
@@ -1120,7 +977,7 @@ void timer_channel_output_shadow_config(uint32_t timer_periph, uint16_t channel,
 */
 void timer_channel_output_fast_config(uint32_t timer_periph, uint16_t channel, uint16_t ocfast)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMFEN);
@@ -1147,9 +1004,9 @@ void timer_channel_output_fast_config(uint32_t timer_periph, uint16_t channel, u
 }
 
 /*!
-    \brief    configure TIMER channel output clear function
+    \brief      configure TIMER channel output clear function
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7))
@@ -1164,7 +1021,7 @@ void timer_channel_output_fast_config(uint32_t timer_periph, uint16_t channel, u
 */
 void timer_channel_output_clear_config(uint32_t timer_periph, uint16_t channel, uint16_t occlear)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMCEN);
@@ -1191,15 +1048,15 @@ void timer_channel_output_clear_config(uint32_t timer_periph, uint16_t channel, 
 }
 
 /*!
-    \brief    configure TIMER channel output polarity 
+    \brief      configure TIMER channel output polarity
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
       \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
       \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
-    \param[in] 	ocpolarity: channel output polarity
+    \param[in]  ocpolarity: channel output polarity
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_OC_POLARITY_HIGH: channel output polarity is high
       \arg        TIMER_OC_POLARITY_LOW: channel output polarity is low
@@ -1208,7 +1065,7 @@ void timer_channel_output_clear_config(uint32_t timer_periph, uint16_t channel, 
 */
 void timer_channel_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocpolarity)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0P);
@@ -1235,14 +1092,14 @@ void timer_channel_output_polarity_config(uint32_t timer_periph, uint16_t channe
 }
 
 /*!
-    \brief    configure TIMER channel complementary output polarity 
+    \brief      configure TIMER channel complementary output polarity
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
       \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
-    \param[in]  ocnpolarity: channel complementary output polarity 
+    \param[in]  ocnpolarity: channel complementary output polarity
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_OCN_POLARITY_HIGH: channel complementary output polarity is high
       \arg        TIMER_OCN_POLARITY_LOW: channel complementary output polarity is low
@@ -1251,7 +1108,7 @@ void timer_channel_output_polarity_config(uint32_t timer_periph, uint16_t channe
 */
 void timer_channel_complementary_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnpolarity)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NP);
@@ -1273,9 +1130,9 @@ void timer_channel_complementary_output_polarity_config(uint32_t timer_periph, u
 }
 
 /*!
-    \brief    configure TIMER channel enable state
+    \brief      configure TIMER channel enable state
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
@@ -1283,14 +1140,14 @@ void timer_channel_complementary_output_polarity_config(uint32_t timer_periph, u
       \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
     \param[in]  state: TIMER channel enable state
                 only one parameter can be selected which is shown as below:
-      \arg        TIMER_CCX_ENABLE: channel enable 
-      \arg        TIMER_CCX_DISABLE: channel disable 
+      \arg        TIMER_CCX_ENABLE: channel enable
+      \arg        TIMER_CCX_DISABLE: channel disable
     \param[out] none
     \retval     none
 */
 void timer_channel_output_state_config(uint32_t timer_periph, uint16_t channel, uint32_t state)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
@@ -1317,23 +1174,23 @@ void timer_channel_output_state_config(uint32_t timer_periph, uint16_t channel, 
 }
 
 /*!
-    \brief    configure TIMER channel complementary output enable state
+    \brief      configure TIMER channel complementary output enable state
     \param[in]  timer_periph: TIMERx(x=0,7)
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0
       \arg        TIMER_CH_1: TIMER channel1
       \arg        TIMER_CH_2: TIMER channel2
     \param[in]  ocnstate: TIMER channel complementary output enable state
                 only one parameter can be selected which is shown as below:
-      \arg        TIMER_CCXN_ENABLE: channel complementary enable 
-      \arg        TIMER_CCXN_DISABLE: channel complementary disable 
+      \arg        TIMER_CCXN_ENABLE: channel complementary enable
+      \arg        TIMER_CCXN_DISABLE: channel complementary disable
     \param[out] none
     \retval     none
 */
 void timer_channel_complementary_output_state_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnstate)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NEN);
@@ -1355,12 +1212,12 @@ void timer_channel_complementary_output_state_config(uint32_t timer_periph, uint
 }
 
 /*!
-    \brief    initialize TIMER channel input parameter struct with a default value
+    \brief      initialize TIMER channel input parameter struct
     \param[in]  icpara: TIMER channel intput parameter struct
     \param[out] none
     \retval     none
 */
-void timer_channel_input_struct_para_init(timer_ic_parameter_struct* icpara)
+void timer_channel_input_struct_para_init(timer_ic_parameter_struct *icpara)
 {
     /* initialize the channel input parameter struct member with the default value */
     icpara->icpolarity  = TIMER_IC_POLARITY_RISING;
@@ -1370,9 +1227,9 @@ void timer_channel_input_struct_para_init(timer_ic_parameter_struct* icpara)
 }
 
 /*!
-    \brief    configure TIMER input capture parameter 
+    \brief      configure TIMER input capture parameter
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
@@ -1386,9 +1243,9 @@ void timer_channel_input_struct_para_init(timer_ic_parameter_struct* icpara)
     \param[out]  none
     \retval      none
 */
-void timer_input_capture_config(uint32_t timer_periph,uint16_t channel, timer_ic_parameter_struct* icpara)
+void timer_input_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct *icpara)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         /* reset the CH0EN bit */
@@ -1407,7 +1264,7 @@ void timer_input_capture_config(uint32_t timer_periph,uint16_t channel, timer_ic
         /* set the CH0EN bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
         break;
-    
+
     /* configure TIMER_CH_1 */
     case TIMER_CH_1:
         /* reset the CH1EN bit */
@@ -1432,7 +1289,7 @@ void timer_input_capture_config(uint32_t timer_periph,uint16_t channel, timer_ic
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2EN);
 
         /* reset the CH2P and CH2NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH2P|TIMER_CHCTL2_CH2NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH2P | TIMER_CHCTL2_CH2NP));
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpara->icpolarity) << 8U);
 
         /* reset the CH2MS bit */
@@ -1474,9 +1331,9 @@ void timer_input_capture_config(uint32_t timer_periph,uint16_t channel, timer_ic
 }
 
 /*!
-    \brief    configure TIMER channel input capture prescaler value
+    \brief      configure TIMER channel input capture prescaler value
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
@@ -1493,7 +1350,7 @@ void timer_input_capture_config(uint32_t timer_periph,uint16_t channel, timer_ic
 */
 void timer_channel_input_capture_prescaler_config(uint32_t timer_periph, uint16_t channel, uint16_t prescaler)
 {
-    switch(channel){
+    switch(channel) {
     /* configure TIMER_CH_0 */
     case TIMER_CH_0:
         TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPPSC);
@@ -1520,9 +1377,9 @@ void timer_channel_input_capture_prescaler_config(uint32_t timer_periph, uint16_
 }
 
 /*!
-    \brief    read TIMER channel capture compare register value
+    \brief      read TIMER channel capture compare register value
     \param[in]  timer_periph: please refer to the following parameters
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
       \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
@@ -1535,7 +1392,7 @@ uint32_t timer_channel_capture_value_register_read(uint32_t timer_periph, uint16
 {
     uint32_t count_value = 0U;
 
-    switch(channel){
+    switch(channel) {
     /* read TIMER channel 0 capture compare register value */
     case TIMER_CH_0:
         count_value = TIMER_CH0CV(timer_periph);
@@ -1559,9 +1416,9 @@ uint32_t timer_channel_capture_value_register_read(uint32_t timer_periph, uint16
 }
 
 /*!
-    \brief    configure TIMER input pwm capture function 
+    \brief      configure TIMER input pwm capture function
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
-    \param[in]  channel: 
+    \param[in]  channel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CH_0: TIMER channel0
       \arg        TIMER_CH_1: TIMER channel1
@@ -1573,30 +1430,30 @@ uint32_t timer_channel_capture_value_register_read(uint32_t timer_periph, uint16
     \param[out] none
     \retval     none
 */
-void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct* icpwm)
+void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct *icpwm)
 {
     uint16_t icpolarity  = 0x0U;
     uint16_t icselection = 0x0U;
 
     /* Set channel input polarity */
-    if(TIMER_IC_POLARITY_RISING == icpwm->icpolarity){
+    if(TIMER_IC_POLARITY_RISING == icpwm->icpolarity) {
         icpolarity = TIMER_IC_POLARITY_FALLING;
-    }else{
+    } else {
         icpolarity = TIMER_IC_POLARITY_RISING;
     }
 
     /* Set channel input mode selection */
-    if(TIMER_IC_SELECTION_DIRECTTI == icpwm->icselection){
+    if(TIMER_IC_SELECTION_DIRECTTI == icpwm->icselection) {
         icselection = TIMER_IC_SELECTION_INDIRECTTI;
-    }else{
+    } else {
         icselection = TIMER_IC_SELECTION_DIRECTTI;
     }
 
-    if(TIMER_CH_0 == channel){
+    if(TIMER_CH_0 == channel) {
         /* reset the CH0EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
         /* reset the CH0P and CH0NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P|TIMER_CHCTL2_CH0NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
         /* set the CH0P and CH0NP bits */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)(icpwm->icpolarity);
         /* reset the CH0MS bit */
@@ -1610,12 +1467,12 @@ void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, tim
         /* set the CH0EN bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
         /* configure TIMER channel input capture prescaler value */
-        timer_channel_input_capture_prescaler_config(timer_periph,TIMER_CH_0,(uint16_t)(icpwm->icprescaler));
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_0, (uint16_t)(icpwm->icprescaler));
 
         /* reset the CH1EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
         /* reset the CH1P and CH1NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P|TIMER_CHCTL2_CH1NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
         /* set the CH1P and CH1NP bits */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)icpolarity << 4U);
         /* reset the CH1MS bit */
@@ -1629,12 +1486,12 @@ void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, tim
         /* set the CH1EN bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
         /* configure TIMER channel input capture prescaler value */
-        timer_channel_input_capture_prescaler_config(timer_periph,TIMER_CH_1,(uint16_t)(icpwm->icprescaler));
-    }else{
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_1, (uint16_t)(icpwm->icprescaler));
+    } else {
         /* reset the CH1EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
         /* reset the CH1P and CH1NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P|TIMER_CHCTL2_CH1NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
         /* set the CH1P and CH1NP bits */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpwm->icpolarity) << 4U);
         /* reset the CH1MS bit */
@@ -1653,7 +1510,7 @@ void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, tim
         /* reset the CH0EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
         /* reset the CH0P and CH0NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P|TIMER_CHCTL2_CH0NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
         /* set the CH0P and CH0NP bits */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)icpolarity;
         /* reset the CH0MS bit */
@@ -1672,9 +1529,9 @@ void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, tim
 }
 
 /*!
-    \brief    configure TIMER hall sensor mode
+    \brief      configure TIMER hall sensor mode
     \param[in]  timer_periph: TIMERx(x=0..4,7)
-    \param[in]  hallmode: 
+    \param[in]  hallmode:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_HALLINTERFACE_ENABLE: TIMER hall sensor mode enable
       \arg        TIMER_HALLINTERFACE_DISABLE: TIMER hall sensor mode disable
@@ -1683,17 +1540,17 @@ void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, tim
 */
 void timer_hall_mode_config(uint32_t timer_periph, uint32_t hallmode)
 {
-    if(TIMER_HALLINTERFACE_ENABLE == hallmode){
+    if(TIMER_HALLINTERFACE_ENABLE == hallmode) {
         TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_TI0S;
-    }else if(TIMER_HALLINTERFACE_DISABLE == hallmode){
+    } else if(TIMER_HALLINTERFACE_DISABLE == hallmode) {
         TIMER_CTL1(timer_periph) &= ~(uint32_t)TIMER_CTL1_TI0S;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    select TIMER input trigger source 
+    \brief      select TIMER input trigger source
     \param[in]  timer_periph: please refer to the following parameters
     \param[in]  intrigger:
                 only one parameter can be selected which is shown as below:
@@ -1715,7 +1572,7 @@ void timer_input_trigger_source_select(uint32_t timer_periph, uint32_t intrigger
 }
 
 /*!
-    \brief    select TIMER master mode output trigger source 
+    \brief      select TIMER master mode output trigger source
     \param[in]  timer_periph: TIMERx(x=0..7)
     \param[in]  outrigger:
                 only one parameter can be selected which is shown as below:
@@ -1737,7 +1594,7 @@ void timer_master_output_trigger_source_select(uint32_t timer_periph, uint32_t o
 }
 
 /*!
-    \brief    select TIMER slave mode 
+    \brief      select TIMER slave mode
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
     \param[in]  slavemode:
                 only one parameter can be selected which is shown as below:
@@ -1761,7 +1618,7 @@ void timer_slave_mode_select(uint32_t timer_periph, uint32_t slavemode)
 }
 
 /*!
-    \brief    configure TIMER master slave mode 
+    \brief      configure TIMER master slave mode
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
     \param[in]  masterslave:
                 only one parameter can be selected which is shown as below:
@@ -1769,20 +1626,20 @@ void timer_slave_mode_select(uint32_t timer_periph, uint32_t slavemode)
       \arg        TIMER_MASTER_SLAVE_MODE_DISABLE: master slave mode disable
     \param[out] none
     \retval     none
-*/ 
+*/
 void timer_master_slave_mode_config(uint32_t timer_periph, uint32_t masterslave)
 {
-    if(TIMER_MASTER_SLAVE_MODE_ENABLE == masterslave){
+    if(TIMER_MASTER_SLAVE_MODE_ENABLE == masterslave) {
         TIMER_SMCFG(timer_periph) |= (uint32_t)TIMER_SMCFG_MSM;
-    }else if(TIMER_MASTER_SLAVE_MODE_DISABLE == masterslave){
+    } else if(TIMER_MASTER_SLAVE_MODE_DISABLE == masterslave) {
         TIMER_SMCFG(timer_periph) &= ~(uint32_t)TIMER_SMCFG_MSM;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    configure TIMER external trigger input
+    \brief      configure TIMER external trigger input
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[in]  extprescaler:
                 only one parameter can be selected which is shown as below:
@@ -1807,14 +1664,14 @@ void timer_external_trigger_config(uint32_t timer_periph, uint32_t extprescaler,
 }
 
 /*!
-    \brief    configure TIMER quadrature decoder mode
-    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
-    \param[in]  decomode: 
+    \brief      configure TIMER quadrature decoder mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  decomode:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_ENCODER_MODE0: counter counts on CI0FE0 edge depending on CI1FE1 level
       \arg        TIMER_ENCODER_MODE1: counter counts on CI1FE1 edge depending on CI0FE0 level
       \arg        TIMER_ENCODER_MODE2: counter counts on both CI0FE0 and CI1FE1 edges depending on the level of the other input
-    \param[in]  ic0polarity: 
+    \param[in]  ic0polarity:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_IC_POLARITY_RISING: capture rising edge
       \arg        TIMER_IC_POLARITY_FALLING: capture falling edge
@@ -1826,21 +1683,21 @@ void timer_external_trigger_config(uint32_t timer_periph, uint32_t extprescaler,
     \retval     none
 */
 void timer_quadrature_decoder_mode_config(uint32_t timer_periph, uint32_t decomode,
-                                   uint16_t ic0polarity, uint16_t ic1polarity)
+        uint16_t ic0polarity, uint16_t ic1polarity)
 {
     TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_SMC);
     TIMER_SMCFG(timer_periph) |= (uint32_t)decomode;
 
-    TIMER_CHCTL0(timer_periph) &= (uint32_t)(((~(uint32_t)TIMER_CHCTL0_CH0MS))&((~(uint32_t)TIMER_CHCTL0_CH1MS)));
-    TIMER_CHCTL0(timer_periph) |= (uint32_t)(TIMER_IC_SELECTION_DIRECTTI|((uint32_t)TIMER_IC_SELECTION_DIRECTTI << 8U));
+    TIMER_CHCTL0(timer_periph) &= (uint32_t)(((~(uint32_t)TIMER_CHCTL0_CH0MS)) & ((~(uint32_t)TIMER_CHCTL0_CH1MS)));
+    TIMER_CHCTL0(timer_periph) |= (uint32_t)(TIMER_IC_SELECTION_DIRECTTI | ((uint32_t)TIMER_IC_SELECTION_DIRECTTI << 8U));
 
-    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P|TIMER_CHCTL2_CH0NP));
-    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P|TIMER_CHCTL2_CH1NP));
-    TIMER_CHCTL2(timer_periph) |= ((uint32_t)ic0polarity|((uint32_t)ic1polarity << 4U));
+    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+    TIMER_CHCTL2(timer_periph) |= ((uint32_t)ic0polarity | ((uint32_t)ic1polarity << 4U));
 }
 
 /*!
-    \brief    configure TIMER internal clock mode
+    \brief      configure TIMER internal clock mode
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
     \param[out] none
     \retval     none
@@ -1851,9 +1708,9 @@ void timer_internal_clock_config(uint32_t timer_periph)
 }
 
 /*!
-    \brief    configure TIMER the internal trigger as external clock input
+    \brief      configure TIMER the internal trigger as external clock input
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
-    \param[in]  intrigger: 
+    \param[in]  intrigger:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_SMCFG_TRGSEL_ITI0: internal trigger 0
       \arg        TIMER_SMCFG_TRGSEL_ITI1: internal trigger 1
@@ -1870,14 +1727,14 @@ void timer_internal_trigger_as_external_clock_config(uint32_t timer_periph, uint
 }
 
 /*!
-    \brief    configure TIMER the external trigger as external clock input
+    \brief      configure TIMER the external trigger as external clock input
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
-    \param[in]  extrigger: 
+    \param[in]  extrigger:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_SMCFG_TRGSEL_CI0F_ED: TI0 edge detector
       \arg        TIMER_SMCFG_TRGSEL_CI0FE0: filtered TIMER input 0
       \arg        TIMER_SMCFG_TRGSEL_CI1FE1: filtered TIMER input 1
-    \param[in]  extpolarity: 
+    \param[in]  extpolarity:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_IC_POLARITY_RISING: active high or rising edge active
       \arg        TIMER_IC_POLARITY_FALLING: active low or falling edge active
@@ -1886,13 +1743,13 @@ void timer_internal_trigger_as_external_clock_config(uint32_t timer_periph, uint
     \retval     none
 */
 void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint32_t extrigger,
-                                       uint16_t extpolarity, uint32_t extfilter)
+        uint16_t extpolarity, uint32_t extfilter)
 {
-    if(TIMER_SMCFG_TRGSEL_CI1FE1 == extrigger){
+    if(TIMER_SMCFG_TRGSEL_CI1FE1 == extrigger) {
         /* reset the CH1EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
         /* reset the CH1NP bit */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P|TIMER_CHCTL2_CH1NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
         /* set the CH1NP bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)extpolarity << 4U);
         /* reset the CH1MS bit */
@@ -1905,11 +1762,11 @@ void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint
         TIMER_CHCTL0(timer_periph) |= (uint32_t)(extfilter << 12U);
         /* set the CH1EN bit */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
-    }else{
+    } else {
         /* reset the CH0EN bit */
         TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
         /* reset the CH0P and CH0NP bits */
-        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P|TIMER_CHCTL2_CH0NP));
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
         /* set the CH0P and CH0NP bits */
         TIMER_CHCTL2(timer_periph) |= (uint32_t)extpolarity;
         /* reset the CH0MS bit */
@@ -1924,7 +1781,7 @@ void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint
         TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
     }
     /* select TIMER input trigger source */
-    timer_input_trigger_source_select(timer_periph,extrigger);
+    timer_input_trigger_source_select(timer_periph, extrigger);
     /* reset the SMC bit */
     TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_SMC);
     /* set the SMC bit */
@@ -1932,15 +1789,15 @@ void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint
 }
 
 /*!
-    \brief    configure TIMER the external clock mode0
+    \brief      configure TIMER the external clock mode0
     \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
-    \param[in]  extprescaler: 
+    \param[in]  extprescaler:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_EXT_TRI_PSC_OFF: no divided
       \arg        TIMER_EXT_TRI_PSC_DIV2: divided by 2
       \arg        TIMER_EXT_TRI_PSC_DIV4: divided by 4
       \arg        TIMER_EXT_TRI_PSC_DIV8: divided by 8
-    \param[in]  extpolarity: 
+    \param[in]  extpolarity:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_ETP_FALLING: active low or falling edge active
       \arg        TIMER_ETP_RISING: active high or rising edge active
@@ -1961,15 +1818,15 @@ void timer_external_clock_mode0_config(uint32_t timer_periph, uint32_t extpresca
 }
 
 /*!
-    \brief    configure TIMER the external clock mode1
+    \brief      configure TIMER the external clock mode1
     \param[in]  timer_periph: TIMERx(x=0..4,7)
-    \param[in]  extprescaler: 
+    \param[in]  extprescaler:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_EXT_TRI_PSC_OFF: no divided
       \arg        TIMER_EXT_TRI_PSC_DIV2: divided by 2
       \arg        TIMER_EXT_TRI_PSC_DIV4: divided by 4
       \arg        TIMER_EXT_TRI_PSC_DIV8: divided by 8
-    \param[in]  extpolarity: 
+    \param[in]  extpolarity:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_ETP_FALLING: active low or falling edge active
       \arg        TIMER_ETP_RISING: active high or rising edge active
@@ -1987,7 +1844,7 @@ void timer_external_clock_mode1_config(uint32_t timer_periph, uint32_t extpresca
 }
 
 /*!
-    \brief    disable TIMER the external clock mode1
+    \brief      disable TIMER the external clock mode1
     \param[in]  timer_periph: TIMERx(x=0..4,7)
     \param[out] none
     \retval     none
@@ -1998,9 +1855,9 @@ void timer_external_clock_mode1_disable(uint32_t timer_periph)
 }
 
 /*!
-    \brief    configure TIMER channel remap function
+    \brief      configure TIMER channel remap function
     \param[in]  timer_periph: TIMERx(x=1,4,10)
-    \param[in]  remap: 
+    \param[in]  remap:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER1_ITI1_RMP_TIMER7_TRGO: timer1 internal trigger input1 remap to TIMER7_TRGO
       \arg        TIMER1_ITI1_RMP_ETHERNET_PTP: timer1 internal trigger input1 remap to ethernet PTP
@@ -2009,7 +1866,7 @@ void timer_external_clock_mode1_disable(uint32_t timer_periph)
       \arg        TIMER4_CI3_RMP_GPIO: timer4 channel 3 input remap to GPIO pin
       \arg        TIMER4_CI3_RMP_IRC32K: timer4 channel 3 input remap to IRC32K
       \arg        TIMER4_CI3_RMP_LXTAL: timer4 channel 3 input remap to  LXTAL
-      \arg        TIMER4_CI3_RMP_RTC_WAKEUP_INT: timer4 channel 3 input remap to RTC wakeup interrupt 
+      \arg        TIMER4_CI3_RMP_RTC_WAKEUP_INT: timer4 channel 3 input remap to RTC wakeup interrupt
       \arg        TIMER10_ITI1_RMP_GPIO: timer10 internal trigger input1 remap based on GPIO setting
       \arg        TIMER10_ITI1_RMP_RTC_HXTAL_DIV: timer10 internal trigger input1 remap  HXTAL _DIV(clock used for RTC which is HXTAL clock divided by RTCDIV bits in RCU_CFG0 register)
     \param[out] none
@@ -2021,9 +1878,9 @@ void timer_channel_remap_config(uint32_t timer_periph, uint32_t remap)
 }
 
 /*!
-    \brief    configure TIMER write CHxVAL register selection
+    \brief      configure TIMER write CHxVAL register selection
     \param[in]  timer_periph: TIMERx(x=0,1,2,13,14,15,16)
-    \param[in]  ccsel: 
+    \param[in]  ccsel:
                 only one parameter can be selected which is shown as below:
       \arg        TIMER_CHVSEL_DISABLE: no effect
       \arg        TIMER_CHVSEL_ENABLE:  when write the CHxVAL register, if the write value is same as the CHxVAL value, the write access is ignored
@@ -2032,17 +1889,17 @@ void timer_channel_remap_config(uint32_t timer_periph, uint32_t remap)
 */
 void timer_write_chxval_register_config(uint32_t timer_periph, uint16_t ccsel)
 {
-    if(TIMER_CHVSEL_ENABLE == ccsel){
+    if(TIMER_CHVSEL_ENABLE == ccsel) {
         TIMER_CFG(timer_periph) |= (uint32_t)TIMER_CFG_CHVSEL;
-    }else if(TIMER_CHVSEL_DISABLE == ccsel){
+    } else if(TIMER_CHVSEL_DISABLE == ccsel) {
         TIMER_CFG(timer_periph) &= ~(uint32_t)TIMER_CFG_CHVSEL;
-    }else{
+    } else {
         /* illegal parameters */
     }
 }
 
 /*!
-    \brief    configure TIMER output value selection
+    \brief      configure TIMER output value selection
     \param[in]  timer_periph: TIMERx(x=0,7)
     \param[in]  outsel:
                 only one parameter can be selected which is shown as below:
@@ -2053,11 +1910,155 @@ void timer_write_chxval_register_config(uint32_t timer_periph, uint16_t ccsel)
 */
 void timer_output_value_selection_config(uint32_t timer_periph, uint16_t outsel)
 {
-    if(TIMER_OUTSEL_ENABLE == outsel){
+    if(TIMER_OUTSEL_ENABLE == outsel) {
         TIMER_CFG(timer_periph) |= (uint32_t)TIMER_CFG_OUTSEL;
-    }else if(TIMER_OUTSEL_DISABLE == outsel){
+    } else if(TIMER_OUTSEL_DISABLE == outsel) {
         TIMER_CFG(timer_periph) &= ~(uint32_t)TIMER_CFG_OUTSEL;
-    }else{
+    } else {
         /* illegal parameters */
     }
+}
+
+/*!
+    \brief      get TIMER flags
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  flag: the timer interrupt flags
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
+      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_CH0OF: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
+      \arg        TIMER_FLAG_CH1OF: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2OF: channel 2 overcapture flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3OF: channel 3 overcapture flag,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag)
+{
+    if(RESET != (TIMER_INTF(timer_periph) & flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear TIMER flags
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  flag: the timer interrupt flags
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
+      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_CH0OF: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
+      \arg        TIMER_FLAG_CH1OF: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2OF: channel 2 overcapture flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3OF: channel 3 overcapture flag,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_flag_clear(uint32_t timer_periph, uint32_t flag)
+{
+    TIMER_INTF(timer_periph) = (~(uint32_t)flag);
+}
+
+/*!
+    \brief      enable the TIMER interrupt
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: timer interrupt enable source
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
+      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
+      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_DMAINTEN(timer_periph) |= (uint32_t) interrupt;
+}
+
+/*!
+    \brief      disable the TIMER interrupt
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: timer interrupt source enable
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
+      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
+      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)interrupt);
+}
+
+/*!
+    \brief      get timer interrupt flag
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: the timer interrupt bits
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
+      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7)
+      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt)
+{
+    uint32_t val;
+    val = (TIMER_DMAINTEN(timer_periph) & interrupt);
+    if((RESET != (TIMER_INTF(timer_periph) & interrupt)) && (RESET != val)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear TIMER interrupt flag
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: the timer interrupt bits
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
+      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7)
+      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_INTF(timer_periph) = (~(uint32_t)interrupt);
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_timer.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_timer.c
@@ -152,7 +152,7 @@ void timer_struct_para_init(timer_parameter_struct *initpara)
     \param[out] none
     \retval     none
 */
-void timer_init(uint32_t timer_periph, timer_parameter_struct *initpara)
+void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct *initpara)
 {
     /* configure the counter prescaler value */
     TIMER_PSC(timer_periph) = (uint16_t)initpara->prescaler;

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_tli.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_tli.c
@@ -1,36 +1,37 @@
 /*!
     \file    gd32f4xx_tli.c
     \brief   TLI driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -117,23 +118,23 @@ void tli_struct_para_init(tli_parameter_struct *tli_struct)
 void tli_init(tli_parameter_struct *tli_struct)
 {
     /* synchronous pulse size configuration */
-    TLI_SPSZ &= ~(TLI_SPSZ_VPSZ|TLI_SPSZ_HPSZ);
-    TLI_SPSZ = (uint32_t)((uint32_t)tli_struct->synpsz_vpsz|((uint32_t)tli_struct->synpsz_hpsz<<16U));
+    TLI_SPSZ &= ~(TLI_SPSZ_VPSZ | TLI_SPSZ_HPSZ);
+    TLI_SPSZ = (uint32_t)((uint32_t)tli_struct->synpsz_vpsz | ((uint32_t)tli_struct->synpsz_hpsz << 16U));
     /* back-porch size configuration */
-    TLI_BPSZ &= ~(TLI_BPSZ_VBPSZ|TLI_BPSZ_HBPSZ);
-    TLI_BPSZ = (uint32_t)((uint32_t)tli_struct->backpsz_vbpsz|((uint32_t)tli_struct->backpsz_hbpsz<<16U));
-    /* active size configuration */    
-    TLI_ASZ &= ~(TLI_ASZ_VASZ|TLI_ASZ_HASZ);
-    TLI_ASZ = (tli_struct->activesz_vasz|(tli_struct->activesz_hasz<<16U));
-    /* total size configuration */    
-    TLI_TSZ &= ~(TLI_TSZ_VTSZ|TLI_TSZ_HTSZ);
-    TLI_TSZ = (tli_struct->totalsz_vtsz|(tli_struct->totalsz_htsz<<16U));
-    /* background color configuration */    
-    TLI_BGC &= ~(TLI_BGC_BVB|(TLI_BGC_BVG)|(TLI_BGC_BVR));
-    TLI_BGC = (tli_struct->backcolor_blue|(tli_struct->backcolor_green<<8U)|(tli_struct->backcolor_red<<16U));
-    TLI_CTL &= ~(TLI_CTL_HPPS|TLI_CTL_VPPS|TLI_CTL_DEPS|TLI_CTL_CLKPS);
-    TLI_CTL |= (tli_struct->signalpolarity_hs|tli_struct->signalpolarity_vs|\
-                tli_struct->signalpolarity_de|tli_struct->signalpolarity_pixelck);
+    TLI_BPSZ &= ~(TLI_BPSZ_VBPSZ | TLI_BPSZ_HBPSZ);
+    TLI_BPSZ = (uint32_t)((uint32_t)tli_struct->backpsz_vbpsz | ((uint32_t)tli_struct->backpsz_hbpsz << 16U));
+    /* active size configuration */
+    TLI_ASZ &= ~(TLI_ASZ_VASZ | TLI_ASZ_HASZ);
+    TLI_ASZ = (tli_struct->activesz_vasz | (tli_struct->activesz_hasz << 16U));
+    /* total size configuration */
+    TLI_TSZ &= ~(TLI_TSZ_VTSZ | TLI_TSZ_HTSZ);
+    TLI_TSZ = (tli_struct->totalsz_vtsz | (tli_struct->totalsz_htsz << 16U));
+    /* background color configuration */
+    TLI_BGC &= ~(TLI_BGC_BVB | (TLI_BGC_BVG) | (TLI_BGC_BVR));
+    TLI_BGC = (tli_struct->backcolor_blue | (tli_struct->backcolor_green << 8U) | (tli_struct->backcolor_red << 16U));
+    TLI_CTL &= ~(TLI_CTL_HPPS | TLI_CTL_VPPS | TLI_CTL_DEPS | TLI_CTL_CLKPS);
+    TLI_CTL |= (tli_struct->signalpolarity_hs | tli_struct->signalpolarity_vs | \
+                tli_struct->signalpolarity_de | tli_struct->signalpolarity_pixelck);
 
 }
 
@@ -148,15 +149,15 @@ void tli_init(tli_parameter_struct *tli_struct)
 */
 void tli_dither_config(uint8_t dither_stat)
 {
-    if(TLI_DITHER_ENABLE == dither_stat){
+    if(TLI_DITHER_ENABLE == dither_stat) {
         TLI_CTL |= TLI_CTL_DFEN;
-    }else{
+    } else {
         TLI_CTL &= ~(TLI_CTL_DFEN);
     }
 }
 
 /*!
-    \brief    enable TLI 
+    \brief    enable TLI
     \param[in]  none
     \param[out] none
     \retval     none
@@ -167,7 +168,7 @@ void tli_enable(void)
 }
 
 /*!
-    \brief    disable TLI 
+    \brief    disable TLI
     \param[in]  none
     \param[out] none
     \retval     none
@@ -188,23 +189,23 @@ void tli_disable(void)
 */
 void tli_reload_config(uint8_t reload_mod)
 {
-    if(TLI_FRAME_BLANK_RELOAD_EN == reload_mod){
+    if(TLI_FRAME_BLANK_RELOAD_EN == reload_mod) {
         /* the layer configuration will be reloaded at frame blank */
         TLI_RL |= TLI_RL_FBR;
-    }else{
+    } else {
         /* the layer configuration will be reloaded after this bit sets */
         TLI_RL |= TLI_RL_RQR;
     }
 }
 
 /*!
-    \brief    initialize the parameters of TLI layer structure with the default values, it is suggested 
+    \brief    initialize the parameters of TLI layer structure with the default values, it is suggested
                 that call this function after a tli_layer_parameter_struct structure is defined
     \param[in]  none
     \param[out] layer_struct: TLI Layer parameter struct
                   layer_window_rightpos: window right position
                   layer_window_leftpos: window left position
-                  layer_window_bottompos: window bottom position 
+                  layer_window_bottompos: window bottom position
                   layer_window_toppos: window top position
                   layer_ppf: LAYER_PPF_ARGB8888,LAYER_PPF_RGB888,LAYER_PPF_RGB565,
                                  LAYER_PPF_ARG1555,LAYER_PPF_ARGB4444,LAYER_PPF_L8,
@@ -244,12 +245,12 @@ void tli_layer_struct_para_init(tli_layer_parameter_struct *layer_struct)
 }
 
 /*!
-    \brief    initialize TLI layer 
+    \brief    initialize TLI layer
     \param[in]  layerx: LAYERx(x=0,1)
     \param[in]  layer_struct: TLI Layer parameter struct
                   layer_window_rightpos: window right position
                   layer_window_leftpos: window left position
-                  layer_window_bottompos: window bottom position 
+                  layer_window_bottompos: window bottom position
                   layer_window_toppos: window top position
                   layer_ppf: LAYER_PPF_ARGB8888,LAYER_PPF_RGB888,LAYER_PPF_RGB565,
                                  LAYER_PPF_ARG1555,LAYER_PPF_ARGB4444,LAYER_PPF_L8,
@@ -268,14 +269,14 @@ void tli_layer_struct_para_init(tli_layer_parameter_struct *layer_struct)
     \param[out] none
     \retval     none
 */
-void tli_layer_init(uint32_t layerx,tli_layer_parameter_struct *layer_struct)
+void tli_layer_init(uint32_t layerx, tli_layer_parameter_struct *layer_struct)
 {
     /* configure layer window horizontal position */
-    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP|(TLI_LxHPOS_WRP));
-    TLI_LxHPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_leftpos|((uint32_t)layer_struct->layer_window_rightpos<<16U));
+    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP | (TLI_LxHPOS_WRP));
+    TLI_LxHPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_leftpos | ((uint32_t)layer_struct->layer_window_rightpos << 16U));
     /* configure layer window vertical position */
-    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP|(TLI_LxVPOS_WBP));
-    TLI_LxVPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_toppos|((uint32_t)layer_struct->layer_window_bottompos<<16U));
+    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP | (TLI_LxVPOS_WBP));
+    TLI_LxVPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_toppos | ((uint32_t)layer_struct->layer_window_bottompos << 16U));
     /* configure layer packeted pixel format */
     TLI_LxPPF(layerx) &= ~(TLI_LxPPF_PPF);
     TLI_LxPPF(layerx) = layer_struct->layer_ppf;
@@ -283,20 +284,20 @@ void tli_layer_init(uint32_t layerx,tli_layer_parameter_struct *layer_struct)
     TLI_LxSA(layerx) &= ~(TLI_LxSA_SA);
     TLI_LxSA(layerx) = layer_struct->layer_sa;
     /* configure layer default color */
-    TLI_LxDC(layerx) &= ~(TLI_LxDC_DCB|(TLI_LxDC_DCG)|(TLI_LxDC_DCR)|(TLI_LxDC_DCA));
-    TLI_LxDC(layerx) = (uint32_t)((uint32_t)layer_struct->layer_default_blue|((uint32_t)layer_struct->layer_default_green<<8U)
-                                                               |((uint32_t)layer_struct->layer_default_red<<16U)
-                                                               |((uint32_t)layer_struct->layer_default_alpha<<24U));
+    TLI_LxDC(layerx) &= ~(TLI_LxDC_DCB | (TLI_LxDC_DCG) | (TLI_LxDC_DCR) | (TLI_LxDC_DCA));
+    TLI_LxDC(layerx) = (uint32_t)((uint32_t)layer_struct->layer_default_blue | ((uint32_t)layer_struct->layer_default_green << 8U)
+                                  | ((uint32_t)layer_struct->layer_default_red << 16U)
+                                  | ((uint32_t)layer_struct->layer_default_alpha << 24U));
 
     /* configure layer alpha calculation factors */
-    TLI_LxBLEND(layerx) &= ~(TLI_LxBLEND_ACF2|(TLI_LxBLEND_ACF1));
-    TLI_LxBLEND(layerx) = ((layer_struct->layer_acf2)|(layer_struct->layer_acf1));
+    TLI_LxBLEND(layerx) &= ~(TLI_LxBLEND_ACF2 | (TLI_LxBLEND_ACF1));
+    TLI_LxBLEND(layerx) = ((layer_struct->layer_acf2) | (layer_struct->layer_acf1));
     /* configure layer frame buffer base address */
     TLI_LxFBADDR(layerx) &= ~(TLI_LxFBADDR_FBADD);
     TLI_LxFBADDR(layerx) = (layer_struct->layer_frame_bufaddr);
     /* configure layer frame line length */
-    TLI_LxFLLEN(layerx) &= ~(TLI_LxFLLEN_FLL|(TLI_LxFLLEN_STDOFF));
-    TLI_LxFLLEN(layerx) = (uint32_t)((uint32_t)layer_struct->layer_frame_line_length|((uint32_t)layer_struct->layer_frame_buf_stride_offset<<16U));
+    TLI_LxFLLEN(layerx) &= ~(TLI_LxFLLEN_FLL | (TLI_LxFLLEN_STDOFF));
+    TLI_LxFLLEN(layerx) = (uint32_t)((uint32_t)layer_struct->layer_frame_line_length | ((uint32_t)layer_struct->layer_frame_buf_stride_offset << 16U));
     /* configure layer frame total line number */
     TLI_LxFTLN(layerx) &= ~(TLI_LxFTLN_FTLN);
     TLI_LxFTLN(layerx) = (uint32_t)(layer_struct->layer_frame_total_line_number);
@@ -304,56 +305,56 @@ void tli_layer_init(uint32_t layerx,tli_layer_parameter_struct *layer_struct)
 }
 
 /*!
-    \brief    reconfigure window position 
+    \brief    reconfigure window position
     \param[in]  layerx: LAYERx(x=0,1)
     \param[in]  offset_x: new horizontal offset
     \param[in]  offset_y: new vertical offset
     \param[out] none
     \retval     none
 */
-void tli_layer_window_offset_modify(uint32_t layerx,uint16_t offset_x,uint16_t offset_y)
+void tli_layer_window_offset_modify(uint32_t layerx, uint16_t offset_x, uint16_t offset_y)
 {
     /* configure window start position */
     uint32_t layer_ppf, line_num, hstart, vstart;
     uint32_t line_length = 0U;
-    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP|(TLI_LxHPOS_WRP));
-    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP|(TLI_LxVPOS_WBP));
-    hstart = (uint32_t)offset_x+(((TLI_BPSZ & TLI_BPSZ_HBPSZ)>>16U)+1U);
-    vstart = (uint32_t)offset_y+((TLI_BPSZ & TLI_BPSZ_VBPSZ)+1U);
+    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP | (TLI_LxHPOS_WRP));
+    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP | (TLI_LxVPOS_WBP));
+    hstart = (uint32_t)offset_x + (((TLI_BPSZ & TLI_BPSZ_HBPSZ) >> 16U) + 1U);
+    vstart = (uint32_t)offset_y + ((TLI_BPSZ & TLI_BPSZ_VBPSZ) + 1U);
     line_num = (TLI_LxFTLN(layerx) & TLI_LxFTLN_FTLN);
     layer_ppf = (TLI_LxPPF(layerx) & TLI_LxPPF_PPF);
     /* the bytes of a line equal TLI_LxFLLEN_FLL bits value minus 3 */
-    switch(layer_ppf){
+    switch(layer_ppf) {
     case LAYER_PPF_ARGB8888:
         /* each pixel includes 4bytes, when pixel format is ARGB8888 */
-        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL)-3U)/4U);
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 4U);
         break;
     case LAYER_PPF_RGB888:
         /* each pixel includes 3bytes, when pixel format is RGB888 */
-        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL)-3U)/3U);
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 3U);
         break;
     case LAYER_PPF_RGB565:
     case LAYER_PPF_ARGB1555:
     case LAYER_PPF_ARGB4444:
     case LAYER_PPF_AL88:
         /* each pixel includes 2bytes, when pixel format is RGB565,ARG1555,ARGB4444 or AL88 */
-        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL)-3U)/2U);
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 2U);
         break;
     case LAYER_PPF_L8:
     case LAYER_PPF_AL44:
         /* each pixel includes 1byte, when pixel format is L8 or AL44 */
-        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL)-3U));
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U));
         break;
     default:
         break;
     }
     /* reconfigure window position */
-    TLI_LxHPOS(layerx) = (hstart|((hstart+line_length-1U)<<16U));
-    TLI_LxVPOS(layerx) = (vstart|((vstart+line_num-1U)<<16U));
+    TLI_LxHPOS(layerx) = (hstart | ((hstart + line_length - 1U) << 16U));
+    TLI_LxVPOS(layerx) = (vstart | ((vstart + line_num - 1U) << 16U));
 }
 
 /*!
-    \brief    initialize the parameters of TLI layer LUT structure with the default values, it is suggested 
+    \brief    initialize the parameters of TLI layer LUT structure with the default values, it is suggested
                 that call this function after a tli_layer_lut_parameter_struct structure is defined
     \param[in]  none
     \param[out] lut_struct: TLI layer LUT parameter struct
@@ -373,7 +374,7 @@ void tli_lut_struct_para_init(tli_layer_lut_parameter_struct *lut_struct)
 }
 
 /*!
-    \brief    initialize TLI layer LUT 
+    \brief    initialize TLI layer LUT
     \param[in]  layerx: LAYERx(x=0,1)
     \param[in]  lut_struct: TLI layer LUT parameter struct
                   layer_table_addr: look up table write address
@@ -383,30 +384,29 @@ void tli_lut_struct_para_init(tli_layer_lut_parameter_struct *lut_struct)
     \param[out] none
     \retval     none
 */
-void tli_lut_init(uint32_t layerx,tli_layer_lut_parameter_struct *lut_struct)
+void tli_lut_init(uint32_t layerx, tli_layer_lut_parameter_struct *lut_struct)
 {
-    TLI_LxLUT(layerx) &= ~(TLI_LxLUT_TB|TLI_LxLUT_TG|TLI_LxLUT_TR|TLI_LxLUT_TADD);
-    TLI_LxLUT(layerx) = (uint32_t)(((uint32_t)lut_struct->layer_lut_channel_blue)|((uint32_t)lut_struct->layer_lut_channel_green<<8U)
-                                                                   |((uint32_t)lut_struct->layer_lut_channel_red<<16U
-                                                                   |((uint32_t)lut_struct->layer_table_addr<<24U)));
+    TLI_LxLUT(layerx) = (uint32_t)(((uint32_t)lut_struct->layer_lut_channel_blue) | ((uint32_t)lut_struct->layer_lut_channel_green << 8U)
+                                   | ((uint32_t)lut_struct->layer_lut_channel_red << 16U
+                                      | ((uint32_t)lut_struct->layer_table_addr << 24U)));
 }
 
 /*!
-    \brief    initialize TLI layer color key 
+    \brief    initialize TLI layer color key
     \param[in]  layerx: LAYERx(x=0,1)
     \param[in]  redkey: color key red
-    \param[in]  greenkey: color key green 
+    \param[in]  greenkey: color key green
     \param[in]  bluekey: color key blue
     \param[out] none
     \retval     none
 */
-void tli_color_key_init(uint32_t layerx,uint8_t redkey,uint8_t greenkey,uint8_t bluekey)
+void tli_color_key_init(uint32_t layerx, uint8_t redkey, uint8_t greenkey, uint8_t bluekey)
 {
-    TLI_LxCKEY(layerx) = (((uint32_t)bluekey)|((uint32_t)greenkey<<8U)|((uint32_t)redkey<<16U));
+    TLI_LxCKEY(layerx) = (((uint32_t)bluekey) | ((uint32_t)greenkey << 8U) | ((uint32_t)redkey << 16U));
 }
 
 /*!
-    \brief    enable TLI layer 
+    \brief    enable TLI layer
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -417,7 +417,7 @@ void tli_layer_enable(uint32_t layerx)
 }
 
 /*!
-    \brief    disable TLI layer 
+    \brief    disable TLI layer
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -428,7 +428,7 @@ void tli_layer_disable(uint32_t layerx)
 }
 
 /*!
-    \brief    enable TLI layer color keying 
+    \brief    enable TLI layer color keying
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -439,7 +439,7 @@ void tli_color_key_enable(uint32_t layerx)
 }
 
 /*!
-    \brief    disable TLI layer color keying 
+    \brief    disable TLI layer color keying
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -450,7 +450,7 @@ void tli_color_key_disable(uint32_t layerx)
 }
 
 /*!
-    \brief    enable TLI layer LUT 
+    \brief    enable TLI layer LUT
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -461,7 +461,7 @@ void tli_lut_enable(uint32_t layerx)
 }
 
 /*!
-    \brief    disable TLI layer LUT 
+    \brief    disable TLI layer LUT
     \param[in]  layerx: LAYERx(x=0,1)
     \param[out] none
     \retval     none
@@ -472,8 +472,8 @@ void tli_lut_disable(uint32_t layerx)
 }
 
 /*!
-    \brief    set line mark value 
-    \param[in]  line_num: line number 
+    \brief    set line mark value
+    \param[in]  line_num: line number
     \param[out] none
     \retval     none
 */
@@ -484,7 +484,7 @@ void tli_line_mark_set(uint16_t line_num)
 }
 
 /*!
-    \brief    get current displayed position 
+    \brief    get current displayed position
     \param[in]  none
     \param[out] none
     \retval     position of current pixel
@@ -495,13 +495,13 @@ uint32_t tli_current_pos_get(void)
 }
 
 /*!
-    \brief    enable TLI interrupt 
+    \brief    enable TLI interrupt
     \param[in]  int_flag: TLI interrupt flags
                 one or more parameters can be selected which are shown as below:
-      \arg        TLI_INT_LM: line mark interrupt 
-      \arg        TLI_INT_FE: FIFO error interrupt 
-      \arg        TLI_INT_TE: transaction error interrupt 
-      \arg        TLI_INT_LCR: layer configuration reloaded interrupt 
+      \arg        TLI_INT_LM: line mark interrupt
+      \arg        TLI_INT_FE: FIFO error interrupt
+      \arg        TLI_INT_TE: transaction error interrupt
+      \arg        TLI_INT_LCR: layer configuration reloaded interrupt
     \param[out] none
     \retval     none
 */
@@ -511,13 +511,13 @@ void tli_interrupt_enable(uint32_t int_flag)
 }
 
 /*!
-    \brief    disable TLI interrupt 
+    \brief    disable TLI interrupt
     \param[in]  int_flag: TLI interrupt flags
                 one or more parameters can be selected which are shown as below:
-      \arg        TLI_INT_LM: line mark interrupt 
-      \arg        TLI_INT_FE: FIFO error interrupt 
-      \arg        TLI_INT_TE: transaction error interrupt 
-      \arg        TLI_INT_LCR: layer configuration reloaded interrupt 
+      \arg        TLI_INT_LM: line mark interrupt
+      \arg        TLI_INT_FE: FIFO error interrupt
+      \arg        TLI_INT_TE: transaction error interrupt
+      \arg        TLI_INT_LCR: layer configuration reloaded interrupt
     \param[out] none
     \retval     none
 */
@@ -527,7 +527,7 @@ void tli_interrupt_disable(uint32_t int_flag)
 }
 
 /*!
-    \brief    get TLI interrupt flag 
+    \brief    get TLI interrupt flag
     \param[in]  int_flag: TLI interrupt flags
                 one or more parameters can be selected which are shown as below:
       \arg        TLI_INT_FLAG_LM: line mark interrupt flag
@@ -541,9 +541,9 @@ FlagStatus tli_interrupt_flag_get(uint32_t int_flag)
 {
     uint32_t state;
     state = TLI_INTF;
-    if(state & int_flag){
+    if(state & int_flag) {
         state = TLI_INTEN;
-        if(state & int_flag){
+        if(state & int_flag) {
             return SET;
         }
     }
@@ -551,7 +551,7 @@ FlagStatus tli_interrupt_flag_get(uint32_t int_flag)
 }
 
 /*!
-    \brief    clear TLI interrupt flag 
+    \brief    clear TLI interrupt flag
     \param[in]  int_flag: TLI interrupt flags
                 one or more parameters can be selected which are shown as below:
       \arg        TLI_INT_FLAG_LM: line mark interrupt flag
@@ -570,14 +570,14 @@ void tli_interrupt_flag_clear(uint32_t int_flag)
     \brief    get TLI flag or state in TLI_INTF register or TLI_STAT register
     \param[in]  flag: TLI flags or states
                 only one parameter can be selected which is shown as below:
-      \arg        TLI_FLAG_VDE: current VDE state 
+      \arg        TLI_FLAG_VDE: current VDE state
       \arg        TLI_FLAG_HDE: current HDE state
       \arg        TLI_FLAG_VS: current VS status of the TLI
       \arg        TLI_FLAG_HS: current HS status of the TLI
       \arg        TLI_FLAG_LM: line mark interrupt flag
       \arg        TLI_FLAG_FE: FIFO error interrupt flag
-      \arg        TLI_FLAG_TE: transaction error interrupt flag 
-      \arg        TLI_FLAG_LCR: layer configuration reloaded interrupt flag 
+      \arg        TLI_FLAG_TE: transaction error interrupt flag
+      \arg        TLI_FLAG_LCR: layer configuration reloaded interrupt flag
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
@@ -585,14 +585,14 @@ FlagStatus tli_flag_get(uint32_t flag)
 {
     uint32_t stat;
     /* choose which register to get flag or state */
-    if(flag >> 31U){
+    if(flag >> 31U) {
         stat = TLI_INTF;
-    }else{
+    } else {
         stat = TLI_STAT;
     }
-    if(flag & stat){
+    if(flag & stat) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_trng.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_trng.c
@@ -5,32 +5,33 @@
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -87,7 +88,7 @@ uint32_t trng_get_true_random_data(void)
     \param[out] none
     \retval     none
 */
-void trng_interrupt_enable(void) 
+void trng_interrupt_enable(void)
 {
     TRNG_CTL |= TRNG_CTL_IE;
 }
@@ -115,9 +116,9 @@ void trng_interrupt_disable(void)
 */
 FlagStatus trng_flag_get(trng_flag_enum flag)
 {
-    if(RESET != (TRNG_STAT & flag)){
+    if(RESET != (TRNG_STAT & flag)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -133,9 +134,9 @@ FlagStatus trng_flag_get(trng_flag_enum flag)
 */
 FlagStatus trng_interrupt_flag_get(trng_int_flag_enum int_flag)
 {
-    if(RESET != (TRNG_STAT & int_flag)){
+    if(RESET != (TRNG_STAT & int_flag)) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_usart.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_usart.c
@@ -1,39 +1,39 @@
 /*!
     \file    gd32f4xx_usart.c
     \brief   USART driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
-
 
 #include "gd32f4xx_usart.h"
 
@@ -43,14 +43,14 @@ OF SUCH DAMAGE.
 #define RT_BL_OFFSET              ((uint32_t)24U)      /* bit offset of BL in USART_RT */
 
 /*!
-    \brief    reset USART/UART 
+    \brief    reset USART/UART
     \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
     \param[out] none
     \retval     none
 */
 void usart_deinit(uint32_t usart_periph)
 {
-    switch(usart_periph){
+    switch(usart_periph) {
     case USART0:
         rcu_periph_reset_enable(RCU_USART0RST);
         rcu_periph_reset_disable(RCU_USART0RST);
@@ -94,52 +94,52 @@ void usart_deinit(uint32_t usart_periph)
     \param[in]  baudval: baud rate value
     \param[out] none
     \retval     none
-*/ 
+*/
 void usart_baudrate_set(uint32_t usart_periph, uint32_t baudval)
 {
-    uint32_t uclk=0U, intdiv=0U, fradiv=0U, udiv=0U;
-    switch(usart_periph){
-         /* get clock frequency */
+    uint32_t uclk = 0U, intdiv = 0U, fradiv = 0U, udiv = 0U;
+    switch(usart_periph) {
+    /* get clock frequency */
     case USART0:
-         uclk=rcu_clock_freq_get(CK_APB2);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB2);
+        break;
     case USART5:
-         uclk=rcu_clock_freq_get(CK_APB2);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB2);
+        break;
     case USART1:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     case USART2:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     case UART3:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     case UART4:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     case UART6:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     case UART7:
-         uclk=rcu_clock_freq_get(CK_APB1);
-         break;
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
     default:
-         break;
+        break;
     }
-    if(USART_CTL0(usart_periph) & USART_CTL0_OVSMOD){
+    if(USART_CTL0(usart_periph) & USART_CTL0_OVSMOD) {
         /* when oversampling by 8, configure the value of USART_BAUD */
-        udiv = ((2U*uclk) + baudval/2U)/baudval;
+        udiv = ((2U * uclk) + baudval / 2U) / baudval;
         intdiv = udiv & 0xfff0U;
-        fradiv = (udiv>>1U) & 0x7U;
+        fradiv = (udiv >> 1U) & 0x7U;
         USART_BAUD(usart_periph) = ((USART_BAUD_FRADIV | USART_BAUD_INTDIV) & (intdiv | fradiv));
-    }else{
+    } else {
         /* when oversampling by 16, configure the value of USART_BAUD */
-        udiv = (uclk+baudval/2U)/baudval;
+        udiv = (uclk + baudval / 2U) / baudval;
         intdiv = udiv & 0xfff0U;
         fradiv = udiv & 0xfU;
         USART_BAUD(usart_periph) = ((USART_BAUD_FRADIV | USART_BAUD_INTDIV) & (intdiv | fradiv));
-    }   
+    }
 }
 
 /*!
@@ -148,7 +148,7 @@ void usart_baudrate_set(uint32_t usart_periph, uint32_t baudval)
     \param[in] paritycfg: configure USART parity
                only one parameter can be selected which is shown as below:
       \arg       USART_PM_NONE: no parity
-      \arg       USART_PM_EVEN: even parity 
+      \arg       USART_PM_EVEN: even parity
       \arg       USART_PM_ODD:  odd parity
     \param[out] none
     \retval     none
@@ -157,7 +157,7 @@ void usart_parity_config(uint32_t usart_periph, uint32_t paritycfg)
 {
     /* clear USART_CTL0 PM,PCEN Bits */
     USART_CTL0(usart_periph) &= ~(USART_CTL0_PM | USART_CTL0_PCEN);
-     /* configure USART parity mode */
+    /* configure USART parity mode */
     USART_CTL0(usart_periph) |= paritycfg ;
 }
 
@@ -194,7 +194,7 @@ void usart_word_length_set(uint32_t usart_periph, uint32_t wlen)
 void usart_stop_bit_set(uint32_t usart_periph, uint32_t stblen)
 {
     /* clear USART_CTL1 STB bits */
-    USART_CTL1(usart_periph) &= ~USART_CTL1_STB; 
+    USART_CTL1(usart_periph) &= ~USART_CTL1_STB;
     /* configure USART stop bits */
     USART_CTL1(usart_periph) |= stblen;
 }
@@ -233,7 +233,7 @@ void usart_disable(uint32_t usart_periph)
 void usart_transmit_config(uint32_t usart_periph, uint32_t txconfig)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL0(usart_periph);
     ctl &= ~USART_CTL0_TEN;
     ctl |= txconfig;
@@ -254,7 +254,7 @@ void usart_transmit_config(uint32_t usart_periph, uint32_t txconfig)
 void usart_receive_config(uint32_t usart_periph, uint32_t rxconfig)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL0(usart_periph);
     ctl &= ~USART_CTL0_REN;
     ctl |= rxconfig;
@@ -275,12 +275,12 @@ void usart_receive_config(uint32_t usart_periph, uint32_t rxconfig)
 void usart_data_first_config(uint32_t usart_periph, uint32_t msbf)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL3(usart_periph);
-    ctl &= ~(USART_CTL3_MSBF); 
+    ctl &= ~(USART_CTL3_MSBF);
     ctl |= msbf;
     /* configure data transmitted/received mode */
-    USART_CTL3(usart_periph) = ctl; 
+    USART_CTL3(usart_periph) = ctl;
 }
 
 /*!
@@ -299,8 +299,8 @@ void usart_data_first_config(uint32_t usart_periph, uint32_t msbf)
 */
 void usart_invert_config(uint32_t usart_periph, usart_invert_enum invertpara)
 {
-    /* inverted or not the specified siginal */ 
-    switch(invertpara){
+    /* inverted or not the specified siginal */
+    switch(invertpara) {
     case USART_DINV_ENABLE:
         USART_CTL3(usart_periph) |= USART_CTL3_DINV;
         break;
@@ -325,7 +325,7 @@ void usart_invert_config(uint32_t usart_periph, usart_invert_enum invertpara)
 }
 
 /*!
-    \brief    configure the USART oversample mode 
+    \brief    configure the USART oversample mode
     \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
     \param[in]  oversamp: oversample value
                 only one parameter can be selected which is shown as below:
@@ -353,7 +353,7 @@ void usart_oversample_config(uint32_t usart_periph, uint32_t oversamp)
 */
 void usart_sample_bit_config(uint32_t usart_periph, uint32_t obsm)
 {
-    USART_CTL2(usart_periph) &= ~(USART_CTL2_OSB); 
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_OSB);
     USART_CTL2(usart_periph) |= obsm;
 }
 
@@ -395,7 +395,7 @@ void usart_receiver_timeout_threshold_config(uint32_t usart_periph, uint32_t rti
 /*!
     \brief    USART transmit data function
     \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
-    \param[in]  data: data of transmission 
+    \param[in]  data: data of transmission
     \param[out] none
     \retval     none
 */
@@ -473,7 +473,7 @@ void usart_mute_mode_wakeup_config(uint32_t usart_periph, uint32_t wmehtod)
     \retval     none
 */
 void usart_lin_mode_enable(uint32_t usart_periph)
-{   
+{
     USART_CTL1(usart_periph) |= USART_CTL1_LMEN;
 }
 
@@ -484,7 +484,7 @@ void usart_lin_mode_enable(uint32_t usart_periph)
     \retval     none
 */
 void usart_lin_mode_disable(uint32_t usart_periph)
-{   
+{
     USART_CTL1(usart_periph) &= ~(USART_CTL1_LMEN);
 }
 
@@ -522,7 +522,7 @@ void usart_send_break(uint32_t usart_periph)
     \retval     none
 */
 void usart_halfduplex_enable(uint32_t usart_periph)
-{   
+{
     USART_CTL2(usart_periph) |= USART_CTL2_HDEN;
 }
 
@@ -533,7 +533,7 @@ void usart_halfduplex_enable(uint32_t usart_periph)
     \retval     none
 */
 void usart_halfduplex_disable(uint32_t usart_periph)
-{  
+{
     USART_CTL2(usart_periph) &= ~(USART_CTL2_HDEN);
 }
 
@@ -564,15 +564,15 @@ void usart_synchronous_clock_disable(uint32_t usart_periph)
     \param[in]  usart_periph: USARTx(x=0,1,2,5)
     \param[in]  clen: CK length
                 only one parameter can be selected which is shown as below:
-      \arg        USART_CLEN_NONE: there are 7 CK pulses for an 8 bit frame and 8 CK pulses for a 9 bit frame 
+      \arg        USART_CLEN_NONE: there are 7 CK pulses for an 8 bit frame and 8 CK pulses for a 9 bit frame
       \arg        USART_CLEN_EN:   there are 8 CK pulses for an 8 bit frame and 9 CK pulses for a 9 bit frame
     \param[in]  cph: clock phase
                 only one parameter can be selected which is shown as below:
-      \arg        USART_CPH_1CK: first clock transition is the first data capture edge 
+      \arg        USART_CPH_1CK: first clock transition is the first data capture edge
       \arg        USART_CPH_2CK: second clock transition is the first data capture edge
     \param[in]  cpl: clock polarity
                 only one parameter can be selected which is shown as below:
-      \arg        USART_CPL_LOW:  steady low value on CK pin 
+      \arg        USART_CPL_LOW:  steady low value on CK pin
       \arg        USART_CPL_HIGH: steady high value on CK pin
     \param[out] none
     \retval     none
@@ -580,7 +580,7 @@ void usart_synchronous_clock_disable(uint32_t usart_periph)
 void usart_synchronous_clock_config(uint32_t usart_periph, uint32_t clen, uint32_t cph, uint32_t cpl)
 {
     uint32_t ctl = 0U;
-    
+
     /* read USART_CTL1 register */
     ctl = USART_CTL1(usart_periph);
     ctl &= ~(USART_CTL1_CLEN | USART_CTL1_CPH | USART_CTL1_CPL);
@@ -597,10 +597,10 @@ void usart_synchronous_clock_config(uint32_t usart_periph, uint32_t clen, uint32
     \param[out] none
     \retval     none
 */
-void usart_guard_time_config(uint32_t usart_periph,uint32_t guat)
+void usart_guard_time_config(uint32_t usart_periph, uint32_t guat)
 {
     USART_GP(usart_periph) &= ~(USART_GP_GUAT);
-    USART_GP(usart_periph) |= (USART_GP_GUAT & ((guat)<<GP_GUAT_OFFSET));
+    USART_GP(usart_periph) |= (USART_GP_GUAT & ((guat) << GP_GUAT_OFFSET));
 }
 
 /*!
@@ -657,7 +657,7 @@ void usart_smartcard_mode_nack_disable(uint32_t usart_periph)
 void usart_smartcard_autoretry_config(uint32_t usart_periph, uint32_t scrtnum)
 {
     USART_CTL3(usart_periph) &= ~(USART_CTL3_SCRTNUM);
-    USART_CTL3(usart_periph) |= (USART_CTL3_SCRTNUM & ((scrtnum)<<CTL3_SCRTNUM_OFFSET));
+    USART_CTL3(usart_periph) |= (USART_CTL3_SCRTNUM & ((scrtnum) << CTL3_SCRTNUM_OFFSET));
 }
 
 /*!
@@ -670,7 +670,7 @@ void usart_smartcard_autoretry_config(uint32_t usart_periph, uint32_t scrtnum)
 void usart_block_length_config(uint32_t usart_periph, uint32_t bl)
 {
     USART_RT(usart_periph) &= ~(USART_RT_BL);
-    USART_RT(usart_periph) |= (USART_RT_BL & ((bl)<<RT_BL_OFFSET));
+    USART_RT(usart_periph) |= (USART_RT_BL & ((bl) << RT_BL_OFFSET));
 }
 
 /*!
@@ -737,7 +737,7 @@ void usart_irda_lowpower_config(uint32_t usart_periph, uint32_t irlp)
 void usart_hardware_flow_rts_config(uint32_t usart_periph, uint32_t rtsconfig)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL2(usart_periph);
     ctl &= ~USART_CTL2_RTSEN;
     ctl |= rtsconfig;
@@ -758,7 +758,7 @@ void usart_hardware_flow_rts_config(uint32_t usart_periph, uint32_t rtsconfig)
 void usart_hardware_flow_cts_config(uint32_t usart_periph, uint32_t ctsconfig)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL2(usart_periph);
     ctl &= ~USART_CTL2_CTSEN;
     ctl |= ctsconfig;
@@ -827,7 +827,7 @@ void usart_hardware_flow_coherence_config(uint32_t usart_periph, uint32_t hcm)
 void usart_dma_receive_config(uint32_t usart_periph, uint32_t dmacmd)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL2(usart_periph);
     ctl &= ~USART_CTL2_DENR;
     ctl |= dmacmd;
@@ -848,7 +848,7 @@ void usart_dma_receive_config(uint32_t usart_periph, uint32_t dmacmd)
 void usart_dma_transmit_config(uint32_t usart_periph, uint32_t dmacmd)
 {
     uint32_t ctl = 0U;
-    
+
     ctl = USART_CTL2(usart_periph);
     ctl &= ~USART_CTL2_DENT;
     ctl |= dmacmd;
@@ -862,27 +862,27 @@ void usart_dma_transmit_config(uint32_t usart_periph, uint32_t dmacmd)
     \param[in]  flag: USART flags, refer to usart_flag_enum
                 only one parameter can be selected which is shown as below:
       \arg        USART_FLAG_CTS: CTS change flag
-      \arg        USART_FLAG_LBD: LIN break detected flag 
-      \arg        USART_FLAG_TBE: transmit data buffer empty 
-      \arg        USART_FLAG_TC: transmission complete 
-      \arg        USART_FLAG_RBNE: read data buffer not empty 
-      \arg        USART_FLAG_IDLE: IDLE frame detected flag 
-      \arg        USART_FLAG_ORERR: overrun error 
-      \arg        USART_FLAG_NERR: noise error flag 
-      \arg        USART_FLAG_FERR: frame error flag 
-      \arg        USART_FLAG_PERR: parity error flag 
-      \arg        USART_FLAG_BSY: busy flag 
-      \arg        USART_FLAG_EB: end of block flag 
-      \arg        USART_FLAG_RT: receiver timeout flag 
+      \arg        USART_FLAG_LBD: LIN break detected flag
+      \arg        USART_FLAG_TBE: transmit data buffer empty
+      \arg        USART_FLAG_TC: transmission complete
+      \arg        USART_FLAG_RBNE: read data buffer not empty
+      \arg        USART_FLAG_IDLE: IDLE frame detected flag
+      \arg        USART_FLAG_ORERR: overrun error
+      \arg        USART_FLAG_NERR: noise error flag
+      \arg        USART_FLAG_FERR: frame error flag
+      \arg        USART_FLAG_PERR: parity error flag
+      \arg        USART_FLAG_BSY: busy flag
+      \arg        USART_FLAG_EB: end of block flag
+      \arg        USART_FLAG_RT: receiver timeout flag
       \arg        USART_FLAG_EPERR: early parity error flag
     \param[out] none
     \retval     FlagStatus: SET or RESET
 */
 FlagStatus usart_flag_get(uint32_t usart_periph, usart_flag_enum flag)
 {
-    if(RESET != (USART_REG_VAL(usart_periph, flag) & BIT(USART_BIT_POS(flag)))){
+    if(RESET != (USART_REG_VAL(usart_periph, flag) & BIT(USART_BIT_POS(flag)))) {
         return SET;
-    }else{
+    } else {
         return RESET;
     }
 }
@@ -982,10 +982,10 @@ FlagStatus usart_interrupt_flag_get(uint32_t usart_periph, usart_interrupt_flag_
     /* get the corresponding flag bit status */
     flagstatus = (USART_REG_VAL2(usart_periph, int_flag) & BIT(USART_BIT_POS2(int_flag)));
 
-    if((0U != flagstatus) && (0U != intenable)){
+    if((0U != flagstatus) && (0U != intenable)) {
         return SET;
-    }else{
-        return RESET; 
+    } else {
+        return RESET;
     }
 }
 

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_wwdgt.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_wwdgt.c
@@ -1,14 +1,15 @@
 /*!
     \file    gd32f4xx_wwdgt.c
     \brief   WWDGT driver
-    
+
     \version 2016-08-15, V1.0.0, firmware for GD32F4xx
     \version 2018-12-12, V2.0.0, firmware for GD32F4xx
     \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -111,17 +112,6 @@ void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler)
 }
 
 /*!
-    \brief    enable early wakeup interrupt of WWDGT
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void wwdgt_interrupt_enable(void)
-{
-    WWDGT_CFG |= WWDGT_CFG_EWIE;
-}
-
-/*!
     \brief    check early wakeup interrupt state of WWDGT
     \param[in]  none
     \param[out] none
@@ -145,4 +135,15 @@ FlagStatus wwdgt_flag_get(void)
 void wwdgt_flag_clear(void)
 {
     WWDGT_STAT &= (~WWDGT_STAT_EWIF);
+}
+
+/*!
+    \brief    enable early wakeup interrupt of WWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_interrupt_enable(void)
+{
+    WWDGT_CFG |= WWDGT_CFG_EWIE;
 }


### PR DESCRIPTION
As mentioned by @nandojve https://github.com/zephyrproject-rtos/hal_gigadevice/pull/23#issuecomment-1166565810 the firmware 3.0.0 adds support for the GD32F470xx series.

I imported the original library and added a minor patch already present in the previous version.  
There is a related PR in Zephyr : [zephyr/pull/47008](https://github.com/zephyrproject-rtos/zephyr/pull/47008).


**Samples tested on GD32F470I-EVAL board :**  
- sample/hellow_world  
- sample/samples/basic/blinky  