### PR TITLE
gd32e10x: update hal to v1.3.0

### DIFF
--- a/gd32e10x/cmsis/gd/gd32e10x/include/gd32e10x.h
+++ b/gd32e10x/cmsis/gd/gd32e10x/include/gd32e10x.h
@@ -195,7 +195,10 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 #define REG32(addr)                  (*(volatile uint32_t *)(uint32_t)(addr))
 #define REG16(addr)                  (*(volatile uint16_t *)(uint32_t)(addr))
 #define REG8(addr)                   (*(volatile uint8_t *)(uint32_t)(addr))
+#ifndef BIT
 #define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
+#endif /* BIT */
+
 #define BITS(start, end)             ((0xFFFFFFFFUL << (start)) & (0xFFFFFFFFUL >> (31U - (uint32_t)(end)))) 
 #define GET_BITS(regval, start, end) (((regval) & BITS((start),(end))) >> (start))
 

--- a/gd32e10x/cmsis/gd/gd32e10x/include/gd32e10x.h
+++ b/gd32e10x/cmsis/gd/gd32e10x/include/gd32e10x.h
@@ -4,10 +4,12 @@
     
     \version 2017-12-26, V1.0.1, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
+    \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -60,14 +62,6 @@ OF SUCH DAMAGE.
   #error "Please select the target board type used in your application (in gd32e10x.h file)"
   #endif
 #endif /* high speed crystal oscillator value */
-
-#if HXTAL_VALUE == 8000000
-  #define HXTAL_VALUE_8M  HXTAL_VALUE
-#elif HXTAL_VALUE == 25000000
-  #define HXTAL_VALUE_25M  HXTAL_VALUE
-#else
-  #error "GD32E10X lib only support 8M and 25M oscillator (HXTAL)"
-#endif
  
 /* define startup timeout value of high speed crystal oscillator (HXTAL) */
 #if !defined  (HXTAL_STARTUP_TIMEOUT)
@@ -201,9 +195,7 @@ typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
 #define REG32(addr)                  (*(volatile uint32_t *)(uint32_t)(addr))
 #define REG16(addr)                  (*(volatile uint16_t *)(uint32_t)(addr))
 #define REG8(addr)                   (*(volatile uint8_t *)(uint32_t)(addr))
-#ifndef BIT
 #define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
-#endif
 #define BITS(start, end)             ((0xFFFFFFFFUL << (start)) & (0xFFFFFFFFUL >> (31U - (uint32_t)(end)))) 
 #define GET_BITS(regval, start, end) (((regval) & BITS((start),(end))) >> (start))
 

--- a/gd32e10x/cmsis/gd/gd32e10x/source/system_gd32e10x.c
+++ b/gd32e10x/cmsis/gd/gd32e10x/source/system_gd32e10x.c
@@ -145,11 +145,6 @@ void SystemInit (void)
     /* configure the system clock source, PLL Multiplier, AHB/APBx prescalers and Flash settings */
     system_clock_config();
     
-#ifdef VECT_TAB_SRAM
-  nvic_vector_table_set(NVIC_VECTTAB_RAM,VECT_TAB_OFFSET);
-#else
-  nvic_vector_table_set(NVIC_VECTTAB_FLASH,VECT_TAB_OFFSET);
-#endif
 
 }
 

--- a/gd32e10x/standard_peripheral/include/gd32e10x_adc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_adc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_bkp.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_bkp.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -179,7 +180,7 @@ typedef enum
 #define RTC_CLOCK_DIV_1               ((uint16_t)BKP_OCTL_CCOSEL)     /*!< RTC clock div 1 */
 
 /* RTC clock calibration direction */
-#define RTC_CLOCK_SLOWED_DOWN         ((uint16_t)0x0000U)             /*!< RTC clock slow down */
+#define RTC_CLOCK_SLOW_DOWN           ((uint16_t)0x0000U)             /*!< RTC clock slow down */
 #define RTC_CLOCK_SPEED_UP            ((uint16_t)BKP_OCTL_CALDIR)     /*!< RTC clock speed up */
 
 /* tamper pin active level */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_crc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_crc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_ctc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_ctc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -96,7 +97,6 @@ OF SUCH DAMAGE.
 #define CTL1_REFSEL(regval)                              (BITS(28,29) & ((uint32_t)(regval) << 28))
 #define CTC_REFSOURCE_GPIO                               CTL1_REFSEL(0)               /*!< GPIO is selected */
 #define CTC_REFSOURCE_LXTAL                              CTL1_REFSEL(1)               /*!< LXTAL is selected */
-#define CTC_REFSOURCE_USBSOF                             CTL1_REFSEL(2)               /*!< USBFS_SOF is selected */
 
 /* reference signal source prescaler definitions */
 #define CTL1_REFPSC(regval)                              (BITS(24,26) & ((uint32_t)(regval) << 24))

--- a/gd32e10x/standard_peripheral/include/gd32e10x_dac.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_dac.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_dbg.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_dbg.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -55,7 +56,6 @@ OF SUCH DAMAGE.
 #define DBG_CTL_DSLP_HOLD        BIT(1)                     /*!< keep debugger connection during deepsleep mode */
 #define DBG_CTL_STB_HOLD         BIT(2)                     /*!< keep debugger connection during standby mode */
 #define DBG_CTL_TRACE_IOEN       BIT(5)                     /*!< enable trace pin assignment */
-#define DBG_CTL_TRACE_MODE       BITS(6,7)                  /*!< trace pin mode selection */
 #define DBG_CTL_FWDGT_HOLD       BIT(8)                     /*!< debug FWDGT kept when core is halted */
 #define DBG_CTL_WWDGT_HOLD       BIT(9)                     /*!< debug WWDGT kept when core is halted */
 #define DBG_CTL_TIMER0_HOLD      BIT(10)                    /*!< hold TIMER0 counter when core is halted */
@@ -103,13 +103,6 @@ typedef enum
     DBG_TIMER10_HOLD           = BIT(30),                   /*!< hold TIMER10 counter when core is halted */
 }dbg_periph_enum;
 
-/* DBG_CTL0_TRACE_MODE configurations */
-#define CTL_TRACE_MODE(regval)       (BITS(6,7) & ((uint32_t)(regval) << 6U))
-#define TRACE_MODE_ASYNC              CTL_TRACE_MODE(0)     /*!< trace pin used for async mode */
-#define TRACE_MODE_SYNC_DATASIZE_1    CTL_TRACE_MODE(1)     /*!< trace pin used for sync mode and data size is 1 */
-#define TRACE_MODE_SYNC_DATASIZE_2    CTL_TRACE_MODE(2)     /*!< trace pin used for sync mode and data size is 2 */
-#define TRACE_MODE_SYNC_DATASIZE_4    CTL_TRACE_MODE(3)     /*!< trace pin used for sync mode and data size is 4 */
-
 /* function declarations */
 /* read DBG_ID code register */
 uint32_t dbg_id_get(void);
@@ -128,7 +121,5 @@ void dbg_periph_disable(dbg_periph_enum dbg_periph);
 void dbg_trace_pin_enable(void);
 /* disable trace pin assignment */
 void dbg_trace_pin_disable(void);
-/* set trace pin mode */
-void dbg_trace_pin_mode_set(uint32_t trace_mode);
 
 #endif /* GD32E10X_DBG_H */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_dma.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_dma.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_exmc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_exmc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -163,21 +164,21 @@ typedef struct
 /* synchronous clock divide ratio */
 #define SNTCFG_CKDIV(regval)              (BITS(20,23) & ((uint32_t)(regval) << 20))
 #define EXMC_SYN_CLOCK_RATIO_DISABLE      SNTCFG_CKDIV(0)               /*!< EXMC_CLK disable */
-#define EXMC_SYN_CLOCK_RATIO_2_CLK        SNTCFG_CKDIV(1)               /*!< EXMC_CLK = 2*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_3_CLK        SNTCFG_CKDIV(2)               /*!< EXMC_CLK = 3*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_4_CLK        SNTCFG_CKDIV(3)               /*!< EXMC_CLK = 4*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_5_CLK        SNTCFG_CKDIV(4)               /*!< EXMC_CLK = 5*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_6_CLK        SNTCFG_CKDIV(5)               /*!< EXMC_CLK = 6*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_7_CLK        SNTCFG_CKDIV(6)               /*!< EXMC_CLK = 7*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_8_CLK        SNTCFG_CKDIV(7)               /*!< EXMC_CLK = 8*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_9_CLK        SNTCFG_CKDIV(8)               /*!< EXMC_CLK = 9*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_10_CLK       SNTCFG_CKDIV(9)               /*!< EXMC_CLK = 10*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_11_CLK       SNTCFG_CKDIV(10)              /*!< EXMC_CLK = 11*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_12_CLK       SNTCFG_CKDIV(11)              /*!< EXMC_CLK = 12*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_13_CLK       SNTCFG_CKDIV(12)              /*!< EXMC_CLK = 13*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_14_CLK       SNTCFG_CKDIV(13)              /*!< EXMC_CLK = 14*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_15_CLK       SNTCFG_CKDIV(14)              /*!< EXMC_CLK = 15*HCLK */
-#define EXMC_SYN_CLOCK_RATIO_16_CLK       SNTCFG_CKDIV(15)              /*!< EXMC_CLK = 16*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_2_CLK        SNTCFG_CKDIV(1)               /*!< frequency EXMC_CLK = HCLK/2 */
+#define EXMC_SYN_CLOCK_RATIO_3_CLK        SNTCFG_CKDIV(2)               /*!< frequency EXMC_CLK = HCLK/3 */
+#define EXMC_SYN_CLOCK_RATIO_4_CLK        SNTCFG_CKDIV(3)               /*!< frequency EXMC_CLK = HCLK/4 */
+#define EXMC_SYN_CLOCK_RATIO_5_CLK        SNTCFG_CKDIV(4)               /*!< frequency EXMC_CLK = HCLK/5 */
+#define EXMC_SYN_CLOCK_RATIO_6_CLK        SNTCFG_CKDIV(5)               /*!< frequency EXMC_CLK = HCLK/6 */
+#define EXMC_SYN_CLOCK_RATIO_7_CLK        SNTCFG_CKDIV(6)               /*!< frequency EXMC_CLK = HCLK/7 */
+#define EXMC_SYN_CLOCK_RATIO_8_CLK        SNTCFG_CKDIV(7)               /*!< frequency EXMC_CLK = HCLK/8 */
+#define EXMC_SYN_CLOCK_RATIO_9_CLK        SNTCFG_CKDIV(8)               /*!< frequency EXMC_CLK = HCLK/9 */
+#define EXMC_SYN_CLOCK_RATIO_10_CLK       SNTCFG_CKDIV(9)               /*!< frequency EXMC_CLK = HCLK/10 */
+#define EXMC_SYN_CLOCK_RATIO_11_CLK       SNTCFG_CKDIV(10)              /*!< frequency EXMC_CLK = HCLK/11 */
+#define EXMC_SYN_CLOCK_RATIO_12_CLK       SNTCFG_CKDIV(11)              /*!< frequency EXMC_CLK = HCLK/12 */
+#define EXMC_SYN_CLOCK_RATIO_13_CLK       SNTCFG_CKDIV(12)              /*!< frequency EXMC_CLK = HCLK/13 */
+#define EXMC_SYN_CLOCK_RATIO_14_CLK       SNTCFG_CKDIV(13)              /*!< frequency EXMC_CLK = HCLK/14 */
+#define EXMC_SYN_CLOCK_RATIO_15_CLK       SNTCFG_CKDIV(14)              /*!< frequency EXMC_CLK = HCLK/15 */
+#define EXMC_SYN_CLOCK_RATIO_16_CLK       SNTCFG_CKDIV(15)              /*!< frequency EXMC_CLK = HCLK/16 */
 
 /* EXMC NOR/SRAM write mode */
 #define EXMC_ASYN_WRITE                   ((uint32_t)0x00000000U)       /*!< asynchronous write mode */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_exti.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_exti.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_fmc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_fmc.h
@@ -6,10 +6,11 @@
     \version 2020-05-11, V1.0.1, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_fwdgt.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_fwdgt.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32e10x_fwdgt.h
     \brief   definitions for the FWDGT
-    
+
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -40,7 +41,7 @@ OF SUCH DAMAGE.
 #include "gd32e10x.h"
 
 /* FWDGT definitions */
-#define FWDGT                       FWDGT_BASE
+#define FWDGT                       FWDGT_BASE                                /*!< FWDGT base address */
 
 /* registers definitions */
 #define FWDGT_CTL                   REG32((FWDGT) + 0x00U)                    /*!< FWDGT control register */
@@ -87,6 +88,9 @@ OF SUCH DAMAGE.
 #define FWDGT_FLAG_PUD              FWDGT_STAT_PUD                            /*!< FWDGT prescaler divider value update flag */
 #define FWDGT_FLAG_RUD              FWDGT_STAT_RUD                            /*!< FWDGT counter reload value update flag */
 
+/* write value to FWDGT_RLD_RLD bit field */
+#define RLD_RLD(regval)             (BITS(0,11) & ((uint32_t)(regval) << 0))
+
 /* function declarations */
 /* enable write access to FWDGT_PSC and FWDGT_RLD */
 void fwdgt_write_enable(void);
@@ -95,6 +99,10 @@ void fwdgt_write_disable(void);
 /* start the free watchdog timer counter */
 void fwdgt_enable(void);
 
+/* configure the free watchdog timer counter prescaler value */
+ErrStatus fwdgt_prescaler_value_config(uint16_t prescaler_value);
+/* configure the free watchdog timer counter reload value */
+ErrStatus fwdgt_reload_value_config(uint16_t reload_value);
 /* reload the counter of FWDGT */
 void fwdgt_counter_reload(void);
 /* configure counter reload value, and prescaler divider value */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_gpio.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_gpio.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -250,13 +251,11 @@ OF SUCH DAMAGE.
 #define AFIO_PCF0_TIMER3_REMAP           BIT(12)             /*!< TIMER3 remapping */
 #define AFIO_PCF0_PD01_REMAP             BIT(15)             /*!< port D0/port D1 mapping on OSC_IN/OSC_OUT */
 #define AFIO_PCF0_TIMER4CH3_IREMAP       BIT(16)             /*!< TIMER4 channel3 internal remapping */
-#define AFIO_PCF0_ADC0_ETRGINS_REMAP     BIT(17)             /*!< ADC 0 external trigger inserted conversion remapping */
-#define AFIO_PCF0_ADC0_ETRGREG_REMAP     BIT(18)             /*!< ADC 0 external trigger regular conversion remapping */
-#define AFIO_PCF0_ADC1_ETRGINS_REMAP     BIT(19)             /*!< ADC 1 external trigger inserted conversion remapping */
-#define AFIO_PCF0_ADC1_ETRGREG_REMAP     BIT(20)             /*!< ADC 1 external trigger regular conversion remapping */
+#define AFIO_PCF0_ADC0_ETRGRT_REMAP     BIT(18)             /*!< ADC 0 external trigger routine conversion remapping */
+#define AFIO_PCF0_ADC1_ETRGRT_REMAP     BIT(20)             /*!< ADC 1 external trigger routine conversion remapping */
 #define AFIO_PCF0_SWJ_CFG                BITS(24,26)         /*!< serial wire JTAG configuration */
 #define AFIO_PCF0_SPI2_REMAP             BIT(28)             /*!< SPI2/I2S2 remapping */
-#define AFIO_PCF0_TIMER1ITR0_REMAP       BIT(29)             /*!< TIMER1 internal trigger 0 remapping */
+#define AFIO_PCF0_TIMER1ITI1_REMAP       BIT(29)             /*!< TIMER1 internal trigger 1 remapping */
 
 /* AFIO_EXTISS0 */
 #define AFIO_EXTI0_SS                    BITS(0,3)           /*!< EXTI 0 sources selection */
@@ -408,15 +407,13 @@ typedef FlagStatus bit_status;
 #define GPIO_TIMER3_REMAP                AFIO_PCF0_TIMER3_REMAP                                           /*!< TIMER3 remapping */
 #define GPIO_PD01_REMAP                  AFIO_PCF0_PD01_REMAP                                             /*!< PD01 remapping */
 #define GPIO_TIMER4CH3_IREMAP            ((uint32_t)0x00200000U | (AFIO_PCF0_TIMER4CH3_IREMAP >> 16))      /*!< TIMER4 channel3 internal remapping */
-#define GPIO_ADC0_ETRGINS_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC0_ETRGINS_REMAP >> 16))    /*!< ADC 0 external trigger inserted conversion remapping */
-#define GPIO_ADC0_ETRGREG_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC0_ETRGREG_REMAP >> 16))    /*!< ADC 0 external trigger regular conversion remapping */
-#define GPIO_ADC1_ETRGINS_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC1_ETRGINS_REMAP >> 16))    /*!< ADC 1 external trigger inserted conversion remapping */
-#define GPIO_ADC1_ETRGREG_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC1_ETRGREG_REMAP >> 16))    /*!< ADC 1 external trigger regular conversion remapping */
+#define GPIO_ADC0_ETRGRT_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC0_ETRGRT_REMAP >> 16))    /*!< ADC 0 external trigger routine conversion remapping */
+#define GPIO_ADC1_ETRGRT_REMAP          ((uint32_t)0x00200000U | (AFIO_PCF0_ADC1_ETRGRT_REMAP >> 16))    /*!< ADC 1 external trigger routine conversion remapping */
 #define GPIO_SWJ_NONJTRST_REMAP          ((uint32_t)0x00300000U | (PCF0_SWJ_CFG(1) >> 16))                 /*!< full SWJ(JTAG-DP + SW-DP),but without NJTRST */
 #define GPIO_SWJ_SWDPENABLE_REMAP        ((uint32_t)0x00300000U | (PCF0_SWJ_CFG(2) >> 16))                 /*!< JTAG-DP disabled and SW-DP enabled */
 #define GPIO_SWJ_DISABLE_REMAP           ((uint32_t)0x00300000U | (PCF0_SWJ_CFG(4) >> 16))                 /*!< JTAG-DP disabled and SW-DP disabled */
 #define GPIO_SPI2_REMAP                  ((uint32_t)0x00200000U | (AFIO_PCF0_SPI2_REMAP >> 16))            /*!< SPI2 remapping */
-#define GPIO_TIMER1ITR0_REMAP            ((uint32_t)0x00200000U | (AFIO_PCF0_TIMER1ITR0_REMAP >> 16))      /*!< TIMER1 internal trigger 0 remapping */
+#define GPIO_TIMER1ITI1_REMAP            ((uint32_t)0x00200000U | (AFIO_PCF0_TIMER1ITI1_REMAP >> 16))      /*!< TIMER1 internal trigger 1 remapping */
 #define GPIO_TIMER8_REMAP                ((uint32_t)0x80000000U | AFIO_PCF1_TIMER8_REMAP)                  /*!< TIMER8 remapping */
 #define GPIO_EXMC_NADV_REMAP             ((uint32_t)0x80000000U | AFIO_PCF1_EXMC_NADV)                     /*!< EXMC_NADV connect/disconnect */
 #define GPIO_CTC_REMAP0                  ((uint32_t)0x801B0000U | PCF1_CTC_REMAP(1))                       /*!< CTC remapping(PD15)*/

--- a/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
@@ -1,15 +1,16 @@
 /*!
     \file    gd32e10x_i2c.h
     \brief   definitions for the I2C
-    
+
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2019-04-16, V1.0.1, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -41,21 +42,21 @@ OF SUCH DAMAGE.
 #include "gd32e10x.h"
 
 /* I2Cx(x=0,1) definitions */
-#define I2C0                          I2C_BASE                   /*!< I2C0 base address */
-#define I2C1                          (I2C_BASE + 0x00000400U)   /*!< I2C1 base address */
+#define I2C0                          I2C_BASE                         /*!< I2C0 base address */
+#define I2C1                          (I2C_BASE + 0x00000400U)         /*!< I2C1 base address */
 
 /* registers definitions */
-#define I2C_CTL0(i2cx)                REG32((i2cx) + 0x00U)      /*!< I2C control register 0 */
-#define I2C_CTL1(i2cx)                REG32((i2cx) + 0x04U)      /*!< I2C control register 1 */
-#define I2C_SADDR0(i2cx)              REG32((i2cx) + 0x08U)      /*!< I2C slave address register 0*/
-#define I2C_SADDR1(i2cx)              REG32((i2cx) + 0x0CU)      /*!< I2C slave address register */
-#define I2C_DATA(i2cx)                REG32((i2cx) + 0x10U)      /*!< I2C transfer buffer register */
-#define I2C_STAT0(i2cx)               REG32((i2cx) + 0x14U)      /*!< I2C transfer status register 0 */
-#define I2C_STAT1(i2cx)               REG32((i2cx) + 0x18U)      /*!< I2C transfer status register */
-#define I2C_CKCFG(i2cx)               REG32((i2cx) + 0x1CU)      /*!< I2C clock configure register */
-#define I2C_RT(i2cx)                  REG32((i2cx) + 0x20U)      /*!< I2C rise time register */
-#define I2C_SAMCS(i2cx)               REG32((i2cx) + 0x80U)      /*!< I2C SAM control and status register */
-#define I2C_FMPCFG(i2cx)              REG32((i2cx) + 0x90U)      /*!< I2C fast-mode-plus configure register */
+#define I2C_CTL0(i2cx)                REG32((i2cx) + 0x00000000U)      /*!< I2C control register 0 */
+#define I2C_CTL1(i2cx)                REG32((i2cx) + 0x00000004U)      /*!< I2C control register 1 */
+#define I2C_SADDR0(i2cx)              REG32((i2cx) + 0x00000008U)      /*!< I2C slave address register 0*/
+#define I2C_SADDR1(i2cx)              REG32((i2cx) + 0x0000000CU)      /*!< I2C slave address register 1 */
+#define I2C_DATA(i2cx)                REG32((i2cx) + 0x00000010U)      /*!< I2C transfer buffer register */
+#define I2C_STAT0(i2cx)               REG32((i2cx) + 0x00000014U)      /*!< I2C transfer status register 0 */
+#define I2C_STAT1(i2cx)               REG32((i2cx) + 0x00000018U)      /*!< I2C transfer status register */
+#define I2C_CKCFG(i2cx)               REG32((i2cx) + 0x0000001CU)      /*!< I2C clock configure register */
+#define I2C_RT(i2cx)                  REG32((i2cx) + 0x00000020U)      /*!< I2C rise time register */
+#define I2C_SAMCS(i2cx)               REG32((i2cx) + 0x00000080U)      /*!< I2C SAM control and status register */
+#define I2C_FMPCFG(i2cx)              REG32((i2cx) + 0x00000090U)      /*!< I2C fast-mode-plus configure register */
 
 /* bits definitions */
 /* I2Cx_CTL0 */
@@ -138,33 +139,32 @@ OF SUCH DAMAGE.
 #define I2C_SAMCS_RFRIE               BIT(7)        /*!< rxframe rise interrupt enable */
 #define I2C_SAMCS_TXF                 BIT(8)        /*!< level of txframe signal */
 #define I2C_SAMCS_RXF                 BIT(9)        /*!< level of rxframe signal */
-#define I2C_SAMCS_TFF                 BIT(12)       /*!< txframe fall flag */
-#define I2C_SAMCS_TFR                 BIT(13)       /*!< txframe rise flag */
-#define I2C_SAMCS_RFF                 BIT(14)       /*!< rxframe fall flag */
-#define I2C_SAMCS_RFR                 BIT(15)       /*!< rxframe rise flag */
+#define I2C_SAMCS_TFF                 BIT(12)       /*!< txframe fall flag, cleared by software write 0 */
+#define I2C_SAMCS_TFR                 BIT(13)       /*!< txframe rise flag, cleared by software write 0 */
+#define I2C_SAMCS_RFF                 BIT(14)       /*!< rxframe fall flag, cleared by software write 0 */
+#define I2C_SAMCS_RFR                 BIT(15)       /*!< rxframe rise flag, cleared by software write 0 */
 
 /* I2Cx_FMPCFG */
-#define I2C_FMPCFG_FMPEN              BIT(0)        /*!< fast mode plus enable bit */
+#define I2C_FMPCFG_FMPEN              BIT(0)        /*!< fast mode plus enable */
 
 /* constants definitions */
 /* define the I2C bit position and its register index offset */
 #define I2C_REGIDX_BIT(regidx, bitpos)  (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
-#define I2C_REG_VAL(i2cx, offset)       (REG32((i2cx) + (((uint32_t)(offset) & 0xFFFFU) >> 6)))
-#define I2C_BIT_POS(val)                ((uint32_t)(val) & 0x1FU)
+#define I2C_REG_VAL(i2cx, offset)       (REG32((i2cx) + (((uint32_t)(offset) & 0x0000FFFFU) >> 6)))
+#define I2C_BIT_POS(val)                ((uint32_t)(val) & 0x0000001FU)
 #define I2C_REGIDX_BIT2(regidx, bitpos, regidx2, bitpos2)   (((uint32_t)(regidx2) << 22) | (uint32_t)((bitpos2) << 16)\
                                                               | (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos)))
 #define I2C_REG_VAL2(i2cx, offset)      (REG32((i2cx) + ((uint32_t)(offset) >> 22)))
-#define I2C_BIT_POS2(val)               (((uint32_t)(val) & 0x1F0000U) >> 16)
+#define I2C_BIT_POS2(val)               (((uint32_t)(val) & 0x001F0000U) >> 16)
 
 /* register offset */
-#define I2C_CTL1_REG_OFFSET           0x04U         /*!< CTL1 register offset */
-#define I2C_STAT0_REG_OFFSET          0x14U         /*!< STAT0 register offset */
-#define I2C_STAT1_REG_OFFSET          0x18U         /*!< STAT1 register offset */
-#define I2C_SAMCS_REG_OFFSET          0x80U         /*!< SAMCS register offset */
+#define I2C_CTL1_REG_OFFSET             ((uint32_t)0x00000004U)                /*!< CTL1 register offset */
+#define I2C_STAT0_REG_OFFSET            ((uint32_t)0x00000014U)                /*!< STAT0 register offset */
+#define I2C_STAT1_REG_OFFSET            ((uint32_t)0x00000018U)                /*!< STAT1 register offset */
+#define I2C_SAMCS_REG_OFFSET            ((uint32_t)0x00000080U)                /*!< SAMCS register offset */
 
 /* I2C flags */
-typedef enum
-{
+typedef enum{
     /* flags in STAT0 register */
     I2C_FLAG_SBSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 0U),                /*!< start condition sent out in master mode */
     I2C_FLAG_ADDSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 1U),               /*!< address is sent in master mode or received and matches in slave mode */
@@ -183,7 +183,7 @@ typedef enum
     /* flags in STAT1 register */
     I2C_FLAG_MASTER = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 0U),                /*!< a flag indicating whether I2C block is in master or slave mode */
     I2C_FLAG_I2CBSY = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 1U),                /*!< busy flag */
-    I2C_FLAG_TRS = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 2U),                   /*!< whether the I2C is a transmitter or a receiver */
+    I2C_FLAG_TR = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 2U),                    /*!< whether the I2C is a transmitter or a receiver */
     I2C_FLAG_RXGC = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 4U),                  /*!< general call address (00h) received */
     I2C_FLAG_DEFSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 5U),                /*!< default address of SMBus device */
     I2C_FLAG_HSTSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 6U),                /*!< SMBus host header detected in slave mode */
@@ -192,47 +192,45 @@ typedef enum
     I2C_FLAG_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 12U),                  /*!< txframe fall flag */
     I2C_FLAG_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 13U),                  /*!< txframe rise flag */
     I2C_FLAG_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 14U),                  /*!< rxframe fall flag */
-    I2C_FLAG_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 15U)                  /*!< rxframe rise flag */
-}i2c_flag_enum;
+    I2C_FLAG_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 15U)                   /*!< rxframe rise flag */
+} i2c_flag_enum;
 
 /* I2C interrupt flags */
-typedef enum
-{
+typedef enum {
     /* interrupt flags in CTL1 register */
     I2C_INT_FLAG_SBSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 0U),        /*!< start condition sent out in master mode interrupt flag */
     I2C_INT_FLAG_ADDSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 1U),       /*!< address is sent in master mode or received and matches in slave mode interrupt flag */
-    I2C_INT_FLAG_BTC =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 2U),          /*!< byte transmission finishes */
+    I2C_INT_FLAG_BTC =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 2U),          /*!< byte transmission finishes interrupt flag */
     I2C_INT_FLAG_ADD10SEND =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 3U),    /*!< header of 10-bit address is sent in master mode interrupt flag */
     I2C_INT_FLAG_STPDET = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 4U),        /*!< stop condition detected in slave mode interrupt flag */
     I2C_INT_FLAG_RBNE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 6U),          /*!< I2C_DATA is not Empty during receiving interrupt flag */
-    I2C_INT_FLAG_TBE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 7U),           /*!< I2C_DATA is empty during transmitting interrupt flag */    
+    I2C_INT_FLAG_TBE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 7U),           /*!< I2C_DATA is empty during transmitting interrupt flag */
     I2C_INT_FLAG_BERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 8U),          /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag */
     I2C_INT_FLAG_LOSTARB = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 9U),       /*!< arbitration lost in master mode interrupt flag */
     I2C_INT_FLAG_AERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 10U),         /*!< acknowledge error interrupt flag */
     I2C_INT_FLAG_OUERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 11U),        /*!< over-run or under-run situation occurs in slave mode interrupt flag */
     I2C_INT_FLAG_PECERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 12U),       /*!< PEC error when receiving data interrupt flag */
     I2C_INT_FLAG_SMBTO = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 14U),        /*!< timeout signal in SMBus mode interrupt flag */
-    I2C_INT_FLAG_SMBALT = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 15U),       /*!< SMBus Alert status interrupt flag */
+    I2C_INT_FLAG_SMBALT = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 15U),       /*!< SMBus alert status interrupt flag */
     /* interrupt flags in SAMCS register */
-    I2C_INT_FLAG_TFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 4U, I2C_SAMCS_REG_OFFSET, 12U),         /*!< txframe fall interrupt flag */ 
-    I2C_INT_FLAG_TFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 5U, I2C_SAMCS_REG_OFFSET, 13U),         /*!< txframe rise interrupt  flag */
+    I2C_INT_FLAG_TFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 4U, I2C_SAMCS_REG_OFFSET, 12U),         /*!< txframe fall interrupt flag */
+    I2C_INT_FLAG_TFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 5U, I2C_SAMCS_REG_OFFSET, 13U),         /*!< txframe rise interrupt flag */
     I2C_INT_FLAG_RFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 6U, I2C_SAMCS_REG_OFFSET, 14U),         /*!< rxframe fall interrupt flag */
-    I2C_INT_FLAG_RFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 7U, I2C_SAMCS_REG_OFFSET, 15U)         /*!< rxframe rise interrupt flag */
+    I2C_INT_FLAG_RFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 7U, I2C_SAMCS_REG_OFFSET, 15U)          /*!< rxframe rise interrupt flag */
 }i2c_interrupt_flag_enum;
 
-/* I2C interrupt enable or disable */
-typedef enum
-{
+/* I2C interrupt */
+typedef enum {
     /* interrupt in CTL1 register */
-    I2C_INT_ERR = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 8U),                     /*!< error interrupt enable */
-    I2C_INT_EV = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 9U),                      /*!< event interrupt enable */
-    I2C_INT_BUF = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 10U),                    /*!< buffer interrupt enable */
+    I2C_INT_ERR = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 8U),                     /*!< error interrupt */
+    I2C_INT_EV = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 9U),                      /*!< event interrupt */
+    I2C_INT_BUF = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 10U),                    /*!< buffer interrupt */
     /* interrupt in SAMCS register */
-    I2C_INT_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 4U),                    /*!< txframe fall interrupt enable  */
-    I2C_INT_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 5U),                    /*!< txframe rise interrupt  enable */
-    I2C_INT_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 6U),                    /*!< rxframe fall interrupt enable */
-    I2C_INT_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 7U)                     /*!< rxframe rise interrupt enable */
-}i2c_interrupt_enum;
+    I2C_INT_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 4U),                    /*!< txframe fall interrupt */
+    I2C_INT_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 5U),                    /*!< txframe rise interrupt */
+    I2C_INT_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 6U),                    /*!< rxframe fall interrupt */
+    I2C_INT_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 7U),                    /*!< rxframe rise interrupt */
+} i2c_interrupt_enum;
 
 /* SMBus/I2C mode switch and SMBus type selection */
 #define I2C_I2CMODE_ENABLE            ((uint32_t)0x00000000U)                  /*!< I2C mode */
@@ -248,15 +246,11 @@ typedef enum
 
 /* whether or not to send an ACK */
 #define I2C_ACK_DISABLE               ((uint32_t)0x00000000U)                  /*!< ACK will be not sent */
-#define I2C_ACK_ENABLE                ((uint32_t)0x00000001U)                  /*!< ACK will be sent */
+#define I2C_ACK_ENABLE                I2C_CTL0_ACKEN                           /*!< ACK will be sent */
 
 /* I2C POAP position*/
-#define I2C_ACKPOS_NEXT               ((uint32_t)0x00000000U)                  /*!< ACKEN bit decides whether or not to send ACK for the next byte */
-#define I2C_ACKPOS_CURRENT            ((uint32_t)0x00000001U)                  /*!< ACKEN bit decides whether or not to send ACK or not for the current byte */
-
-/* I2C dual-address mode switch */
-#define I2C_DUADEN_DISABLE            ((uint32_t)0x00000000U)                  /*!< dual-address mode disabled */
-#define I2C_DUADEN_ENABLE             ((uint32_t)0x00000001U)                  /*!< dual-address mode enabled */
+#define I2C_ACKPOS_CURRENT            ((uint32_t)0x00000000U)                  /*!< ACKEN bit decides whether or not to send ACK or not for the current byte */
+#define I2C_ACKPOS_NEXT               I2C_CTL0_POAP                            /*!< ACKEN bit decides whether or not to send ACK for the next byte */
 
 /* whether or not to stretch SCL low */
 #define I2C_SCLSTRETCH_ENABLE         ((uint32_t)0x00000000U)                  /*!< SCL stretching is enabled */
@@ -267,39 +261,39 @@ typedef enum
 #define I2C_GCEN_DISABLE              ((uint32_t)0x00000000U)                  /*!< slave will not response to a general call */
 
 /* software reset I2C */
-#define I2C_SRESET_SET                I2C_CTL0_SRESET                          /*!< I2C is under reset */
 #define I2C_SRESET_RESET              ((uint32_t)0x00000000U)                  /*!< I2C is not under reset */
+#define I2C_SRESET_SET                I2C_CTL0_SRESET                          /*!< I2C is under reset */
 
 /* I2C DMA mode configure */
 /* DMA mode switch */
-#define I2C_DMA_ON                    I2C_CTL1_DMAON                           /*!< DMA mode enabled */
-#define I2C_DMA_OFF                   ((uint32_t)0x00000000U)                  /*!< DMA mode disabled */
+#define I2C_DMA_OFF                   ((uint32_t)0x00000000U)                  /*!< disable DMA mode */
+#define I2C_DMA_ON                    I2C_CTL1_DMAON                           /*!< enable DMA mode */
 
 /* flag indicating DMA last transfer */
-#define I2C_DMALST_ON                 I2C_CTL1_DMALST                          /*!< next DMA EOT is the last transfer */
 #define I2C_DMALST_OFF                ((uint32_t)0x00000000U)                  /*!< next DMA EOT is not the last transfer */
+#define I2C_DMALST_ON                 I2C_CTL1_DMALST                          /*!< next DMA EOT is the last transfer */
 
 /* I2C PEC configure */
 /* PEC enable */
-#define I2C_PEC_ENABLE                I2C_CTL0_PECEN                           /*!< PEC calculation on */
 #define I2C_PEC_DISABLE               ((uint32_t)0x00000000U)                  /*!< PEC calculation off */
+#define I2C_PEC_ENABLE                I2C_CTL0_PECEN                           /*!< PEC calculation on */
 
 /* PEC transfer */
-#define I2C_PECTRANS_ENABLE           I2C_CTL0_PECTRANS                        /*!< transfer PEC */
 #define I2C_PECTRANS_DISABLE          ((uint32_t)0x00000000U)                  /*!< not transfer PEC value */
+#define I2C_PECTRANS_ENABLE           I2C_CTL0_PECTRANS                        /*!< transfer PEC value */
 
 /* I2C SMBus configure */
 /* issue or not alert through SMBA pin */
-#define I2C_SALTSEND_ENABLE           I2C_CTL0_SALT                            /*!< issue alert through SMBA pin */
 #define I2C_SALTSEND_DISABLE          ((uint32_t)0x00000000U)                  /*!< not issue alert through SMBA */
+#define I2C_SALTSEND_ENABLE           I2C_CTL0_SALT                            /*!< issue alert through SMBA pin */
 
 /* ARP protocol in SMBus switch */
-#define I2C_ARP_ENABLE                I2C_CTL0_ARPEN                           /*!< ARP is enabled */
-#define I2C_ARP_DISABLE               ((uint32_t)0x00000000U)                  /*!< ARP is disabled */
+#define I2C_ARP_DISABLE               ((uint32_t)0x00000000U)                  /*!< disable ARP */
+#define I2C_ARP_ENABLE                I2C_CTL0_ARPEN                           /*!< enable ARP */
 
 /* fast mode plus enable */
-#define I2C_FAST_MODE_PLUS_ENABLE     I2C_FMPCFG_FMPEN                         /*!< fast mode plus enable */
 #define I2C_FAST_MODE_PLUS_DISABLE    ((uint32_t)0x00000000U)                  /*!< fast mode plus disable */
+#define I2C_FAST_MODE_PLUS_ENABLE     I2C_FMPCFG_FMPEN                         /*!< fast mode plus enable */
 
 /* transmit I2C data */
 #define DATA_TRANS(regval)            (BITS(0,7) & ((uint32_t)(regval) << 0))
@@ -308,18 +302,12 @@ typedef enum
 #define DATA_RECV(regval)             GET_BITS((uint32_t)(regval), 0, 7)
 
 /* I2C duty cycle in fast mode or fast mode plus */
-#define I2C_DTCY_2                    ((uint32_t)0x00000000U)                  /*!< in I2C fast mode or fast mode plus Tlow/Thigh = 2 */
-#define I2C_DTCY_16_9                 I2C_CKCFG_DTCY                           /*!< in I2C fast mode or fast mode plus Tlow/Thigh = 16/9 */
+#define I2C_DTCY_2                    ((uint32_t)0x00000000U)                  /*!< Tlow/Thigh = 2 in I2C fast mode or fast mode plus */
+#define I2C_DTCY_16_9                 I2C_CKCFG_DTCY                           /*!< Tlow/Thigh = 16/9 in I2C fast mode or fast mode plus */
 
 /* address mode for the I2C slave */
-#define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address:7 bits */
-#define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address:10 bits */
-
-/* I2C clock frequency, MHz */
-#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)                  /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)                  /*!< i2cclk minimum value for standard mode */
-#define I2CCLK_FM_MIN                 ((uint32_t)0x00000008U)                  /*!< i2cclk minimum value for fast mode */
-#define I2CCLK_FM_PLUS_MIN            ((uint32_t)0x00000018U)                  /*!< i2cclk minimum value for fast mode plus */
+#define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address format is 7 bits */
+#define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address format is 10 bits */
 
 /* function declarations */
 /* reset I2C */
@@ -328,7 +316,7 @@ void i2c_deinit(uint32_t i2c_periph);
 void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc);
 /* configure I2C address */
 void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat, uint32_t addr);
-/* SMBus type selection */
+/* select SMBus type */
 void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type);
 /* whether or not to send an ACK */
 void i2c_ack_config(uint32_t i2c_periph, uint32_t ack);
@@ -340,11 +328,11 @@ void i2c_master_addressing(uint32_t i2c_periph, uint32_t addr, uint32_t trandire
 void i2c_dualaddr_enable(uint32_t i2c_periph, uint32_t addr);
 /* disable dual-address mode */
 void i2c_dualaddr_disable(uint32_t i2c_periph);
-
 /* enable I2C */
 void i2c_enable(uint32_t i2c_periph);
 /* disable I2C */
 void i2c_disable(uint32_t i2c_periph);
+
 /* generate a START condition on I2C bus */
 void i2c_start_on_bus(uint32_t i2c_periph);
 /* generate a STOP condition on I2C bus */
@@ -353,27 +341,27 @@ void i2c_stop_on_bus(uint32_t i2c_periph);
 void i2c_data_transmit(uint32_t i2c_periph, uint8_t data);
 /* I2C receive data function */
 uint8_t i2c_data_receive(uint32_t i2c_periph);
-/* enable I2C DMA mode */
-void i2c_dma_enable(uint32_t i2c_periph, uint32_t dmastate);
+/* configure I2C DMA mode */
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate);
 /* configure whether next DMA EOT is DMA last transfer or not */
 void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast);
 /* whether to stretch SCL low when data is not ready in slave mode */
 void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara);
 /* whether or not to response to a general call */
 void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara);
-/* software reset I2C */
+/* configure software reset of I2C */
 void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset);
 
-/* I2C PEC calculation on or off */
-void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate);
-/* I2C whether to transfer PEC value */
-void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara);
-/* packet error checking value */
+/* configure I2C PEC calculation */
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate);
+/* configure whether to transfer PEC value */
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara);
+/* get packet error checking value */
 uint8_t i2c_pec_value_get(uint32_t i2c_periph);
-/* I2C issue alert through SMBA pin */
-void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara);
-/* I2C ARP protocol in SMBus switch */
-void i2c_smbus_arp_enable(uint32_t i2c_periph, uint32_t arpstate);
+/* configure I2C alert through SMBA pin */
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara);
+/* configure I2C ARP protocol in SMBus */
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate);
 
 /* enable SAM_V interface */
 void i2c_sam_enable(uint32_t i2c_periph);
@@ -384,17 +372,17 @@ void i2c_sam_timeout_enable(uint32_t i2c_periph);
 /* disable SAM_V interface timeout detect */
 void i2c_sam_timeout_disable(uint32_t i2c_periph);
 
-/* check I2C flag is set or not */
+/* get I2C flag status */
 FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag);
-/* clear I2C flag */
+/* clear I2C flag status */
 void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag);
 /* enable I2C interrupt */
 void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
 /* disable I2C interrupt */
 void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
-/* check I2C interrupt flag */
+/* get I2C interrupt flag status */
 FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
-/* clear I2C interrupt flag */
+/* clear I2C interrupt flag status */
 void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
 
 #endif /* GD32E10X_I2C_H */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_i2c.h
@@ -309,6 +309,11 @@ typedef enum {
 #define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)                  /*!< address format is 7 bits */
 #define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT                     /*!< address format is 10 bits */
 
+#define I2CCLK_MAX ((uint32_t)0x0000003FU)/*!< i2cclk maximum value */
+#define I2CCLK_MIN ((uint32_t)0x00000002U)/*!< i2cclk minimum value for standard mode */
+#define I2CCLK_FM_MIN ((uint32_t)0x00000008U)/*!< i2cclk minimum value for fast mode */
+#define I2CCLK_FM_PLUS_MIN ((uint32_t)0x00000018U)/*!< i2cclk minimum value for fast mode plus */
+
 /* function declarations */
 /* reset I2C */
 void i2c_deinit(uint32_t i2c_periph);

--- a/gd32e10x/standard_peripheral/include/gd32e10x_libopt.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_libopt.h
@@ -2,13 +2,14 @@
     \file    gd32e10x_libopt.h
     \brief   library optional for gd32e10x
     
-    \version 2018-03-26, V1.0.0, demo for GD32E103
-    \version 2020-09-30, V1.1.0, demo for GD32E103
-    \version 2020-12-31, V1.2.0, demo for GD32E103
+    \version 2017-12-26, V1.0.0, firmware for GD32E10x
+    \version 2020-09-30, V1.1.0, firmware for GD32E10x
+    \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_misc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_misc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_pmu.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_pmu.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -80,14 +81,14 @@ OF SUCH DAMAGE.
 #define PMU_LDOVS_NORMAL              CTL_LDOVS(1)             /*!< LDO output voltage select normal mode */
 #define PMU_LDOVS_LOW                 CTL_LDOVS(3)             /*!< LDO output voltage select low mode */
 
+/* PMU ldo definitions */
+#define PMU_LDO_NORMAL                ((uint32_t)0x00000000U)  /*!< LDO normal work when PMU enter deepsleep mode */
+#define PMU_LDO_LOWPOWER              PMU_CTL_LDOLP            /*!< LDO work at low power status when PMU enter deepsleep mode */
+
 /* PMU flag definitions */
 #define PMU_FLAG_WAKEUP               PMU_CS_WUF               /*!< wakeup flag status */
 #define PMU_FLAG_STANDBY              PMU_CS_STBF              /*!< standby flag status */
 #define PMU_FLAG_LVD                  PMU_CS_LVDF              /*!< lvd flag status */
-
-/* PMU ldo definitions */
-#define PMU_LDO_NORMAL                ((uint32_t)0x00000000U)  /*!< LDO normal work when PMU enter deepsleep mode */
-#define PMU_LDO_LOWPOWER              PMU_CTL_LDOLP            /*!< LDO work at low power status when PMU enter deepsleep mode */
 
 /* PMU flag reset definitions */
 #define PMU_FLAG_RESET_WAKEUP         ((uint8_t)0x00U)         /*!< wakeup flag reset */
@@ -114,7 +115,7 @@ void pmu_to_sleepmode(uint8_t sleepmodecmd);
 /* PMU work at deepsleep mode */
 void pmu_to_deepsleepmode(uint32_t ldo, uint8_t deepsleepmodecmd);
 /* PMU work at standby mode */
-void pmu_to_standbymode(uint8_t standbymodecmd);
+void pmu_to_standbymode(void);
 
 /* wakeup pin related functions */
 /* enable PMU wakeup pin */
@@ -129,9 +130,9 @@ void pmu_backup_write_enable(void);
 void pmu_backup_write_disable(void);
 
 /* flag functions */
-/* clear flag bit */
-void pmu_flag_clear(uint32_t flag_reset);
 /* get flag state */
 FlagStatus pmu_flag_get(uint32_t flag);
+/* clear flag bit */
+void pmu_flag_clear(uint32_t flag);
 
 #endif /* GD32E10X_PMU_H */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_rcu.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_rcu.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -718,6 +719,7 @@ typedef enum
 #define RCU_CK48MSRC_IRC48M             RCU_ADDCTL_CK48MSEL                 /*!< select IRC48M clock */
 
 /* function declarations */
+/* peripherals clock configure functions */
 /* deinitialize the RCU */
 void rcu_deinit(void);
 /* enable the peripherals clock */
@@ -737,6 +739,7 @@ void rcu_bkp_reset_enable(void);
 /* disable the BKP domain reset */
 void rcu_bkp_reset_disable(void);
 
+/* system and peripherals clock source, system reset configure functions */
 /* configure the system clock source */
 void rcu_system_clock_source_config(uint32_t ck_sys);
 /* get the system clock source */
@@ -775,20 +778,7 @@ void rcu_i2s2_clock_config(uint32_t i2s_clock_source);
 /* configure the CK48M clock selection */
 void rcu_ck48m_clock_config(uint32_t ck48m_clock_source);
 
-
-/* get the clock stabilization and periphral reset flags */
-FlagStatus rcu_flag_get(rcu_flag_enum flag);
-/* clear the reset flag */
-void rcu_all_reset_flag_clear(void);
-/* get the clock stabilization interrupt and ckm flags */
-FlagStatus rcu_interrupt_flag_get(rcu_int_flag_enum int_flag);
-/* clear the interrupt flags */
-void rcu_interrupt_flag_clear(rcu_int_flag_clear_enum int_flag_clear);
-/* enable the stabilization interrupt */
-void rcu_interrupt_enable(rcu_int_enum stab_int);
-/* disable the stabilization interrupt */
-void rcu_interrupt_disable(rcu_int_enum stab_int);
-
+/* LXTAL, IRC8M, PLL and other oscillator configure functions */
 /* configure the LXTAL drive capability */
 void rcu_lxtal_drive_capability_config(uint32_t lxtal_dricap);
 /* wait for oscillator stabilization flags is SET or oscillator startup is timeout */
@@ -801,18 +791,33 @@ void rcu_osci_off(rcu_osci_type_enum osci);
 void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci);
 /* disable the oscillator bypass mode, HXTALEN or LXTALEN must be reset before it */
 void rcu_osci_bypass_mode_disable(rcu_osci_type_enum osci);
+/* set the IRC8M adjust value */
+void rcu_irc8m_adjust_value_set(uint32_t irc8m_adjval);
+
+/* clock monitor configure functions */
 /* enable the HXTAL clock monitor */
 void rcu_hxtal_clock_monitor_enable(void);
 /* disable the HXTAL clock monitor */
 void rcu_hxtal_clock_monitor_disable(void);
 
-/* set the IRC8M adjust value */
-void rcu_irc8m_adjust_value_set(uint32_t irc8m_adjval);
-
+/* voltage configure and clock frequency get functions */
 /* set the deep sleep mode voltage */
 void rcu_deepsleep_voltage_set(uint32_t dsvol);
-
 /* get the system clock, bus and peripheral clock frequency */
 uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock);
+
+/* flag & interrupt functions */
+/* get the clock stabilization and periphral reset flags */
+FlagStatus rcu_flag_get(rcu_flag_enum flag);
+/* clear the reset flag */
+void rcu_all_reset_flag_clear(void);
+/* get the clock stabilization interrupt and ckm flags */
+FlagStatus rcu_interrupt_flag_get(rcu_int_flag_enum int_flag);
+/* clear the interrupt flags */
+void rcu_interrupt_flag_clear(rcu_int_flag_clear_enum int_flag_clear);
+/* enable the stabilization interrupt */
+void rcu_interrupt_enable(rcu_int_enum stab_int);
+/* disable the stabilization interrupt */
+void rcu_interrupt_disable(rcu_int_enum stab_int);
 
 #endif /* GD32E10X_RCU_H */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_rtc.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_rtc.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_spi.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_spi.h
@@ -5,10 +5,13 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2021-05-31, V1.2.1, firmware for GD32E10x
+    \version 2022-06-16, V1.2.2, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -334,18 +337,18 @@ void spi_nssp_mode_enable(uint32_t spi_periph);
 void spi_nssp_mode_disable(uint32_t spi_periph);
 
 /* quad wire SPI functions */
-/* enable quad wire SPI */
-void qspi_enable(uint32_t spi_periph);
-/* disable quad wire SPI */
-void qspi_disable(uint32_t spi_periph);
-/* enable quad wire SPI write */
-void qspi_write_enable(uint32_t spi_periph);
-/* enable quad wire SPI read */
-void qspi_read_enable(uint32_t spi_periph);
-/* enable quad wire SPI_IO2 and SPI_IO3 pin output */
-void qspi_io23_output_enable(uint32_t spi_periph);
-/* disable quad wire SPI_IO2 and SPI_IO3 pin output */
-void qspi_io23_output_disable(uint32_t spi_periph);
+/* enable SPI quad wire mode */
+void spi_quad_enable(uint32_t spi_periph);
+/* disable SPI quad wire mode */
+void spi_quad_disable(uint32_t spi_periph);
+/* enable SPI quad wire mode write */
+void spi_quad_write_enable(uint32_t spi_periph);
+/* enable SPI quad wire mode read */
+void spi_quad_read_enable(uint32_t spi_periph);
+/* enable SPI quad wire mode SPI_IO2 and SPI_IO3 pin output */
+void spi_quad_io23_output_enable(uint32_t spi_periph);
+/* disable SPI quad wire mode SPI_IO2 and SPI_IO3 pin output */
+void spi_quad_io23_output_disable(uint32_t spi_periph);
 
 /* flag and interrupt functions */
 /* enable SPI and I2S interrupt */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_timer.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_timer.h
@@ -591,7 +591,7 @@ void timer_deinit(uint32_t timer_periph);
 /* initialize TIMER init parameter struct */
 void timer_struct_para_init(timer_parameter_struct* initpara);
 /* initialize TIMER counter */
-void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
+void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
 /* enable a timer */
 void timer_enable(uint32_t timer_periph);
 /* disable a timer */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_timer.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_timer.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -590,7 +591,7 @@ void timer_deinit(uint32_t timer_periph);
 /* initialize TIMER init parameter struct */
 void timer_struct_para_init(timer_parameter_struct* initpara);
 /* initialize TIMER counter */
-void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
+void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
 /* enable a timer */
 void timer_enable(uint32_t timer_periph);
 /* disable a timer */

--- a/gd32e10x/standard_peripheral/include/gd32e10x_usart.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_usart.h
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/include/gd32e10x_wwdgt.h
+++ b/gd32e10x/standard_peripheral/include/gd32e10x_wwdgt.h
@@ -1,36 +1,37 @@
 /*!
     \file    gd32e10x_wwdgt.h
     \brief   definitions for the WWDGT
-    
+
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
-    \version 2020-12-31, V1.2.0, firmware for GD32E10x    
+    \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
@@ -40,7 +41,7 @@ OF SUCH DAMAGE.
 #include "gd32e10x.h"
 
 /* WWDGT definitions */
-#define WWDGT                       WWDGT_BASE
+#define WWDGT                       WWDGT_BASE                                /*!< WWDGT base address */
 
 /* registers definitions */
 #define WWDGT_CTL                   REG32((WWDGT) + 0x00U)                    /*!< WWDGT control register */
@@ -67,6 +68,11 @@ OF SUCH DAMAGE.
 #define WWDGT_CFG_PSC_DIV4          CFG_PSC(2)                                /*!< the time base of WWDGT = (PCLK1/4096)/4 */
 #define WWDGT_CFG_PSC_DIV8          CFG_PSC(3)                                /*!< the time base of WWDGT = (PCLK1/4096)/8 */
 
+/* write value to WWDGT_CTL_CNT bit field */
+#define CTL_CNT(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
+/* write value to WWDGT_CFG_WIN bit field */
+#define CFG_WIN(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
+
 /* function declarations */
 /* reset the window watchdog timer configuration */
 void wwdgt_deinit(void);
@@ -78,11 +84,11 @@ void wwdgt_counter_update(uint16_t counter_value);
 /* configure counter value, window value, and prescaler divider value */
 void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler);
 
-/* enable early wakeup interrupt of WWDGT */
-void wwdgt_interrupt_enable(void);
 /* check early wakeup interrupt state of WWDGT */
 FlagStatus wwdgt_flag_get(void);
 /* clear early wakeup interrupt state of WWDGT */
 void wwdgt_flag_clear(void);
+/* enable early wakeup interrupt of WWDGT */
+void wwdgt_interrupt_enable(void);
 
 #endif /* GD32E10X_WWDGT_H */

--- a/gd32e10x/standard_peripheral/source/gd32e10x_adc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_adc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/source/gd32e10x_bkp.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_bkp.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -183,7 +184,7 @@ void bkp_rtc_clock_output_select(uint16_t clocksel)
     \brief      select RTC clock calibration direction
     \param[in]  direction: RTC clock calibration direction
                 only one parameter can be selected which is shown as below:
-      \arg        RTC_CLOCK_SLOWED_DOWN: RTC clock slow down
+      \arg        RTC_CLOCK_SLOW_DOWN: RTC clock slow down
       \arg        RTC_CLOCK_SPEED_UP: RTC clock speed up
     \param[out] none
     \retval     none

--- a/gd32e10x/standard_peripheral/source/gd32e10x_crc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_crc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/source/gd32e10x_ctc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_ctc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -141,7 +142,6 @@ void ctc_refsource_polarity_config(uint32_t polarity)
                 only one parameter can be selected which is shown as below:
       \arg        CTC_REFSOURCE_GPIO: GPIO is selected
       \arg        CTC_REFSOURCE_LXTAL: LXTAL is selected
-      \arg        CTC_REFSOURCE_USBSOF: USBFS_SOF is selected
     \param[out] none
     \retval     none
 */

--- a/gd32e10x/standard_peripheral/source/gd32e10x_dac.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_dac.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/source/gd32e10x_dbg.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_dbg.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -133,19 +134,3 @@ void dbg_trace_pin_disable(void)
     DBG_CTL &= ~DBG_CTL_TRACE_IOEN;
 }
 
-/*!
-    \brief      trace pin mode selection 
-    \param[in]  trace_mode:
-                only one parameter can be selected which is shown as below:
-      \arg        TRACE_MODE_ASYNC: trace pin used for async mode 
-      \arg        TRACE_MODE_SYNC_DATASIZE_1: trace pin used for sync mode and data size is 1
-      \arg        TRACE_MODE_SYNC_DATASIZE_2: trace pin used for sync mode and data size is 2
-      \arg        TRACE_MODE_SYNC_DATASIZE_4: trace pin used for sync mode and data size is 4
-    \param[out] none
-    \retval     none
-*/
-void dbg_trace_pin_mode_set(uint32_t trace_mode)
-{
-    DBG_CTL &= ~DBG_CTL_TRACE_MODE;
-    DBG_CTL |= trace_mode;
-}

--- a/gd32e10x/standard_peripheral/source/gd32e10x_dma.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_dma.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -377,7 +378,7 @@ void dma_priority_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_
     
     /* acquire DMA_CHxCTL register */
     ctl = DMA_CHCTL(dma_periph, channelx);
-    /* assign regiser */
+    /* assign register */
     ctl &= ~DMA_CHXCTL_PRIO;
     ctl |= priority;
     DMA_CHCTL(dma_periph, channelx) = ctl;
@@ -439,14 +440,14 @@ void dma_periph_width_config(uint32_t dma_periph, dma_channel_enum channelx, uin
     
     /* acquire DMA_CHxCTL register */
     ctl = DMA_CHCTL(dma_periph, channelx);
-    /* assign regiser */
+    /* assign register */
     ctl &= ~DMA_CHXCTL_PWIDTH;
     ctl |= pwidth;
     DMA_CHCTL(dma_periph, channelx) = ctl;
 }
 
 /*!
-    \brief      enable next address increasement algorithm of memory  
+    \brief      enable next address increment algorithm of memory  
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specified DMA channel
@@ -465,7 +466,7 @@ void dma_memory_increase_enable(uint32_t dma_periph, dma_channel_enum channelx)
 }
 
 /*!
-    \brief      disable next address increasement algorithm of memory  
+    \brief      disable next address increment algorithm of memory  
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specified DMA channel
@@ -484,7 +485,7 @@ void dma_memory_increase_disable(uint32_t dma_periph, dma_channel_enum channelx)
 }
 
 /*!
-    \brief      enable next address increasement algorithm of peripheral
+    \brief      enable next address increment algorithm of peripheral
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specified DMA channel
@@ -503,7 +504,7 @@ void dma_periph_increase_enable(uint32_t dma_periph, dma_channel_enum channelx)
 }
 
 /*!
-    \brief      disable next address increasement algorithm of peripheral 
+    \brief      disable next address increment algorithm of peripheral 
     \param[in]  dma_periph: DMAx(x=0,1)
       \arg        DMAx(x=0,1)
     \param[in]  channelx: specified DMA channel
@@ -673,7 +674,7 @@ void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, ui
     \param[in]  channelx: specified DMA channel 
                 only one parameter can be selected which is shown as below:
       \arg        DMA0: DMA_CHx(x=0..6), DMA1: DMA_CHx(x=0..4)
-    \param[in]  source: specify which interrupt to enbale
+    \param[in]  source: specify which interrupt to enable
                 one or more parameters can be selected which are shown as below
       \arg        DMA_INT_FTF: channel full transfer finish interrupt
       \arg        DMA_INT_HTF: channel half transfer finish interrupt
@@ -697,7 +698,7 @@ void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32
     \param[in]  channelx: specified DMA channel 
                 only one parameter can be selected which is shown as below:
       \arg        DMA0: DMA_CHx(x=0..6), DMA1: DMA_CHx(x=0..4)
-    \param[in]  source: specify which interrupt to disbale
+    \param[in]  source: specify which interrupt to disable
                 one or more parameters can be selected which are shown as below
       \arg        DMA_INT_FTF: channel full transfer finish interrupt
       \arg        DMA_INT_HTF: channel half transfer finish interrupt

--- a/gd32e10x/standard_peripheral/source/gd32e10x_exmc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_exmc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/source/gd32e10x_exti.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_exti.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:

--- a/gd32e10x/standard_peripheral/source/gd32e10x_fmc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_fmc.c
@@ -6,10 +6,11 @@
     \version 2020-05-11, V1.0.1, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -288,13 +289,20 @@ fmc_state_enum fmc_mass_erase(void)
 */
 fmc_state_enum fmc_doubleword_program(uint32_t address, uint64_t data)
 {
+    uint32_t data0, data1;
+
     fmc_state_enum fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    data0 = (uint32_t)(data & 0xFFFFFFFFU);
+    data1 = (uint32_t)((data >> 32U) & 0xFFFFFFFFU);
 
     if(FMC_READY == fmc_state){
         /* set the PGW and PG bit to start program */
         FMC_WS |= FMC_WS_PGW;
         FMC_CTL |= FMC_CTL_PG;
-        *(__IO uint64_t*)(address) = data;
+
+        REG32(address) = data0;
+        REG32(address + 4U) = data1;
 
         /* wait for the FMC ready */
         fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);

--- a/gd32e10x/standard_peripheral/source/gd32e10x_fwdgt.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_fwdgt.c
@@ -1,45 +1,41 @@
 /*!
     \file    gd32e10x_fwdgt.c
     \brief   FWDGT driver
-        
+
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32e10x_fwdgt.h"
-
-/* write value to FWDGT_CTL_CMD bit field */
-#define CTL_CMD(regval)             (BITS(0,15) & ((uint32_t)(regval) << 0))
-/* write value to FWDGT_RLD_RLD bit field */
-#define RLD_RLD(regval)             (BITS(0,11) & ((uint32_t)(regval) << 0))
 
 /*!
     \brief      enable write access to FWDGT_PSC and FWDGT_RLD
@@ -75,6 +71,71 @@ void fwdgt_enable(void)
 }
 
 /*!
+    \brief      configure the free watchdog timer counter prescaler value
+    \param[in]  prescaler_value: specify prescaler value
+                only one parameter can be selected which is shown as below:
+      \arg        FWDGT_PSC_DIV4: FWDGT prescaler set to 4
+      \arg        FWDGT_PSC_DIV8: FWDGT prescaler set to 8
+      \arg        FWDGT_PSC_DIV16: FWDGT prescaler set to 16
+      \arg        FWDGT_PSC_DIV32: FWDGT prescaler set to 32
+      \arg        FWDGT_PSC_DIV64: FWDGT prescaler set to 64
+      \arg        FWDGT_PSC_DIV128: FWDGT prescaler set to 128
+      \arg        FWDGT_PSC_DIV256: FWDGT prescaler set to 256
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus fwdgt_prescaler_value_config(uint16_t prescaler_value)
+{
+    uint32_t timeout = FWDGT_PSC_TIMEOUT;
+    uint32_t flag_status = RESET;
+
+    /* enable write access to FWDGT_PSC */
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+
+    /* wait until the PUD flag to be reset */
+    do {
+        flag_status = FWDGT_STAT & FWDGT_STAT_PUD;
+    } while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET != flag_status) {
+        return ERROR;
+    }
+
+    /* configure FWDGT */
+    FWDGT_PSC = (uint32_t)prescaler_value;
+
+    return SUCCESS;
+}
+
+/*!
+    \brief      configure the free watchdog timer counter reload value
+    \param[in]  reload_value: specify reload value(0x0000 - 0x0FFF)
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus fwdgt_reload_value_config(uint16_t reload_value)
+{
+    uint32_t timeout = FWDGT_RLD_TIMEOUT;
+    uint32_t flag_status = RESET;
+
+    /* enable write access to FWDGT_RLD */
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+
+    /* wait until the RUD flag to be reset */
+    do {
+        flag_status = FWDGT_STAT & FWDGT_STAT_RUD;
+    } while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET != flag_status) {
+        return ERROR;
+    }
+
+    FWDGT_RLD = RLD_RLD(reload_value);
+
+    return SUCCESS;
+}
+
+/*!
     \brief      reload the counter of FWDGT
     \param[in]  none
     \param[out] none
@@ -104,16 +165,16 @@ ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div)
 {
     uint32_t timeout = FWDGT_PSC_TIMEOUT;
     uint32_t flag_status = RESET;
-  
+
     /* enable write access to FWDGT_PSC,and FWDGT_RLD */
     FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
-  
+
     /* wait until the PUD flag to be reset */
-    do{
-       flag_status = FWDGT_STAT & FWDGT_STAT_PUD;
-    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
-    
-    if((uint32_t)RESET != flag_status){
+    do {
+        flag_status = FWDGT_STAT & FWDGT_STAT_PUD;
+    } while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET != flag_status) {
         return ERROR;
     }
 
@@ -122,16 +183,16 @@ ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div)
 
     timeout = FWDGT_RLD_TIMEOUT;
     /* wait until the RUD flag to be reset */
-    do{
-       flag_status = FWDGT_STAT & FWDGT_STAT_RUD;
-    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
-   
-    if((uint32_t)RESET != flag_status){
+    do {
+        flag_status = FWDGT_STAT & FWDGT_STAT_RUD;
+    } while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET != flag_status) {
         return ERROR;
     }
-    
+
     FWDGT_RLD = RLD_RLD(reload_value);
-    
+
     /* reload the counter */
     FWDGT_CTL = FWDGT_KEY_RELOAD;
 
@@ -140,7 +201,7 @@ ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div)
 
 /*!
     \brief      get flag state of FWDGT
-    \param[in]  flag: flag to get 
+    \param[in]  flag: flag to get
                 only one parameter can be selected which is shown as below:
       \arg        FWDGT_FLAG_PUD: a write operation to FWDGT_PSC register is on going
       \arg        FWDGT_FLAG_RUD: a write operation to FWDGT_RLD register is on going
@@ -149,7 +210,7 @@ ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div)
 */
 FlagStatus fwdgt_flag_get(uint16_t flag)
 {
-    if(RESET != (FWDGT_STAT & flag)){
+    if(FWDGT_STAT & flag) {
         return SET;
     }
 

--- a/gd32e10x/standard_peripheral/source/gd32e10x_gpio.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_gpio.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -335,16 +336,14 @@ uint16_t gpio_output_port_get(uint32_t gpio_periph)
       \arg        GPIO_CAN0_FULL_REMAP: CAN0 full remapping
       \arg        GPIO_PD01_REMAP: PD01 remapping
       \arg        GPIO_TIMER4CH3_IREMAP: TIMER4 channel3 internal remapping
-      \arg        GPIO_ADC0_ETRGINS_REMAP: ADC0 external trigger inserted conversion remapping
-      \arg        GPIO_ADC0_ETRGREG_REMAP: ADC0 external trigger regular conversion remapping
-      \arg        GPIO_ADC1_ETRGINS_REMAP: ADC1 external trigger inserted conversion remapping
-      \arg        GPIO_ADC1_ETRGREG_REMAP: ADC1 external trigger regular conversion remapping
+      \arg        GPIO_ADC0_ETRGRT_REMAP: ADC0 external trigger routine conversion remapping
+      \arg        GPIO_ADC1_ETRGRT_REMAP: ADC1 external trigger routine conversion remapping
       \arg        GPIO_CAN1_REMAP: CAN1 remapping
       \arg        GPIO_SWJ_NONJTRST_REMAP: full SWJ(JTAG-DP + SW-DP),but without NJTRST
       \arg        GPIO_SWJ_SWDPENABLE_REMAP: JTAG-DP disabled and SW-DP enabled
       \arg        GPIO_SWJ_DISABLE_REMAP: JTAG-DP disabled and SW-DP disabled
       \arg        GPIO_SPI2_REMAP: SPI2 remapping 
-      \arg        GPIO_TIMER1ITR0_REMAP: TIMER1 internal trigger 0 remapping
+      \arg        GPIO_TIMER1ITI1_REMAP: TIMER1 internal trigger 1 remapping
       \arg        GPIO_TIMER8_REMAP: TIMER8 remapping
       \arg        GPIO_EXMC_NADV_REMAP: EXMC_NADV connect/disconnect
       \arg        GPIO_CTC_REMAP0: CTC remapping(PD15)

--- a/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
@@ -39,8 +39,6 @@ OF SUCH DAMAGE.
 #include "gd32e10x_i2c.h"
 
 /* I2C register bit mask */
-#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)             /*!< i2cclk maximum value */
-#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */

--- a/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_i2c.c
@@ -6,10 +6,11 @@
     \version 2019-04-16, V1.0.1, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -37,15 +38,15 @@ OF SUCH DAMAGE.
 
 #include "gd32e10x_i2c.h"
 
-#define I2C_ERROR_HANDLE(s)           do{}while(1)
-
 /* I2C register bit mask */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003FU)             /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
 #define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
 #define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
 #define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */
 
 /* I2C register bit offset */
-#define STAT1_PECV_OFFSET             ((uint32_t)8U)     /* bit offset of PECV in I2C_STAT1 */
+#define STAT1_PECV_OFFSET             ((uint32_t)0x00000008U)             /*!< bit offset of PECV in I2C_STAT1 */
 
 /*!
     \brief      reset I2C
@@ -76,7 +77,7 @@ void i2c_deinit(uint32_t i2c_periph)
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  clkspeed: I2C clock speed, supports standard mode (up to 100 kHz), fast mode (up to 400 kHz)
                           and fast mode plus (up to 1MHz)
-    \param[in]  dutycyc: duty cycle in fast mode or fast mode plus
+    \param[in]  dutycyc: duty cycle in fast mode or fast mode plus, and only I2C_DTCY_2 can be selected in standard mode
                 only one parameter can be selected which is shown as below:
       \arg        I2C_DTCY_2: T_low/T_high=2 
       \arg        I2C_DTCY_16_9: T_low/T_high=16/9
@@ -88,51 +89,48 @@ void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc)
     uint32_t pclk1, clkc, freq, risetime;
     uint32_t temp;
 
-    if(0U == clkspeed){
-        I2C_ERROR_HANDLE("the parameter can not be 0 \r\n");
-    }
-
     pclk1 = rcu_clock_freq_get(CK_APB1);
     /* I2C peripheral clock frequency */
-    freq = (uint32_t)(pclk1/1000000U);
-    if(freq >= I2CCLK_MAX){
+    freq = (uint32_t)(pclk1 / 1000000U);
+    if(freq >= I2CCLK_MAX) {
         freq = I2CCLK_MAX;
     }
     temp = I2C_CTL1(i2c_periph);
     temp &= ~I2C_CTL1_I2CCLK;
     temp |= freq;
-    
+
     I2C_CTL1(i2c_periph) = temp;
-    
-    if(100000U >= clkspeed){
+
+    if(100000U >= clkspeed) {
         /* the maximum SCL rise time is 1000ns in standard mode */
-        risetime = (uint32_t)((pclk1/1000000U)+1U);
-        if(risetime >= I2CCLK_MAX){
+        risetime = (uint32_t)((pclk1 / 1000000U) + 1U);
+        if(risetime >= I2CCLK_MAX) {
             I2C_RT(i2c_periph) = I2CCLK_MAX;
-        }else if(risetime <= I2CCLK_MIN){
+        } else if(risetime <= I2CCLK_MIN) {
             I2C_RT(i2c_periph) = I2CCLK_MIN;
         }else{
             I2C_RT(i2c_periph) = risetime;
         }
-        clkc = (uint32_t)(pclk1/(clkspeed*2U));
-        if(clkc < 0x04U){
+        clkc = (uint32_t)(pclk1 / (clkspeed * 2U));
+        if(clkc < 0x04U) {
             /* the CLKC in standard mode minimum value is 4 */
             clkc = 0x04U;
         }
+
         I2C_CKCFG(i2c_periph) |= (I2C_CKCFG_CLKC & clkc);
-    }else if(400000U >= clkspeed){
+    } else if(400000U >= clkspeed) {
         /* the maximum SCL rise time is 300ns in fast mode */
-        I2C_RT(i2c_periph) = (uint32_t)(((freq*(uint32_t)300U)/(uint32_t)1000U)+(uint32_t)1U);
-        if(I2C_DTCY_2 == dutycyc){
+        I2C_RT(i2c_periph) = (uint32_t)(((freq * (uint32_t)300U) / (uint32_t)1000U) + (uint32_t)1U);
+        if(I2C_DTCY_2 == dutycyc) {
             /* I2C duty cycle is 2 */
-            clkc = (uint32_t)(pclk1/(clkspeed*3U));
+            clkc = (uint32_t)(pclk1 / (clkspeed * 3U));
             I2C_CKCFG(i2c_periph) &= ~I2C_CKCFG_DTCY;
-        }else{
+        } else {
             /* I2C duty cycle is 16/9 */
-            clkc = (uint32_t)(pclk1/(clkspeed*25U));
+            clkc = (uint32_t)(pclk1 / (clkspeed * 25U));
             I2C_CKCFG(i2c_periph) |= I2C_CKCFG_DTCY;
         }
-        if(0U == (clkc & I2C_CKCFG_CLKC)){
+        if(0U == (clkc & I2C_CKCFG_CLKC)) {
             /* the CLKC in fast mode minimum value is 1 */
             clkc |= 0x0001U;
         }
@@ -167,8 +165,8 @@ void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc)
       \arg        I2C_SMBUSMODE_ENABLE: SMBus mode
     \param[in]  addformat: 7bits or 10bits
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_ADDFORMAT_7BITS: 7bits
-      \arg        I2C_ADDFORMAT_10BITS: 10bits
+      \arg        I2C_ADDFORMAT_7BITS: address format is 7 bits
+      \arg        I2C_ADDFORMAT_10BITS: address format is 10 bits
     \param[in]  addr: I2C address
     \param[out] none
     \retval     none
@@ -177,9 +175,9 @@ void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat
 {
     /* SMBus/I2C mode selected */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SMBEN); 
+    ctl &= ~(I2C_CTL0_SMBEN);
     ctl |= mode;
     I2C_CTL0(i2c_periph) = ctl;
     /* configure address */
@@ -188,12 +186,12 @@ void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat
 }
 
 /*!
-    \brief      SMBus type selection
+    \brief      select SMBus type
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  type:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SMBUS_DEVICE: device
-      \arg        I2C_SMBUS_HOST: host
+      \arg        I2C_SMBUS_DEVICE: SMBus mode device type
+      \arg        I2C_SMBUS_HOST: SMBus mode host type
     \param[out] none
     \retval     none
 */
@@ -218,11 +216,12 @@ void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type)
 */
 void i2c_ack_config(uint32_t i2c_periph, uint32_t ack)
 {
-    if(I2C_ACK_ENABLE == ack){
-        I2C_CTL0(i2c_periph) |= I2C_CTL0_ACKEN;
-    }else{
-        I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_ACKEN);
-    }
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_ACKEN);
+    ctl |= ack;
+    I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
@@ -230,19 +229,20 @@ void i2c_ack_config(uint32_t i2c_periph, uint32_t ack)
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  pos:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_ACKPOS_CURRENT: whether to send ACK or not for the current
-      \arg        I2C_ACKPOS_NEXT: whether to send ACK or not for the next byte
+      \arg        I2C_ACKPOS_CURRENT: ACKEN bit decides whether or not to send ACK or not for the current byte
+      \arg        I2C_ACKPOS_NEXT: ACKEN bit decides whether or not to send ACK for the next byte
     \param[out] none
     \retval     none
 */
 void i2c_ackpos_config(uint32_t i2c_periph, uint32_t pos)
 {
+    uint32_t ctl = 0U;
+
     /* configure I2C POAP position */
-    if(I2C_ACKPOS_NEXT == pos){
-        I2C_CTL0(i2c_periph) |= I2C_CTL0_POAP;
-    }else{
-        I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_POAP);
-    }
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_POAP);
+    ctl |= pos;
+    I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
@@ -251,8 +251,8 @@ void i2c_ackpos_config(uint32_t i2c_periph, uint32_t pos)
     \param[in]  addr: slave address  
     \param[in]  trandirection: transmitter or receiver
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_TRANSMITTER: transmitter  
-      \arg        I2C_RECEIVER:    receiver  
+      \arg        I2C_TRANSMITTER: transmitter
+      \arg        I2C_RECEIVER: receiver
     \param[out] none
     \retval     none
 */
@@ -295,7 +295,7 @@ void i2c_dualaddr_disable(uint32_t i2c_periph)
 
 /*!
     \brief      enable I2C
-    \param[in]  i2c_periph: I2Cx(x=0,1) 
+    \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[out] none
     \retval     none
 */
@@ -361,22 +361,22 @@ uint8_t i2c_data_receive(uint32_t i2c_periph)
 }
 
 /*!
-    \brief      enable I2C DMA mode 
+    \brief      configure I2C DMA mode
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  dmastate:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_DMA_ON: DMA mode enable
-      \arg        I2C_DMA_OFF: DMA mode disable
+      \arg        I2C_DMA_ON: enable DMA mode
+      \arg        I2C_DMA_OFF: disable DMA mode
     \param[out] none
     \retval     none
 */
-void i2c_dma_enable(uint32_t i2c_periph, uint32_t dmastate)
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate)
 {
     /* configure I2C DMA function */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL1(i2c_periph);
-    ctl &= ~(I2C_CTL1_DMAON); 
+    ctl &= ~(I2C_CTL1_DMAON);
     ctl |= dmastate;
     I2C_CTL1(i2c_periph) = ctl;
 }
@@ -395,36 +395,36 @@ void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast)
 {
     /* configure DMA last transfer */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL1(i2c_periph);
-    ctl &= ~(I2C_CTL1_DMALST); 
+    ctl &= ~(I2C_CTL1_DMALST);
     ctl |= dmalast;
     I2C_CTL1(i2c_periph) = ctl;
 }
 
 /*!
-    \brief      whether to stretch SCL low when data is not ready in slave mode 
+    \brief      whether to stretch SCL low when data is not ready in slave mode
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  stretchpara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SCLSTRETCH_ENABLE: SCL stretching is enabled
-      \arg        I2C_SCLSTRETCH_DISABLE: SCL stretching is disabled
+      \arg        I2C_SCLSTRETCH_ENABLE: enable SCL stretching
+      \arg        I2C_SCLSTRETCH_DISABLE: disable SCL stretching
     \param[out] none
     \retval     none
 */
 void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara)
 {
-    /* configure I2C SCL stretching enable or disable */
+    /* configure I2C SCL stretching */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SS); 
+    ctl &= ~(I2C_CTL0_SS);
     ctl |= stretchpara;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief      whether or not to response to a general call 
+    \brief      whether or not to response to a general call
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  gcallpara:
                 only one parameter can be selected which is shown as below:
@@ -437,15 +437,15 @@ void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara)
 {
     /* configure slave response to a general call enable or disable */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_GCEN); 
+    ctl &= ~(I2C_CTL0_GCEN);
     ctl |= gcallpara;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief      software reset I2C 
+    \brief      configure software reset of I2C
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  sreset:
                 only one parameter can be selected which is shown as below:
@@ -458,28 +458,28 @@ void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset)
 {
     /* modify CTL0 and configure software reset I2C state */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
-    ctl &= ~(I2C_CTL0_SRESET); 
+    ctl &= ~(I2C_CTL0_SRESET);
     ctl |= sreset;
     I2C_CTL0(i2c_periph) = ctl;
 }
 
 /*!
-    \brief      I2C PEC calculation on or off
+    \brief      configure I2C PEC calculation
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  pecstate:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_PEC_ENABLE: PEC calculation on 
-      \arg        I2C_PEC_DISABLE: PEC calculation off 
+      \arg        I2C_PEC_ENABLE: PEC calculation on
+      \arg        I2C_PEC_DISABLE: PEC calculation off
     \param[out] none
     \retval     none
 */
-void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate)
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate)
 {
     /* on/off PEC calculation */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_PECEN);
     ctl |= pecstate;
@@ -487,20 +487,20 @@ void i2c_pec_enable(uint32_t i2c_periph, uint32_t pecstate)
 }
 
 /*!
-    \brief      I2C whether to transfer PEC value
+    \brief      configure whether to transfer PEC value
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  pecpara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_PECTRANS_ENABLE: transfer PEC 
-      \arg        I2C_PECTRANS_DISABLE: not transfer PEC 
+      \arg        I2C_PECTRANS_ENABLE: transfer PEC value
+      \arg        I2C_PECTRANS_DISABLE: not transfer PEC value
     \param[out] none
     \retval     none
 */
-void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara)
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara)
 {
     /* whether to transfer PEC */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_PECTRANS);
     ctl |= pecpara;
@@ -508,31 +508,31 @@ void i2c_pec_transfer_enable(uint32_t i2c_periph, uint32_t pecpara)
 }
 
 /*!
-    \brief      get packet error checking value 
+    \brief      get packet error checking value
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[out] none
     \retval     PEC value
 */
 uint8_t i2c_pec_value_get(uint32_t i2c_periph)
 {
-    return (uint8_t)((I2C_STAT1(i2c_periph) & I2C_STAT1_PECV)>>STAT1_PECV_OFFSET);
+    return (uint8_t)((I2C_STAT1(i2c_periph) & I2C_STAT1_PECV) >> STAT1_PECV_OFFSET);
 }
 
 /*!
-    \brief      I2C issue alert through SMBA pin 
+    \brief      configure I2C alert through SMBA pin
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  smbuspara:
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_SALTSEND_ENABLE: issue alert through SMBA pin 
-      \arg        I2C_SALTSEND_DISABLE: not issue alert through SMBA pin 
+      \arg        I2C_SALTSEND_ENABLE: issue alert through SMBA pin
+      \arg        I2C_SALTSEND_DISABLE: not issue alert through SMBA pin
     \param[out] none
     \retval     none
 */
-void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara)
 {
-    /* issue alert through SMBA pin configure*/
+    /* configure smbus alert through SMBA pin */
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_SALT);
     ctl |= smbuspara;
@@ -540,7 +540,7 @@ void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
 }
 
 /*!
-    \brief      enable or disable I2C ARP protocol in SMBus switch
+    \brief      configure I2C ARP protocol in SMBus
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  arpstate:
                 only one parameter can be selected which is shown as below:
@@ -549,11 +549,11 @@ void i2c_smbus_issue_alert(uint32_t i2c_periph, uint32_t smbuspara)
     \param[out] none
     \retval     none
 */
-void i2c_smbus_arp_enable(uint32_t i2c_periph, uint32_t arpstate)
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate)
 {
     /* enable or disable I2C ARP protocol*/
     uint32_t ctl = 0U;
-    
+
     ctl = I2C_CTL0(i2c_periph);
     ctl &= ~(I2C_CTL0_ARPEN);
     ctl |= arpstate;
@@ -609,23 +609,23 @@ void i2c_sam_timeout_disable(uint32_t i2c_periph)
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  flag: I2C flags, refer to i2c_flag_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_FLAG_SBSEND: start condition send out 
+      \arg        I2C_FLAG_SBSEND: start condition sent out in master mode
       \arg        I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
       \arg        I2C_FLAG_BTC: byte transmission finishes
       \arg        I2C_FLAG_ADD10SEND: header of 10-bit address is sent in master mode
       \arg        I2C_FLAG_STPDET: stop condition detected in slave mode
-      \arg        I2C_FLAG_RBNE: I2C_DATA is not Empty during receiving
+      \arg        I2C_FLAG_RBNE: I2C_DATA is not empty during receiving
       \arg        I2C_FLAG_TBE: I2C_DATA is empty during transmitting
       \arg        I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
       \arg        I2C_FLAG_LOSTARB: arbitration lost in master mode
       \arg        I2C_FLAG_AERR: acknowledge error
-      \arg        I2C_FLAG_OUERR: overrun or underrun situation occurs in slave mode
+      \arg        I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
       \arg        I2C_FLAG_PECERR: PEC error when receiving data
       \arg        I2C_FLAG_SMBTO: timeout signal in SMBus mode
       \arg        I2C_FLAG_SMBALT: SMBus alert status
       \arg        I2C_FLAG_MASTER: a flag indicating whether I2C block is in master or slave mode
       \arg        I2C_FLAG_I2CBSY: busy flag
-      \arg        I2C_FLAG_TRS: whether the I2C is a transmitter or a receiver
+      \arg        I2C_FLAG_TR: whether the I2C is a transmitter or a receiver
       \arg        I2C_FLAG_RXGC: general call address (00h) received
       \arg        I2C_FLAG_DEFSMB: default address of SMBus device
       \arg        I2C_FLAG_HSTSMB: SMBus host header detected in slave mode
@@ -647,18 +647,18 @@ FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag)
 }
 
 /*!
-    \brief      clear I2C flag
+    \brief      clear I2C flag status
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  flag: I2C flags, refer to i2c_flag_enum
                 only one parameter can be selected which is shown as below:
-      \arg       I2C_FLAG_SMBALT: SMBus Alert status
+      \arg       I2C_FLAG_SMBALT: SMBus alert status
       \arg       I2C_FLAG_SMBTO: timeout signal in SMBus mode
       \arg       I2C_FLAG_PECERR: PEC error when receiving data
-      \arg       I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode    
+      \arg       I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
       \arg       I2C_FLAG_AERR: acknowledge error
-      \arg       I2C_FLAG_LOSTARB: arbitration lost in master mode   
-      \arg       I2C_FLAG_BERR: a bus error   
-      \arg       I2C_FLAG_ADDSEND: cleared by reading I2C_STAT0 and reading I2C_STAT1
+      \arg       I2C_FLAG_LOSTARB: arbitration lost in master mode
+      \arg       I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
+      \arg       I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
       \arg       I2C_FLAG_TFF: txframe fall flag
       \arg       I2C_FLAG_TFR: txframe rise flag
       \arg       I2C_FLAG_RFF: rxframe fall flag
@@ -682,13 +682,13 @@ void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag)
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_INT_ERR: error interrupt enable 
-      \arg        I2C_INT_EV: event interrupt enable 
-      \arg        I2C_INT_BUF: buffer interrupt enable
-      \arg        I2C_INT_TFF: txframe fall interrupt enable
-      \arg        I2C_INT_TFR: txframe rise interrupt enable
-      \arg        I2C_INT_RFF: rxframe fall interrupt enable
-      \arg        I2C_INT_RFR: rxframe rise interrupt enable
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
     \param[out] none
     \retval     none
 */
@@ -700,15 +700,15 @@ void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 /*!
     \brief      disable I2C interrupt
     \param[in]  i2c_periph: I2Cx(x=0,1)
-    \param[in]  interrupt: I2C interrupts, refer to i2c_flag_enum
+    \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
                 only one parameter can be selected which is shown as below:
-      \arg        I2C_INT_ERR: error interrupt enable 
-      \arg        I2C_INT_EV: event interrupt enable 
-      \arg        I2C_INT_BUF: buffer interrupt enable
-      \arg        I2C_INT_TFF: txframe fall interrupt enable
-      \arg        I2C_INT_TFR: txframe rise interrupt enable
-      \arg        I2C_INT_RFF: rxframe fall interrupt enable
-      \arg        I2C_INT_RFR: rxframe rise interrupt enable
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
     \param[out] none
     \retval     none
 */
@@ -718,13 +718,13 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 }
 
 /*!
-    \brief      check I2C interrupt flag
+    \brief      get I2C interrupt flag status
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
                 only one parameter can be selected which is shown as below:
       \arg        I2C_INT_FLAG_SBSEND: start condition sent out in master mode interrupt flag
       \arg        I2C_INT_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode interrupt flag
-      \arg        I2C_INT_FLAG_BTC: byte transmission finishes
+      \arg        I2C_INT_FLAG_BTC: byte transmission finishes interrupt flag
       \arg        I2C_INT_FLAG_ADD10SEND: header of 10-bit address is sent in master mode interrupt flag
       \arg        I2C_INT_FLAG_STPDET: stop condition detected in slave mode interrupt flag
       \arg        I2C_INT_FLAG_RBNE: I2C_DATA is not Empty during receiving interrupt flag
@@ -735,7 +735,7 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
       \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
       \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
       \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
-      \arg        I2C_INT_FLAG_SMBALT: SMBus Alert status interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
       \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
       \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
       \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag
@@ -746,10 +746,10 @@ void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
 FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
 {
     uint32_t intenable = 0U, flagstatus = 0U, bufie;
-    
+
     /* check BUFIE */
     bufie = I2C_CTL1(i2c_periph)&I2C_CTL1_BUFIE;
-    
+
     /* get the interrupt enable bit status */
     intenable = (I2C_REG_VAL(i2c_periph, int_flag) & BIT(I2C_BIT_POS(int_flag)));
     /* get the corresponding flag bit status */
@@ -757,7 +757,7 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
 
     if((I2C_INT_FLAG_RBNE == int_flag) || (I2C_INT_FLAG_TBE == int_flag)){
         if(intenable && bufie){
-            intenable = 1U;                       
+            intenable = 1U;
         }else{
             intenable = 0U;
         }
@@ -770,7 +770,7 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
 }
 
 /*!
-    \brief      clear I2C interrupt flag
+    \brief      clear I2C interrupt flag status
     \param[in]  i2c_periph: I2Cx(x=0,1)
     \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
                 only one parameter can be selected which is shown as below:
@@ -781,7 +781,7 @@ FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum i
       \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
       \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
       \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
-      \arg        I2C_INT_FLAG_SMBALT: SMBus Alert status interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
       \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
       \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
       \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag

--- a/gd32e10x/standard_peripheral/source/gd32e10x_misc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_misc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -130,6 +131,7 @@ void nvic_irq_disable(uint8_t nvic_irq)
 void nvic_vector_table_set(uint32_t nvic_vict_tab, uint32_t offset)
 {
     SCB->VTOR = nvic_vict_tab | (offset & NVIC_VECTTAB_OFFSET_MASK);
+    __DSB();
 }
 
 /*!

--- a/gd32e10x/standard_peripheral/source/gd32e10x_rcu.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_rcu.c
@@ -6,10 +6,11 @@
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
     \version 2021-05-31, V1.2.1, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2021, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -58,7 +59,6 @@ OF SUCH DAMAGE.
 /* RCU PREDV1 division factor offset*/
 #define RCU_CFG1_PREDV1_OFFSET      ((uint32_t)4U)
 
-
 /*!
     \brief      deinitialize the RCU
     \param[in]  none
@@ -71,11 +71,15 @@ void rcu_deinit(void)
     RCU_CTL |= RCU_CTL_IRC8MEN;
     rcu_osci_stab_wait(RCU_IRC8M);
 
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+
+    /* reset HXTALEN, CKMEN, PLLEN bits */
+    RCU_CTL &= ~(RCU_CTL_HXTALEN | RCU_CTL_CKMEN | RCU_CTL_PLLEN);
+
     /* reset CFG0 register */
     RCU_CFG0 &= ~(RCU_CFG0_SCS | RCU_CFG0_AHBPSC | RCU_CFG0_APB1PSC | RCU_CFG0_APB2PSC |
                   RCU_CFG0_ADCPSC | RCU_CFG0_CKOUT0SEL | RCU_CFG0_ADCPSC_2);
-    /* reset HXTALEN, CKMEN, PLLEN bits */
-    RCU_CTL &= ~(RCU_CTL_HXTALEN | RCU_CTL_CKMEN | RCU_CTL_PLLEN);
+
     /* reset HXTALBPS bit */
     RCU_CTL &= ~RCU_CTL_HXTALBPS;
     /* reset PLLSEL, PREDV0_LSB, PLLMF, USBFSPSC bits */

--- a/gd32e10x/standard_peripheral/source/gd32e10x_rtc.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_rtc.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -149,10 +150,18 @@ void rtc_alarm_config(uint32_t alarm)
 */
 uint32_t rtc_counter_get(void)
 {
-    uint32_t temp = 0x0U;
-    
+    uint32_t temp = 0x0U, high_old, high_new;
+
+    high_old = RTC_CNTH;
     temp = RTC_CNTL;
-    temp |= (RTC_CNTH << RTC_HIGH_BITS_OFFSET);
+    high_new = RTC_CNTH;
+
+    if(high_old != high_new){
+        temp = (high_new << RTC_HIGH_BITS_OFFSET) | RTC_CNTL;
+    }else{
+        temp |= (high_new << RTC_HIGH_BITS_OFFSET);
+    }
+
     return temp;
 }
 
@@ -246,7 +255,7 @@ void rtc_interrupt_flag_clear(uint32_t flag)
 
 /*!
     \brief      enable RTC interrupt
-    \param[in]  interrupt: specify which interrupt to enbale
+    \param[in]  interrupt: specify which interrupt to enable
                 one or more parameters can be selected which are shown as below:
       \arg        RTC_INT_SECOND: second interrupt
       \arg        RTC_INT_ALARM: alarm interrupt
@@ -261,7 +270,7 @@ void rtc_interrupt_enable(uint32_t interrupt)
 
 /*!
     \brief      disable RTC interrupt
-    \param[in]  interrupt: specify which interrupt to disbale
+    \param[in]  interrupt: specify which interrupt to disable
                 one or more parameters can be selected which are shown as below:
       \arg        RTC_INT_SECOND: second interrupt
       \arg        RTC_INT_ALARM: alarm interrupt

--- a/gd32e10x/standard_peripheral/source/gd32e10x_spi.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_spi.c
@@ -6,10 +6,12 @@
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
     \version 2021-05-31, V1.2.1, firmware for GD32E10x
+    \version 2022-06-16, V1.2.2, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2021, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -96,6 +98,7 @@ void spi_struct_para_init(spi_parameter_struct* spi_struct)
     spi_struct->trans_mode = SPI_TRANSMODE_FULLDUPLEX;
     spi_struct->frame_size = SPI_FRAMESIZE_8BIT;
     spi_struct->nss = SPI_NSS_HARD;
+    spi_struct->endian = SPI_ENDIAN_MSB;
     spi_struct->clock_polarity_phase = SPI_CK_PL_LOW_PH_1EDGE;
     spi_struct->prescale = SPI_PSC_2;
 }
@@ -604,67 +607,67 @@ void spi_nssp_mode_disable(uint32_t spi_periph)
 }
 
 /*!
-    \brief      enable quad wire SPI
+    \brief      enable SPI quad wire mode 
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_enable(uint32_t spi_periph)
+void spi_quad_enable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_QMOD;
 }
 
 /*!
-    \brief      disable quad wire SPI 
+    \brief      disable SPI quad wire mode 
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_disable(uint32_t spi_periph)
+void spi_quad_disable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_QMOD);
 }
 
 /*!
-    \brief      enable quad wire SPI write 
+    \brief      enable SPI quad wire mode write 
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_write_enable(uint32_t spi_periph)
+void spi_quad_write_enable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_QRD);
 }
 
 /*!
-    \brief      enable quad wire SPI read 
+    \brief      enable SPI quad wire mode read 
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_read_enable(uint32_t spi_periph)
+void spi_quad_read_enable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_QRD;
 }
 
 /*!
-    \brief      enable SPI_IO2 and SPI_IO3 pin output 
+    \brief      enable SPI quad wire mode SPI_IO2 and SPI_IO3 pin output
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_io23_output_enable(uint32_t spi_periph)
+void spi_quad_io23_output_enable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_IO23_DRV;
 }
 
  /*!
-    \brief      disable SPI_IO2 and SPI_IO3 pin output 
+    \brief      disable SPI quad wire mode SPI_IO2 and SPI_IO3 pin output
     \param[in]  spi_periph: SPIx(only x=0)
     \param[out] none
     \retval     none
 */
-void qspi_io23_output_disable(uint32_t spi_periph)
+void spi_quad_io23_output_disable(uint32_t spi_periph)
 {
     SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_IO23_DRV);
 }

--- a/gd32e10x/standard_peripheral/source/gd32e10x_timer.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_timer.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -156,7 +157,7 @@ void timer_struct_para_init(timer_parameter_struct* initpara)
     \param[out] none
     \retval     none
 */
-void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
+void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
 {
     /* configure the counter prescaler value */
     TIMER_PSC(timer_periph) = (uint16_t)initpara->prescaler;

--- a/gd32e10x/standard_peripheral/source/gd32e10x_timer.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_timer.c
@@ -157,7 +157,7 @@ void timer_struct_para_init(timer_parameter_struct* initpara)
     \param[out] none
     \retval     none
 */
-void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
+void gd32_timer_init(uint32_t timer_periph, timer_parameter_struct* initpara)
 {
     /* configure the counter prescaler value */
     TIMER_PSC(timer_periph) = (uint16_t)initpara->prescaler;

--- a/gd32e10x/standard_peripheral/source/gd32e10x_usart.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_usart.c
@@ -5,10 +5,11 @@
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
     Redistribution and use in source and binary forms, with or without modification, 
 are permitted provided that the following conditions are met:
@@ -280,7 +281,7 @@ void usart_data_first_config(uint32_t usart_periph, uint32_t msbf)
 */
 void usart_invert_config(uint32_t usart_periph, usart_invert_enum invertpara)
 {
-    /* inverted or not the specified siginal */ 
+    /* inverted or not the specified signal */ 
     switch(invertpara){
     case USART_DINV_ENABLE:
         /* data bit level inversion */

--- a/gd32e10x/standard_peripheral/source/gd32e10x_wwdgt.c
+++ b/gd32e10x/standard_peripheral/source/gd32e10x_wwdgt.c
@@ -1,45 +1,41 @@
 /*!
     \file    gd32e10x_wwdgt.c
     \brief   WWDGT driver
-        
+
     \version 2017-12-26, V1.0.0, firmware for GD32E10x
     \version 2020-09-30, V1.1.0, firmware for GD32E10x
     \version 2020-12-31, V1.2.0, firmware for GD32E10x
+    \version 2022-06-30, V1.3.0, firmware for GD32E10x
 */
 
 /*
-    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
 
-    Redistribution and use in source and binary forms, with or without modification, 
+    Redistribution and use in source and binary forms, with or without modification,
 are permitted provided that the following conditions are met:
 
-    1. Redistributions of source code must retain the above copyright notice, this 
+    1. Redistributions of source code must retain the above copyright notice, this
        list of conditions and the following disclaimer.
-    2. Redistributions in binary form must reproduce the above copyright notice, 
-       this list of conditions and the following disclaimer in the documentation 
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
        and/or other materials provided with the distribution.
-    3. Neither the name of the copyright holder nor the names of its contributors 
-       may be used to endorse or promote products derived from this software without 
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
        specific prior written permission.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
-IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
 OF SUCH DAMAGE.
 */
 
 #include "gd32e10x_wwdgt.h"
-
-/* write value to WWDGT_CTL_CNT bit field */
-#define CTL_CNT(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
-/* write value to WWDGT_CFG_WIN bit field */
-#define CFG_WIN(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
 
 /*!
     \brief      reset the window watchdog timer configuration
@@ -72,17 +68,12 @@ void wwdgt_enable(void)
 */
 void wwdgt_counter_update(uint16_t counter_value)
 {
-    uint32_t reg = 0U;
-    
-    reg = (WWDGT_CTL & (~WWDGT_CTL_CNT));
-    reg |= CTL_CNT(counter_value);
-    
-    WWDGT_CTL = reg;
+    WWDGT_CTL = (uint32_t)(CTL_CNT(counter_value));
 }
 
 /*!
-    \brief      configure counter value, window value, and prescaler divider value  
-    \param[in]  counter: 0x00 - 0x7F   
+    \brief      configure counter value, window value, and prescaler divider value
+    \param[in]  counter: 0x00 - 0x7F
     \param[in]  window: 0x00 - 0x7F
     \param[in]  prescaler: wwdgt prescaler value
                 only one parameter can be selected which is shown as below:
@@ -95,30 +86,8 @@ void wwdgt_counter_update(uint16_t counter_value)
 */
 void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler)
 {
-    uint32_t reg_cfg = 0U, reg_ctl = 0U;
-
-    /* clear WIN and PSC bits, clear CNT bit */
-    reg_cfg = (WWDGT_CFG &(~(WWDGT_CFG_WIN|WWDGT_CFG_PSC)));
-    reg_ctl = (WWDGT_CTL &(~WWDGT_CTL_CNT));
-  
-    /* configure WIN and PSC bits, configure CNT bit */
-    reg_cfg |= CFG_WIN(window);
-    reg_cfg |= prescaler;
-    reg_ctl |= CTL_CNT(counter);
-    
-    WWDGT_CTL = reg_ctl;
-    WWDGT_CFG = reg_cfg;
-}
-
-/*!
-    \brief      enable early wakeup interrupt of WWDGT
-    \param[in]  none
-    \param[out] none
-    \retval     none
-*/
-void wwdgt_interrupt_enable(void)
-{
-    WWDGT_CFG |= WWDGT_CFG_EWIE;
+    WWDGT_CTL = (uint32_t)(CTL_CNT(counter));
+    WWDGT_CFG = (uint32_t)(CFG_WIN(window) | prescaler);
 }
 
 /*!
@@ -129,7 +98,7 @@ void wwdgt_interrupt_enable(void)
 */
 FlagStatus wwdgt_flag_get(void)
 {
-    if(RESET != (WWDGT_STAT & WWDGT_STAT_EWIF)){
+    if(WWDGT_STAT & WWDGT_STAT_EWIF) {
         return SET;
     }
 
@@ -144,5 +113,16 @@ FlagStatus wwdgt_flag_get(void)
 */
 void wwdgt_flag_clear(void)
 {
-    WWDGT_STAT &= (~WWDGT_STAT_EWIF);
+    WWDGT_STAT = (uint32_t)(RESET);
+}
+
+/*!
+    \brief      enable early wakeup interrupt of WWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_interrupt_enable(void)
+{
+    WWDGT_CFG |= WWDGT_CFG_EWIE;
 }


### PR DESCRIPTION
update gd32e10x hal to latest version.

hal download from:
https://www.gd32mcu.com/en/download/7?kw=GD32E1#:~:text=GD32E10x%20Firmware%20Library