### PR TITLE
can: unify timeout macro naming in gd32f4xx with compatibility alias

### DIFF
--- a/gd32e50x/standard_peripheral/include/gd32e50x_can.h
+++ b/gd32e50x/standard_peripheral/include/gd32e50x_can.h
@@ -825,7 +825,7 @@ typedef enum
 #endif /* GD32E508 */
 
 /* CAN timeout */
-#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */

--- a/gd32e50x/standard_peripheral/source/gd32e50x_can.c
+++ b/gd32e50x/standard_peripheral/source/gd32e50x_can.c
@@ -296,7 +296,7 @@ void can_struct_para_init(can_struct_type_enum type, void* p_struct)
 */
 ErrStatus can_init(uint32_t can_periph, can_parameter_struct* can_parameter_init)
 {
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
     ErrStatus flag = ERROR;
 #ifdef GD32E508    
     uint32_t fdctl_status;
@@ -383,7 +383,7 @@ ErrStatus can_init(uint32_t can_periph, can_parameter_struct* can_parameter_init
         }
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         /* wait the ACK */
         while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
             timeout--;
@@ -586,7 +586,7 @@ void can_filter_mask_mode_init(uint32_t can_periph, uint32_t id, uint32_t mask, 
 ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
 {
     ErrStatus reval = SUCCESS;
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     if(mode == (mode & CAN_SILENT_LOOPBACK_MODE)){
         /* disable sleep mode */
@@ -594,7 +594,7 @@ ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
         /* set initialize mode */
         CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_IWMOD;
         /* wait the acknowledge */
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
             timeout--;
         }
@@ -605,7 +605,7 @@ ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
             CAN_BT(can_periph) &= ~BT_MODE(3);
             CAN_BT(can_periph) |= BT_MODE(mode);
 
-            timeout = CAN_TIMEOUT;
+            timeout = GD32_CAN_TIMEOUT;
             /* enter normal mode */
             CAN_CTL(can_periph) &= ~(uint32_t)(CAN_CTL_SLPWMOD | CAN_CTL_IWMOD);
             /* wait the acknowledge */
@@ -648,7 +648,7 @@ ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
 */
 ErrStatus can_fd_init(uint32_t can_periph, can_fdframe_struct* can_fdframe_init)
 {
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
     uint32_t tempreg = 0U;
 
     /* check null pointer */
@@ -707,7 +707,7 @@ ErrStatus can_fd_init(uint32_t can_periph, can_fdframe_struct* can_fdframe_init)
 
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         /* wait the ACK */
         while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)){
             timeout--;
@@ -1386,7 +1386,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 {
     ErrStatus flag = ERROR;
     /* timeout for IWS or also for SLPWS bits */
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     if(GD32_CAN_MODE_INITIALIZE == working_mode){
         /* disable sleep mode */
@@ -1444,7 +1444,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 ErrStatus can_wakeup(uint32_t can_periph)
 {
     ErrStatus flag = ERROR;
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     /* wakeup */
     CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
@@ -666,8 +666,7 @@ typedef enum {
 #define CAN_FT_REMOTE                      ((uint32_t)0x00000002U)      /*!< remote frame */
 
 /* CAN timeout */
-#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
-#define GD32_CAN_TIMEOUT                   CAN_TIMEOUT                  /*!< compatibility alias */
+#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */

--- a/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
+++ b/gd32f4xx/standard_peripheral/include/gd32f4xx_can.h
@@ -666,7 +666,8 @@ typedef enum {
 #define CAN_FT_REMOTE                      ((uint32_t)0x00000002U)      /*!< remote frame */
 
 /* CAN timeout */
-#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define GD32_CAN_TIMEOUT                   CAN_TIMEOUT                  /*!< compatibility alias */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */

--- a/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
+++ b/gd32f4xx/standard_peripheral/source/gd32f4xx_can.c
@@ -159,7 +159,7 @@ void can_struct_para_init(can_struct_type_enum type, void *p_struct)
 */
 ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init)
 {
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
     ErrStatus flag = ERROR;
 
     /* disable sleep mode */
@@ -219,7 +219,7 @@ ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init
         }
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         /* wait the ACK */
         while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
@@ -674,7 +674,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 {
     ErrStatus flag = ERROR;
     /* timeout for IWS or also for SLPWS bits */
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     if(CAN_MODE_INITIALIZE == working_mode) {
         /* disable sleep mode */
@@ -732,7 +732,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 ErrStatus can_wakeup(uint32_t can_periph)
 {
     ErrStatus flag = ERROR;
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     /* wakeup */
     CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;

--- a/gd32f5xx/standard_peripheral/include/gd32f5xx_can.h
+++ b/gd32f5xx/standard_peripheral/include/gd32f5xx_can.h
@@ -823,7 +823,7 @@ typedef enum {
 #define CAN_ESI_RECESSIVE                  (1U)                         /*!< transmit the recessive bit in ESI phase */
 
 /* CAN timeout */
-#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+#define GD32_CAN_TIMEOUT                   ((uint32_t)0x0000FFFFU)      /*!< timeout value */
 
 /* interrupt enable bits */
 #define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */

--- a/gd32f5xx/standard_peripheral/source/gd32f5xx_can.c
+++ b/gd32f5xx/standard_peripheral/source/gd32f5xx_can.c
@@ -185,7 +185,7 @@ void can_struct_para_init(can_struct_type_enum type, void *p_struct)
 */
 ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init)
 {
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
     ErrStatus flag = ERROR;
     uint32_t fdctl_status;
 
@@ -261,7 +261,7 @@ ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init
         }
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         /* wait the ACK */
         while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
@@ -298,7 +298,7 @@ ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init
 */
 ErrStatus can_fd_init(uint32_t can_periph, can_fdframe_struct *can_fdframe_init)
 {
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
     uint32_t tempreg = 0U;
 
     /* check null pointer */
@@ -358,7 +358,7 @@ ErrStatus can_fd_init(uint32_t can_periph, can_fdframe_struct *can_fdframe_init)
 
         /* disable initialize mode */
         CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         /* wait the ACK */
         while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
@@ -558,7 +558,7 @@ void can_filter_mask_mode_init(uint32_t id, uint32_t mask, can_format_fifo_enum 
 ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
 {
     ErrStatus reval = SUCCESS;
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     if(mode == (mode & CAN_SILENT_LOOPBACK_MODE)) {
         /* disable sleep mode */
@@ -566,7 +566,7 @@ ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
         /* set initialize mode */
         CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_IWMOD;
         /* wait the acknowledge */
-        timeout = CAN_TIMEOUT;
+        timeout = GD32_CAN_TIMEOUT;
         while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
             timeout--;
         }
@@ -577,7 +577,7 @@ ErrStatus can_monitor_mode_set(uint32_t can_periph, uint8_t mode)
             CAN_BT(can_periph) &= ~BT_MODE(3);
             CAN_BT(can_periph) |= BT_MODE(mode);
 
-            timeout = CAN_TIMEOUT;
+            timeout = GD32_CAN_TIMEOUT;
             /* enter normal mode */
             CAN_CTL(can_periph) &= ~(uint32_t)(CAN_CTL_SLPWMOD | CAN_CTL_IWMOD);
             /* wait the acknowledge */
@@ -1084,7 +1084,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 {
     ErrStatus flag = ERROR;
     /* timeout for IWS or also for SLPWS bits */
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     if(CAN_MODE_INITIALIZE == working_mode) {
         /* disable sleep mode */
@@ -1142,7 +1142,7 @@ ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
 ErrStatus can_wakeup(uint32_t can_periph)
 {
     ErrStatus flag = ERROR;
-    uint32_t timeout = CAN_TIMEOUT;
+    uint32_t timeout = GD32_CAN_TIMEOUT;
 
     /* wakeup */
     CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;


### PR DESCRIPTION
In gd32f4xx CAN driver header the timeout macro was previously named
GD32_CAN_TIMEOUT, while source used CAN_TIMEOUT.  This mismatch is
inconsistent with other series (where CAN_TIMEOUT is used) and could
confuse users.

* add CAN_TIMEOUT definition
* keep GD32_CAN_TIMEOUT as alias for backwards compatibility
* update source references to use CAN_TIMEOUT

No functional change; purely naming cleanup.